### PR TITLE
Add PostUserV1HttpRequestController  @notaphplover

### DIFF
--- a/packages/backend-http/CHANGELOG.md
+++ b/packages/backend-http/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `Response`
 - Added `ResponseWithBody`
 - Added `SingleEntityGetResponseBuilder`.
+- Added `SingleEntityHttpRequestController`.
 - Added `SingleEntityPostResponseBuilder`.
 
 

--- a/packages/backend-http/src/http/controllers/application/SingleEntityHttpRequestController.ts
+++ b/packages/backend-http/src/http/controllers/application/SingleEntityHttpRequestController.ts
@@ -5,33 +5,26 @@ import { RequestWithBody } from '../../models/application/RequestWithBody';
 import { Response } from '../../models/application/Response';
 import { ResponseWithBody } from '../../models/application/ResponseWithBody';
 
-export class SingleEntityHttpRequestController<
+export abstract class SingleEntityHttpRequestController<
   TRequest extends Request | RequestWithBody = Request | RequestWithBody,
   TUseCaseParams extends unknown[] = unknown[],
   TModel = unknown,
-  TModelApi = unknown,
 > implements Handler<[TRequest], Response | ResponseWithBody<unknown>>
 {
   readonly #requestParamHandler: Handler<[TRequest], TUseCaseParams>;
-  readonly #useCaseHandler: Handler<TUseCaseParams, TModel | undefined>;
-  readonly #apiModelBuilder: Builder<TModelApi, [TModel]>;
   readonly #responseBuilder: Builder<
-    Response | ResponseWithBody<TModelApi>,
-    [TModelApi | undefined]
+    Response | ResponseWithBody<TModel>,
+    [TModel | undefined]
   >;
 
   constructor(
     requestParamHandler: Handler<[TRequest], TUseCaseParams>,
-    useCaseHandler: Handler<TUseCaseParams, TModel | undefined>,
-    apiModelBuilder: Builder<TModelApi, [TModel]>,
     responseBuilder: Builder<
-      Response | ResponseWithBody<TModelApi>,
-      [TModelApi | undefined]
+      Response | ResponseWithBody<TModel>,
+      [TModel | undefined]
     >,
   ) {
     this.#requestParamHandler = requestParamHandler;
-    this.#useCaseHandler = useCaseHandler;
-    this.#apiModelBuilder = apiModelBuilder;
     this.#responseBuilder = responseBuilder;
   }
 
@@ -40,21 +33,17 @@ export class SingleEntityHttpRequestController<
   ): Promise<Response | ResponseWithBody<unknown>> {
     const useCaseParams: TUseCaseParams =
       await this.#requestParamHandler.handle(request);
-    const model: TModel | undefined = await this.#useCaseHandler.handle(
+    const model: TModel | undefined = await this._handleUseCase(
       ...useCaseParams,
     );
 
-    let modelApi: TModelApi | undefined;
-
-    if (model === undefined) {
-      modelApi = undefined;
-    } else {
-      modelApi = this.#apiModelBuilder.build(model);
-    }
-
     const response: Response | ResponseWithBody<unknown> =
-      this.#responseBuilder.build(modelApi);
+      this.#responseBuilder.build(model);
 
     return response;
   }
+
+  protected abstract _handleUseCase(
+    ...useCaseParams: TUseCaseParams
+  ): Promise<TModel | undefined>;
 }

--- a/packages/backend-http/src/index.ts
+++ b/packages/backend-http/src/index.ts
@@ -1,6 +1,7 @@
 import { SingleEntityGetResponseBuilder } from './http/builders/application/SingleEntityGetResponseBuilder';
 import { SingleEntityPostResponseBuilder } from './http/builders/application/SingleEntityPostResponseBuilder';
 import { HttpController } from './http/controllers/application/HttpController';
+import { SingleEntityHttpRequestController } from './http/controllers/application/SingleEntityHttpRequestController';
 import { Request } from './http/models/application/Request';
 import { RequestWithBody } from './http/models/application/RequestWithBody';
 import { Response } from './http/models/application/Response';
@@ -11,5 +12,6 @@ export type { Request, RequestWithBody, Response, ResponseWithBody };
 export {
   HttpController,
   SingleEntityGetResponseBuilder,
+  SingleEntityHttpRequestController,
   SingleEntityPostResponseBuilder,
 };

--- a/packages/backend-service-user/src/app/adapter/nest/modules/AppModule.ts
+++ b/packages/backend-service-user/src/app/adapter/nest/modules/AppModule.ts
@@ -1,8 +1,8 @@
 import { Module } from '@nestjs/common';
 
-import { UserModule } from '../../../../user/adapter/nest/modules/UserModule';
+import { UserHttpApiModule } from '../../../../user/adapter/nest/modules/UserHttpApiModule';
 
 @Module({
-  imports: [UserModule],
+  imports: [UserHttpApiModule],
 })
 export class AppModule {}

--- a/packages/backend-service-user/src/foundation/http/adapter/nest/modules/HttpModule.ts
+++ b/packages/backend-service-user/src/foundation/http/adapter/nest/modules/HttpModule.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { SingleEntityPostResponseBuilder } from '@one-game-js/backend-http';
+
+@Module({
+  exports: [SingleEntityPostResponseBuilder],
+  providers: [SingleEntityPostResponseBuilder],
+})
+export class HttpModule {}

--- a/packages/backend-service-user/src/user/adapter/nest/modules/UserHttpApiModule.ts
+++ b/packages/backend-service-user/src/user/adapter/nest/modules/UserHttpApiModule.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
 
+import { HttpModule } from '../../../../foundation/http/adapter/nest/modules/HttpModule';
 import { JsonSchemaModule } from '../../../../foundation/jsonSchema/adapter/nest/modules/JsonSchemaModule';
+import { PostUserV1HttpRequestController } from '../../../application/controllers/PostUserV1HttpRequestController';
 import { PostUserV1RequestParamHandler } from '../../../application/handlers/PostUserV1RequestParamHandler';
+import { UserModule } from './UserModule';
 
 @Module({
-  imports: [JsonSchemaModule],
-  providers: [PostUserV1RequestParamHandler],
+  imports: [JsonSchemaModule, HttpModule, UserModule],
+  providers: [PostUserV1HttpRequestController, PostUserV1RequestParamHandler],
 })
 export class UserHttpApiModule {}

--- a/packages/backend-service-user/src/user/application/controllers/PostUserV1HttpRequestController.ts
+++ b/packages/backend-service-user/src/user/application/controllers/PostUserV1HttpRequestController.ts
@@ -1,0 +1,47 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { models as apiModels } from '@one-game-js/backend-api-models';
+import { Builder, Handler } from '@one-game-js/backend-common';
+import {
+  RequestWithBody,
+  Response,
+  ResponseWithBody,
+  SingleEntityHttpRequestController,
+  SingleEntityPostResponseBuilder,
+} from '@one-game-js/backend-http';
+
+import { PostUserV1RequestParamHandler } from '../handlers/PostUserV1RequestParamHandler';
+import { UserManagementInputPort } from '../ports/input/UserManagementInputPort';
+
+@Injectable()
+export class PostUserV1HttpRequestController extends SingleEntityHttpRequestController<
+  RequestWithBody,
+  [apiModels.UserCreateQueryV1],
+  apiModels.UserV1
+> {
+  readonly #userManagementInputPort: UserManagementInputPort;
+
+  constructor(
+    @Inject(PostUserV1RequestParamHandler)
+    requestParamHandler: Handler<
+      [RequestWithBody],
+      [apiModels.UserCreateQueryV1]
+    >,
+    @Inject(SingleEntityPostResponseBuilder)
+    responseBuilder: Builder<
+      Response | ResponseWithBody<unknown>,
+      [apiModels.UserV1 | undefined]
+    >,
+    @Inject(UserManagementInputPort)
+    userManagementInputPort: UserManagementInputPort,
+  ) {
+    super(requestParamHandler, responseBuilder);
+
+    this.#userManagementInputPort = userManagementInputPort;
+  }
+
+  protected async _handleUseCase(
+    userCreateQueryV1: apiModels.UserCreateQueryV1,
+  ): Promise<apiModels.UserV1 | undefined> {
+    return this.#userManagementInputPort.create(userCreateQueryV1);
+  }
+}


### PR DESCRIPTION
### Added
- Added `PostUserV1HttpRequestController`.
- Added `HttpModule`.

### Changed
- Exposed `SingleEntityHttpRequestController`.
- Updated `SingleEntityHttpRequestController` to no longer rely on TApiModel and rely on protected use case handler.