### PR TITLE
Add json schema ref to resource location

### DIFF
--- a/packages/backend-api-models/schemas/src/api/types.json
+++ b/packages/backend-api-models/schemas/src/api/types.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft/2020-12/schema",
   "title": "Types",
   "$id": "http://onegame.schemas/api/types.json",
-  "oneOf": [
+  "anyOf": [
     { "$ref": "http://onegame.schemas/api/v1/types.json" }
   ]
 }

--- a/packages/backend-api-models/schemas/src/api/v1/cards/card.json
+++ b/packages/backend-api-models/schemas/src/api/v1/cards/card.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft/2020-12/schema",
   "$id": "http://onegame.schemas/api/v1/cards/card.json",
   "title": "CardV1",
-  "oneOf": [
+  "anyOf": [
     { "$ref": "http://onegame.schemas/api/v1/cards/normal-card.json" }
   ]
 }

--- a/packages/json-schema-utils/CHANGELOG.md
+++ b/packages/json-schema-utils/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `JsonSchema202012MimeContentTransferEncoding`.
 - Added `JsonSchema202012Object`.
 - Added `JsonSchema202012Type`.
+- Added `jsonSchemaRefToResourceLocation`.
 - Added `ResourceLocation`.
 - Added `ResourceLocationType`.
 - Added `traverseJsonSchema`.

--- a/packages/json-schema-utils/CHANGELOG.md
+++ b/packages/json-schema-utils/CHANGELOG.md
@@ -27,7 +27,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `JsonRootSchema202012`.
 - Added `JsonRootSchema202012Object`.
 - Added `JsonSchema202012`.
+- Added `JsonSchema202012BaseContentEncoding`.
+- Added `JsonSchema202012Format`.
+- Added `JsonSchema202012MimeContentTransferEncoding`.
 - Added `JsonSchema202012Object`.
+- Added `JsonSchema202012Type`.
+- Added `ResourceLocation`.
+- Added `ResourceLocationType`.
 - Added `traverseJsonSchema`.
 
 

--- a/packages/json-schema-utils/src/index.ts
+++ b/packages/json-schema-utils/src/index.ts
@@ -1,14 +1,29 @@
+import { jsonSchemaRefToResourceLocation } from './json-schema/functions/jsonSchemaRefToResourceLocation';
 import { traverseJsonSchema } from './json-schema/functions/traverseJsonSchema';
 import {
   JsonRootSchema202012,
   JsonRootSchema202012Object,
   JsonSchema202012,
+  JsonSchema202012BaseContentEncoding,
+  JsonSchema202012Format,
+  JsonSchema202012MimeContentTransferEncoding,
   JsonSchema202012Object,
+  JsonSchema202012Type,
 } from './json-schema/models/JsonSchema202012';
 import { JsonValue } from './json-schema/models/JsonValue';
 import { TraverseJsonSchemaCallbackParams } from './json-schema/models/TraverseJsonSchemaCallbackParams';
+import { ResourceLocation } from './resource/models/ResourceLocation';
+import { ResourceLocationType } from './resource/models/ResourceLocationType';
 
-export { traverseJsonSchema };
+export {
+  JsonSchema202012BaseContentEncoding,
+  JsonSchema202012Format,
+  JsonSchema202012MimeContentTransferEncoding,
+  JsonSchema202012Type,
+  jsonSchemaRefToResourceLocation,
+  ResourceLocationType,
+  traverseJsonSchema,
+};
 
 export type {
   JsonRootSchema202012,
@@ -16,5 +31,6 @@ export type {
   JsonSchema202012,
   JsonSchema202012Object,
   JsonValue,
+  ResourceLocation,
   TraverseJsonSchemaCallbackParams,
 };

--- a/packages/json-schema-utils/src/json-schema/fixtures/JsonRootSchema202012Fixtures.ts
+++ b/packages/json-schema-utils/src/json-schema/fixtures/JsonRootSchema202012Fixtures.ts
@@ -1,4 +1,7 @@
-import { JsonRootSchema202012Object } from '../models/JsonSchema202012';
+import {
+  JsonRootSchema202012Object,
+  JsonSchema202012Type,
+} from '../models/JsonSchema202012';
 
 export class JsonRootSchema202012Fixtures {
   public static get any(): JsonRootSchema202012Object {
@@ -17,7 +20,7 @@ export class JsonRootSchema202012Fixtures {
 disabled (false), or under
 automatic control (null)`,
           title: 'Enabled',
-          type: ['boolean', 'null'],
+          type: [JsonSchema202012Type.boolean, JsonSchema202012Type.null],
         },
       },
     };
@@ -54,7 +57,7 @@ automatic control (null)`,
 disabled (false), or under
 automatic control (null)`,
           title: 'Enabled',
-          type: ['boolean', 'null'],
+          type: [JsonSchema202012Type.boolean, JsonSchema202012Type.null],
         },
       },
     };
@@ -70,7 +73,7 @@ automatic control (null)`,
 disabled (false), or under
 automatic control (null)`,
           title: 'Enabled',
-          type: ['boolean', 'null'],
+          type: [JsonSchema202012Type.boolean, JsonSchema202012Type.null],
         },
       },
     };
@@ -86,7 +89,7 @@ automatic control (null)`,
 disabled (false), or under
 automatic control (null)`,
           title: 'Enabled',
-          type: ['boolean', 'null'],
+          type: [JsonSchema202012Type.boolean, JsonSchema202012Type.null],
         },
       },
     };
@@ -102,7 +105,7 @@ automatic control (null)`,
 disabled (false), or under
 automatic control (null)`,
           title: 'Enabled',
-          type: ['boolean', 'null'],
+          type: [JsonSchema202012Type.boolean, JsonSchema202012Type.null],
         },
       },
     };
@@ -118,7 +121,7 @@ automatic control (null)`,
 disabled (false), or under
 automatic control (null)`,
           title: 'Enabled',
-          type: ['boolean', 'null'],
+          type: [JsonSchema202012Type.boolean, JsonSchema202012Type.null],
         },
       },
     };
@@ -134,7 +137,7 @@ automatic control (null)`,
 disabled (false), or under
 automatic control (null)`,
           title: 'Enabled',
-          type: ['boolean', 'null'],
+          type: [JsonSchema202012Type.boolean, JsonSchema202012Type.null],
         },
       },
     };
@@ -152,7 +155,7 @@ automatic control (null)`,
       ...JsonRootSchema202012Fixtures.any,
       patternProperties: {
         '^[a-z0-9]+$': {
-          type: ['boolean', 'null'],
+          type: [JsonSchema202012Type.boolean, JsonSchema202012Type.null],
         },
       },
     };
@@ -169,7 +172,7 @@ automatic control (null)`,
 disabled (false), or under
 automatic control (null)`,
             title: 'Enabled',
-            type: ['boolean', 'null'],
+            type: [JsonSchema202012Type.boolean, JsonSchema202012Type.null],
           },
         },
       ],
@@ -181,7 +184,7 @@ automatic control (null)`,
       ...JsonRootSchema202012Fixtures.any,
       properties: {
         z39: {
-          type: ['boolean', 'null'],
+          type: [JsonSchema202012Type.boolean, JsonSchema202012Type.null],
         },
       },
     };
@@ -204,7 +207,7 @@ automatic control (null)`,
 disabled (false), or under
 automatic control (null)`,
           title: 'Enabled',
-          type: ['boolean', 'null'],
+          type: [JsonSchema202012Type.boolean, JsonSchema202012Type.null],
         },
       },
     };

--- a/packages/json-schema-utils/src/json-schema/functions/jsonSchemaRefToResourceLocation.spec.ts
+++ b/packages/json-schema-utils/src/json-schema/functions/jsonSchemaRefToResourceLocation.spec.ts
@@ -1,0 +1,143 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { ResourceLocation } from '../../resource/models/ResourceLocation';
+import { ResourceLocationType } from '../../resource/models/ResourceLocationType';
+import { jsonSchemaRefToResourceLocation } from './jsonSchemaRefToResourceLocation';
+
+describe(jsonSchemaRefToResourceLocation.name, () => {
+  describe('having an empty referenceHostToSchemasRootDirectoryMap', () => {
+    let referenceHostToSchemasRootDirectoryMapFixture: Map<string, string>;
+
+    beforeAll(() => {
+      referenceHostToSchemasRootDirectoryMapFixture = new Map();
+    });
+
+    describe('having an absolute url ref', () => {
+      let refFixture: string;
+
+      beforeAll(() => {
+        refFixture = 'https://sample.co';
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = jsonSchemaRefToResourceLocation(
+            referenceHostToSchemasRootDirectoryMapFixture,
+            refFixture,
+          );
+        });
+
+        it('should return a FileLocation', () => {
+          const expectedFileLocation: ResourceLocation = {
+            rawLocation: 'https://sample.co/',
+            type: ResourceLocationType.url,
+          };
+
+          expect(result).toStrictEqual(expectedFileLocation);
+        });
+      });
+    });
+
+    describe('having a relative url ref with a base ref', () => {
+      let baseRefFixture: string;
+      let refFixture: string;
+
+      beforeAll(() => {
+        baseRefFixture = 'https://sample.co';
+        refFixture = '/foo';
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = jsonSchemaRefToResourceLocation(
+            referenceHostToSchemasRootDirectoryMapFixture,
+            refFixture,
+            baseRefFixture,
+          );
+        });
+
+        it('should return a FileLocation', () => {
+          const expectedFileLocation: ResourceLocation = {
+            rawLocation: 'https://sample.co/foo',
+            type: ResourceLocationType.url,
+          };
+
+          expect(result).toStrictEqual(expectedFileLocation);
+        });
+      });
+    });
+  });
+
+  describe('having a non empty referenceHostToSchemasRootDirectoryMap', () => {
+    let referenceHostToSchemasRootDirectoryMapFixture: Map<string, string>;
+
+    beforeAll(() => {
+      referenceHostToSchemasRootDirectoryMapFixture = new Map([
+        ['sample.co', '/root/path/fixture'],
+      ]);
+    });
+
+    describe('having an absolute url ref', () => {
+      let refFixture: string;
+
+      beforeAll(() => {
+        refFixture = 'https://sample.co/subpath';
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = jsonSchemaRefToResourceLocation(
+            referenceHostToSchemasRootDirectoryMapFixture,
+            refFixture,
+          );
+        });
+
+        it('should return a FileLocation', () => {
+          const expectedFileLocation: ResourceLocation = {
+            rawLocation: '/root/path/fixture/subpath',
+            type: ResourceLocationType.fsPath,
+          };
+
+          expect(result).toStrictEqual(expectedFileLocation);
+        });
+      });
+    });
+
+    describe('having a relative url ref with a base ref', () => {
+      let baseRefFixture: string;
+      let refFixture: string;
+
+      beforeAll(() => {
+        baseRefFixture = 'https://sample.co';
+        refFixture = '/foo';
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = jsonSchemaRefToResourceLocation(
+            referenceHostToSchemasRootDirectoryMapFixture,
+            refFixture,
+            baseRefFixture,
+          );
+        });
+
+        it('should return a FileLocation', () => {
+          const expectedFileLocation: ResourceLocation = {
+            rawLocation: '/root/path/fixture/foo',
+            type: ResourceLocationType.fsPath,
+          };
+
+          expect(result).toStrictEqual(expectedFileLocation);
+        });
+      });
+    });
+  });
+});

--- a/packages/json-schema-utils/src/json-schema/functions/jsonSchemaRefToResourceLocation.ts
+++ b/packages/json-schema-utils/src/json-schema/functions/jsonSchemaRefToResourceLocation.ts
@@ -1,0 +1,33 @@
+import path from 'node:path';
+
+import { ResourceLocation } from '../../resource/models/ResourceLocation';
+import { ResourceLocationType } from '../../resource/models/ResourceLocationType';
+
+export function jsonSchemaRefToResourceLocation(
+  referenceHostToSchemasRootDirectoryMap: Map<string, string>,
+  ref: string,
+  baseRef?: string | undefined,
+): ResourceLocation {
+  const urlObject: URL = new URL(ref, baseRef);
+  const urlHost: string = urlObject.hostname;
+  const urlPathName: string = urlObject.pathname;
+
+  const schemasRootDirectory: string | undefined =
+    referenceHostToSchemasRootDirectoryMap.get(urlHost);
+
+  let resourceLocation: ResourceLocation;
+
+  if (schemasRootDirectory === undefined) {
+    resourceLocation = {
+      rawLocation: urlObject.href,
+      type: ResourceLocationType.url,
+    };
+  } else {
+    resourceLocation = {
+      rawLocation: path.join(schemasRootDirectory, ...urlPathName.split('/')),
+      type: ResourceLocationType.fsPath,
+    };
+  }
+
+  return resourceLocation;
+}

--- a/packages/json-schema-utils/src/json-schema/models/JsonSchema202012.ts
+++ b/packages/json-schema-utils/src/json-schema/models/JsonSchema202012.ts
@@ -7,8 +7,10 @@ export type JsonSchema202012Boolean = boolean;
 
 // https://json-schema.org/draft/2020-12/json-schema-core.html#name-the-json-schema-core-vocabu
 export interface JsonSchema202012CoreVocabularyProperties {
+  $anchor?: string;
   $comments?: string;
   $defs?: Record<string, JsonSchema202012>;
+  $dynamicAnchor?: string;
   $dynamicRef?: string;
   $id?: string;
   $ref?: string;
@@ -30,6 +32,8 @@ export type JsonSchema202012KnownPropertiesObject =
     JsonSchema202012SubschemeAppliedProperties &
     JsonSchema202012UnevaluatedLocationProperties &
     JsonSchema202012StructuralValidationProperties &
+    JsonSchema202012FormatProperties &
+    JsonSchema202012StringContentEncodedProperties &
     JsonSchema202012MetadataAnnotationsProperties;
 
 export type JsonSchema202012Object = JsonSchema202012KnownPropertiesObject &
@@ -80,8 +84,81 @@ export interface JsonSchema202012StructuralValidationProperties {
   multipleOf?: number;
   pattern?: string;
   required?: string[];
-  type?: string | string[];
+  type?: JsonSchema202012Type | JsonSchema202012Type[];
   uniqueItems?: boolean;
+}
+
+// https://json-schema.org/draft/2020-12/json-schema-validation.html#name-validation-keywords-for-any
+export enum JsonSchema202012Type {
+  array = 'array',
+  boolean = 'boolean',
+  integer = 'integer',
+  null = 'null',
+  number = 'number',
+  object = 'object',
+  string = 'string',
+}
+
+// https://json-schema.org/draft/2020-12/json-schema-validation.html#name-vocabularies-for-semantic-c
+export interface JsonSchema202012FormatProperties {
+  format?: JsonSchema202012CustomFormat | JsonSchema202012Format;
+}
+
+// https://json-schema.org/draft/2020-12/json-schema-validation.html#name-custom-format-attributes
+export type JsonSchema202012CustomFormat = string;
+
+// https://json-schema.org/draft/2020-12/json-schema-validation.html#name-defined-formats
+export enum JsonSchema202012Format {
+  dateTime = 'date-time',
+  date = 'date',
+  duration = 'duration',
+  email = 'email',
+  hostname = 'hostname',
+  idnEmail = 'idn-email',
+  idnHostname = 'idn-hostname',
+  ipV4 = 'ipv4',
+  ipV6 = 'ipv6',
+  iri = 'iri',
+  iriReference = 'iri-reference',
+  jsonPointer = 'json-pointer',
+  regex = 'regex',
+  relativeJsonPointer = 'relative-json-pointer',
+  time = 'time',
+  uri = 'uri',
+  uriReference = 'uri-reference',
+  uriTemplate = 'uri-template',
+  uuid = 'uuid',
+}
+
+// https://json-schema.org/draft/2020-12/json-schema-validation.html#name-a-vocabulary-for-the-conten
+export interface JsonSchema202012StringContentEncodedProperties {
+  contentEncoding?:
+    | JsonSchema202012BaseContentEncoding
+    | JsonSchema202012MimeContentTransferEncoding;
+  contentMediaType?: string;
+  contentSchema?: JsonSchema202012;
+}
+
+/*
+ * https://json-schema.org/draft/2020-12/json-schema-validation.html#name-contentencoding
+ * - https://www.rfc-editor.org/rfc/rfc4648.html
+ */
+export enum JsonSchema202012BaseContentEncoding {
+  base32 = 'base32',
+  base32hex = 'base32hex',
+  base64 = 'base64',
+  base64url = 'base64url',
+  hex = 'hex',
+}
+
+export enum JsonSchema202012MimeContentTransferEncoding {
+  base64 = 'base64',
+  bit7 = '7bit',
+  bit8 = '8bit',
+  binary = 'binary',
+  ietfToken = 'ietf-token',
+  quotedPrintable = 'quoted-printable',
+  xToken = 'x-token',
 }
 
 // https://json-schema.org/draft/2020-12/json-schema-validation.html#name-a-vocabulary-for-basic-meta

--- a/packages/json-schema-utils/src/resource/models/ResourceLocation.ts
+++ b/packages/json-schema-utils/src/resource/models/ResourceLocation.ts
@@ -1,0 +1,6 @@
+import { ResourceLocationType } from './ResourceLocationType';
+
+export interface ResourceLocation {
+  rawLocation: string;
+  type: ResourceLocationType;
+}

--- a/packages/json-schema-utils/src/resource/models/ResourceLocationType.ts
+++ b/packages/json-schema-utils/src/resource/models/ResourceLocationType.ts
@@ -1,0 +1,4 @@
+export enum ResourceLocationType {
+  fsPath,
+  url,
+}


### PR DESCRIPTION
### Added
- Added `jsonSchemaRefToResourceLocation`.
- Added `ResourceLocation`.

### Changed
- Updated `card` schemas to use `anyOf` instead of `oneOf` structures.
- Updated `JsonSchema202012` with better types and missing optional properties.