### PR TITLE
Update turborepo to avoid relying on a build:clean task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -3,19 +3,12 @@
   "pipeline": {
     "build": {
       "dependsOn": [
-        "build:clean",
         "^build"
       ],
       "inputs": [
         "src/**/*.ts"
       ],
       "outputs": [
-        "dist/**",
-        "lib/**"
-      ]
-    },
-    "build:clean": {
-      "inputs": [
         "dist/**",
         "lib/**"
       ]


### PR DESCRIPTION
### Changed
- Updated `turborepo` to avoid relying on a `build:clean` task.