### PR TITLE
Update user persistence output port with find one method

### DIFF
--- a/packages/backend/libraries/backend-db/src/persistence/services/typeorm/FindTypeOrmService.spec.ts
+++ b/packages/backend/libraries/backend-db/src/persistence/services/typeorm/FindTypeOrmService.spec.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
-import { ConverterAsync } from '@one-game-js/backend-common';
+import { Converter, ConverterAsync } from '@one-game-js/backend-common';
 import {
   FindManyOptions,
   QueryBuilder,
@@ -26,8 +26,8 @@ describe(FindTypeOrmService.name, () => {
   let queryToQueryTypeOrmConverterMock: jest.Mocked<
     QueryToFindQueryTypeOrmConverter<ModelTest, QueryTest>
   >;
-  let modelDbToModelConverter: jest.Mocked<
-    ConverterAsync<ModelTest, ModelTest>
+  let modelDbToModelConverterMock: jest.Mocked<
+    Converter<ModelTest, ModelTest> | ConverterAsync<ModelTest, ModelTest>
   >;
 
   let findTypeOrmService: FindTypeOrmService<ModelTest, ModelTest, QueryTest>;
@@ -60,13 +60,15 @@ describe(FindTypeOrmService.name, () => {
       QueryToFindQueryTypeOrmConverter<ModelTest, QueryTest>
     >;
 
-    modelDbToModelConverter = {
+    modelDbToModelConverterMock = {
       convert: jest.fn(),
-    };
+    } as jest.Mocked<
+      Converter<ModelTest, ModelTest> | ConverterAsync<ModelTest, ModelTest>
+    >;
 
     findTypeOrmService = new FindTypeOrmService(
       repositoryMock,
-      modelDbToModelConverter,
+      modelDbToModelConverterMock,
       queryToQueryTypeOrmConverterMock,
     );
   });
@@ -89,7 +91,11 @@ describe(FindTypeOrmService.name, () => {
         };
         queryTypeOrmFixture = {};
 
-        modelDbToModelConverter.convert.mockResolvedValueOnce(modelTestFixture);
+        (
+          modelDbToModelConverterMock as jest.Mocked<
+            ConverterAsync<ModelTest, ModelTest>
+          >
+        ).convert.mockResolvedValueOnce(modelTestFixture);
         (
           queryToQueryTypeOrmConverterMock.convert as jest.Mock<
             (query: QueryTest) => Promise<FindManyOptions<ModelTest>>
@@ -115,8 +121,8 @@ describe(FindTypeOrmService.name, () => {
       });
 
       it('should call modelDbToModelConverter.convert()', () => {
-        expect(modelDbToModelConverter.convert).toHaveBeenCalledTimes(1);
-        expect(modelDbToModelConverter.convert).toHaveBeenCalledWith(
+        expect(modelDbToModelConverterMock.convert).toHaveBeenCalledTimes(1);
+        expect(modelDbToModelConverterMock.convert).toHaveBeenCalledWith(
           modelTestFixture,
         );
       });
@@ -142,7 +148,11 @@ describe(FindTypeOrmService.name, () => {
         };
         queryTypeOrmFixture = {};
 
-        modelDbToModelConverter.convert.mockResolvedValueOnce(modelTestFixture);
+        (
+          modelDbToModelConverterMock as jest.Mocked<
+            ConverterAsync<ModelTest, ModelTest>
+          >
+        ).convert.mockResolvedValueOnce(modelTestFixture);
         (
           queryToQueryTypeOrmConverterMock.convert as jest.Mock<
             (query: QueryTest) => Promise<FindManyOptions<ModelTest>>
@@ -177,7 +187,11 @@ describe(FindTypeOrmService.name, () => {
           fooValue: 'bar',
         };
 
-        modelDbToModelConverter.convert.mockResolvedValueOnce(modelTestFixture);
+        (
+          modelDbToModelConverterMock as jest.Mocked<
+            ConverterAsync<ModelTest, ModelTest>
+          >
+        ).convert.mockResolvedValueOnce(modelTestFixture);
         (
           queryToQueryTypeOrmConverterMock.convert as jest.Mock<
             (
@@ -248,7 +262,7 @@ describe(FindTypeOrmService.name, () => {
       });
 
       it('should not call modelDbToModelConverter.convert()', () => {
-        expect(modelDbToModelConverter.convert).not.toHaveBeenCalled();
+        expect(modelDbToModelConverterMock.convert).not.toHaveBeenCalled();
       });
 
       it('should return undefined', () => {
@@ -271,7 +285,11 @@ describe(FindTypeOrmService.name, () => {
         };
         queryTypeOrmFixture = {};
 
-        modelDbToModelConverter.convert.mockResolvedValueOnce(modelTestFixture);
+        (
+          modelDbToModelConverterMock as jest.Mocked<
+            ConverterAsync<ModelTest, ModelTest>
+          >
+        ).convert.mockResolvedValueOnce(modelTestFixture);
         (
           queryToQueryTypeOrmConverterMock.convert as jest.Mock<
             (query: QueryTest) => Promise<FindManyOptions<ModelTest>>
@@ -304,8 +322,8 @@ describe(FindTypeOrmService.name, () => {
       });
 
       it('should call modelDbToModelConverter.convert()', () => {
-        expect(modelDbToModelConverter.convert).toHaveBeenCalledTimes(1);
-        expect(modelDbToModelConverter.convert).toHaveBeenCalledWith(
+        expect(modelDbToModelConverterMock.convert).toHaveBeenCalledTimes(1);
+        expect(modelDbToModelConverterMock.convert).toHaveBeenCalledWith(
           modelTestFixture,
         );
       });
@@ -359,7 +377,7 @@ describe(FindTypeOrmService.name, () => {
       });
 
       it('should not call modelDbToModelConverter.convert()', () => {
-        expect(modelDbToModelConverter.convert).not.toHaveBeenCalled();
+        expect(modelDbToModelConverterMock.convert).not.toHaveBeenCalled();
       });
 
       it('should return undefined', () => {
@@ -389,7 +407,11 @@ describe(FindTypeOrmService.name, () => {
           >
         ).mockResolvedValueOnce(queryBuilderMock);
         queryBuilderMock.getOne.mockResolvedValueOnce(modelTestFixture);
-        modelDbToModelConverter.convert.mockResolvedValueOnce(modelTestFixture);
+        (
+          modelDbToModelConverterMock as jest.Mocked<
+            ConverterAsync<ModelTest, ModelTest>
+          >
+        ).convert.mockResolvedValueOnce(modelTestFixture);
 
         result = await findTypeOrmService.findOne(queryTestFixture);
       });
@@ -414,8 +436,8 @@ describe(FindTypeOrmService.name, () => {
       });
 
       it('should call modelDbToModelConverter.convert()', () => {
-        expect(modelDbToModelConverter.convert).toHaveBeenCalledTimes(1);
-        expect(modelDbToModelConverter.convert).toHaveBeenCalledWith(
+        expect(modelDbToModelConverterMock.convert).toHaveBeenCalledTimes(1);
+        expect(modelDbToModelConverterMock.convert).toHaveBeenCalledWith(
           modelTestFixture,
         );
       });

--- a/packages/backend/libraries/backend-db/src/persistence/services/typeorm/FindTypeOrmService.ts
+++ b/packages/backend/libraries/backend-db/src/persistence/services/typeorm/FindTypeOrmService.ts
@@ -1,4 +1,4 @@
-import { ConverterAsync } from '@one-game-js/backend-common';
+import { Converter, ConverterAsync } from '@one-game-js/backend-common';
 import {
   FindManyOptions,
   FindOneOptions,
@@ -17,7 +17,9 @@ export class FindTypeOrmService<
   TQuery,
 > {
   readonly #repository: Repository<TModelDb>;
-  readonly #modelDbToModelConverter: ConverterAsync<TModelDb, TModel>;
+  readonly #modelDbToModelConverter:
+    | Converter<TModelDb, TModel>
+    | ConverterAsync<TModelDb, TModel>;
   readonly #queryToQueryTypeOrmConverter: QueryToFindQueryTypeOrmConverter<
     TModelDb,
     TQuery
@@ -25,7 +27,9 @@ export class FindTypeOrmService<
 
   constructor(
     repository: Repository<TModelDb>,
-    modelDbToModelConverter: ConverterAsync<TModelDb, TModel>,
+    modelDbToModelConverter:
+      | Converter<TModelDb, TModel>
+      | ConverterAsync<TModelDb, TModel>,
     queryToQueryTypeOrmConverter: QueryToFindQueryTypeOrmConverter<
       TModelDb,
       TQuery

--- a/packages/backend/services/backend-service-user/src/user/adapter/nest/modules/UserModule.ts
+++ b/packages/backend/services/backend-service-user/src/user/adapter/nest/modules/UserModule.ts
@@ -11,8 +11,10 @@ import { userPersistenceOutputPortSymbol } from '../../../application/ports/outp
 import { UserPersistenceTypeOrmAdapter } from '../../typeorm/adapters/UserPersistenceTypeOrmAdapter';
 import { UserCreateQueryToUserCreateQueryTypeOrmConverter } from '../../typeorm/converters/UserCreateQueryToUserCreateQueryTypeOrmConverter';
 import { UserDbToUserConverter } from '../../typeorm/converters/UserDbToUserConverter';
+import { UserFindQueryToUserFindQueryTypeOrmConverter } from '../../typeorm/converters/UserFindQueryToUserFindQueryTypeOrmConverter';
 import { UserDb } from '../../typeorm/models/UserDb';
 import { CreateUserTypeOrmService } from '../../typeorm/services/CreateUserTypeOrmService';
+import { FindUserTypeOrmService } from '../../typeorm/services/FindUserTypeOrmService';
 
 @Module({
   exports: [UserManagementInputPort],
@@ -24,8 +26,10 @@ import { CreateUserTypeOrmService } from '../../typeorm/services/CreateUserTypeO
   ],
   providers: [
     CreateUserTypeOrmService,
+    FindUserTypeOrmService,
     UserCreateQueryToUserCreateQueryTypeOrmConverter,
     UserCreateQueryV1ToUserCreateQueryConverter,
+    UserFindQueryToUserFindQueryTypeOrmConverter,
     UserDbToUserConverter,
     UserManagementInputPort,
     UserToUserV1Converter,

--- a/packages/backend/services/backend-service-user/src/user/adapter/typeorm/adapters/UserPersistenceTypeOrmAdapter.spec.ts
+++ b/packages/backend/services/backend-service-user/src/user/adapter/typeorm/adapters/UserPersistenceTypeOrmAdapter.spec.ts
@@ -1,13 +1,18 @@
-import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 import { UserCreateQueryFixtures } from '../../../domain/fixtures/UserCreateQueryFixtures';
+import { UserFindQueryFixtures } from '../../../domain/fixtures/UserFindQueryFixtures';
+import { UserFixtures } from '../../../domain/fixtures/UserFixtures';
 import { User } from '../../../domain/models/User';
 import { UserCreateQuery } from '../../../domain/models/UserCreateQuery';
+import { UserFindQuery } from '../../../domain/models/UserFindQuery';
 import { CreateUserTypeOrmService } from '../services/CreateUserTypeOrmService';
+import { FindUserTypeOrmService } from '../services/FindUserTypeOrmService';
 import { UserPersistenceTypeOrmAdapter } from './UserPersistenceTypeOrmAdapter';
 
 describe(UserPersistenceTypeOrmAdapter, () => {
   let createUserTypeOrmServiceMock: jest.Mocked<CreateUserTypeOrmService>;
+  let findUserTypeOrmServiceMock: jest.Mocked<FindUserTypeOrmService>;
 
   let userPersistenceTypeOrmAdapter: UserPersistenceTypeOrmAdapter;
 
@@ -18,8 +23,15 @@ describe(UserPersistenceTypeOrmAdapter, () => {
       jest.Mocked<CreateUserTypeOrmService>
     > as jest.Mocked<CreateUserTypeOrmService>;
 
+    findUserTypeOrmServiceMock = {
+      findOne: jest.fn(),
+    } as Partial<
+      jest.Mocked<FindUserTypeOrmService>
+    > as jest.Mocked<FindUserTypeOrmService>;
+
     userPersistenceTypeOrmAdapter = new UserPersistenceTypeOrmAdapter(
       createUserTypeOrmServiceMock,
+      findUserTypeOrmServiceMock,
     );
   });
 
@@ -47,6 +59,45 @@ describe(UserPersistenceTypeOrmAdapter, () => {
         expect(createUserTypeOrmServiceMock.insertOne).toHaveBeenCalledTimes(1);
         expect(createUserTypeOrmServiceMock.insertOne).toHaveBeenCalledWith(
           userCreateQueryFixture,
+        );
+      });
+
+      it('should return a User', () => {
+        expect(result).toBe(userFixture);
+      });
+    });
+  });
+
+  describe('.findOne', () => {
+    let userFindQueryFixture: UserFindQuery;
+
+    beforeAll(() => {
+      userFindQueryFixture = UserFindQueryFixtures.withId;
+    });
+
+    describe('when called', () => {
+      let userFixture: User;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        userFixture = UserFixtures.any;
+
+        findUserTypeOrmServiceMock.findOne.mockResolvedValueOnce(userFixture);
+
+        result = await userPersistenceTypeOrmAdapter.findOne(
+          userFindQueryFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call findUserTypeOrmService.findOne()', () => {
+        expect(findUserTypeOrmServiceMock.findOne).toHaveBeenCalledTimes(1);
+        expect(findUserTypeOrmServiceMock.findOne).toHaveBeenCalledWith(
+          userFindQueryFixture,
         );
       });
 

--- a/packages/backend/services/backend-service-user/src/user/adapter/typeorm/adapters/UserPersistenceTypeOrmAdapter.ts
+++ b/packages/backend/services/backend-service-user/src/user/adapter/typeorm/adapters/UserPersistenceTypeOrmAdapter.ts
@@ -3,22 +3,34 @@ import { Inject, Injectable } from '@nestjs/common';
 import { UserPersistenceOutputPort } from '../../../application/ports/output/UserPersistenceOutputPort';
 import { User } from '../../../domain/models/User';
 import { UserCreateQuery } from '../../../domain/models/UserCreateQuery';
+import { UserFindQuery } from '../../../domain/models/UserFindQuery';
 import { CreateUserTypeOrmService } from '../services/CreateUserTypeOrmService';
+import { FindUserTypeOrmService } from '../services/FindUserTypeOrmService';
 
 @Injectable()
 export class UserPersistenceTypeOrmAdapter
   implements UserPersistenceOutputPort
 {
   readonly #createUserTypeOrmService: CreateUserTypeOrmService;
+  readonly #findUserTypeOrmService: FindUserTypeOrmService;
 
   constructor(
     @Inject(CreateUserTypeOrmService)
     createUserTypeOrmService: CreateUserTypeOrmService,
+    @Inject(FindUserTypeOrmService)
+    findUserTypeOrmService: FindUserTypeOrmService,
   ) {
     this.#createUserTypeOrmService = createUserTypeOrmService;
+    this.#findUserTypeOrmService = findUserTypeOrmService;
   }
 
   public async create(userCreateQuery: UserCreateQuery): Promise<User> {
     return this.#createUserTypeOrmService.insertOne(userCreateQuery);
+  }
+
+  public async findOne(
+    userFindQuery: UserFindQuery,
+  ): Promise<User | undefined> {
+    return this.#findUserTypeOrmService.findOne(userFindQuery);
   }
 }

--- a/packages/backend/services/backend-service-user/src/user/adapter/typeorm/converters/UserFindQueryToUserFindQueryTypeOrmConverter.spec.ts
+++ b/packages/backend/services/backend-service-user/src/user/adapter/typeorm/converters/UserFindQueryToUserFindQueryTypeOrmConverter.spec.ts
@@ -1,0 +1,70 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { FindManyOptions } from 'typeorm';
+
+import { UserFindQueryFixtures } from '../../../domain/fixtures/UserFindQueryFixtures';
+import { UserFindQuery } from '../../../domain/models/UserFindQuery';
+import { UserDb } from '../models/UserDb';
+import { UserFindQueryToUserFindQueryTypeOrmConverter } from './UserFindQueryToUserFindQueryTypeOrmConverter';
+
+describe(UserFindQueryToUserFindQueryTypeOrmConverter.name, () => {
+  let userFindQueryToUserFindQueryTypeOrmConverter: UserFindQueryToUserFindQueryTypeOrmConverter;
+
+  beforeAll(() => {
+    userFindQueryToUserFindQueryTypeOrmConverter =
+      new UserFindQueryToUserFindQueryTypeOrmConverter();
+  });
+
+  describe('having a UserFindQuery with no properties', () => {
+    let userFindQueryFixture: UserFindQuery;
+
+    beforeAll(() => {
+      userFindQueryFixture = UserFindQueryFixtures.withNoProperties;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        result = await userFindQueryToUserFindQueryTypeOrmConverter.convert(
+          userFindQueryFixture,
+        );
+      });
+
+      it('should return a FindManyOptions<UserDb>', () => {
+        const expected: FindManyOptions<UserDb> = {
+          where: {},
+        };
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having a UserFindQuery with an id', () => {
+    let userFindQueryFixture: UserFindQuery;
+
+    beforeAll(() => {
+      userFindQueryFixture = UserFindQueryFixtures.withId;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        result = await userFindQueryToUserFindQueryTypeOrmConverter.convert(
+          userFindQueryFixture,
+        );
+      });
+
+      it('should return a FindManyOptions<UserDb>', () => {
+        const expected: FindManyOptions<UserDb> = {
+          where: {
+            id: userFindQueryFixture.id as string,
+          },
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+});

--- a/packages/backend/services/backend-service-user/src/user/adapter/typeorm/converters/UserFindQueryToUserFindQueryTypeOrmConverter.ts
+++ b/packages/backend/services/backend-service-user/src/user/adapter/typeorm/converters/UserFindQueryToUserFindQueryTypeOrmConverter.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { ConverterAsync } from '@one-game-js/backend-common';
+import { FindManyOptions, FindOptionsWhere } from 'typeorm';
+
+import { Writable } from '../../../../foundation/common/application/models/Writable';
+import { UserFindQuery } from '../../../domain/models/UserFindQuery';
+import { UserDb } from '../models/UserDb';
+
+@Injectable()
+export class UserFindQueryToUserFindQueryTypeOrmConverter
+  implements ConverterAsync<UserFindQuery, FindManyOptions<UserDb>>
+{
+  public async convert(
+    userFindQuery: UserFindQuery,
+  ): Promise<FindManyOptions<UserDb>> {
+    const userFindQueryTypeOrmWhere: Writable<FindOptionsWhere<UserDb>> = {};
+
+    const userFindQueryTypeOrm: FindManyOptions<UserDb> = {
+      where: userFindQueryTypeOrmWhere,
+    };
+
+    if (userFindQuery.id !== undefined) {
+      userFindQueryTypeOrmWhere.id = userFindQuery.id;
+    }
+
+    return userFindQueryTypeOrm;
+  }
+}

--- a/packages/backend/services/backend-service-user/src/user/adapter/typeorm/services/FindUserTypeOrmService.ts
+++ b/packages/backend/services/backend-service-user/src/user/adapter/typeorm/services/FindUserTypeOrmService.ts
@@ -1,0 +1,36 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Converter, ConverterAsync } from '@one-game-js/backend-common';
+import { FindTypeOrmService } from '@one-game-js/backend-db';
+import { FindManyOptions, Repository } from 'typeorm';
+
+import { User } from '../../../domain/models/User';
+import { UserFindQuery } from '../../../domain/models/UserFindQuery';
+import { UserDbToUserConverter } from '../converters/UserDbToUserConverter';
+import { UserFindQueryToUserFindQueryTypeOrmConverter } from '../converters/UserFindQueryToUserFindQueryTypeOrmConverter';
+import { UserDb } from '../models/UserDb';
+
+@Injectable()
+export class FindUserTypeOrmService extends FindTypeOrmService<
+  User,
+  UserDb,
+  UserFindQuery
+> {
+  constructor(
+    @InjectRepository(UserDb)
+    repository: Repository<UserDb>,
+    @Inject(UserDbToUserConverter)
+    userDbToUserConverter: Converter<UserDb, User>,
+    @Inject(UserFindQueryToUserFindQueryTypeOrmConverter)
+    userCreateQueryToUserCreateQueryTypeOrmConverter: ConverterAsync<
+      UserFindQuery,
+      FindManyOptions<UserDb>
+    >,
+  ) {
+    super(
+      repository,
+      userDbToUserConverter,
+      userCreateQueryToUserCreateQueryTypeOrmConverter,
+    );
+  }
+}

--- a/packages/backend/services/backend-service-user/src/user/application/ports/input/UserManagementInputPort.spec.ts
+++ b/packages/backend/services/backend-service-user/src/user/application/ports/input/UserManagementInputPort.spec.ts
@@ -11,6 +11,7 @@ import { UserCreateQueryFixtures } from '../../../domain/fixtures/UserCreateQuer
 import { UserFixtures } from '../../../domain/fixtures/UserFixtures';
 import { User } from '../../../domain/models/User';
 import { UserCreateQuery } from '../../../domain/models/UserCreateQuery';
+import { UserFindQuery } from '../../../domain/models/UserFindQuery';
 import { UserCreateQueryV1Fixtures } from '../../fixtures/UserCreateQueryV1Fixtures';
 import { UserV1Fixtures } from '../../fixtures/UserV1Fixtures';
 import { UserPersistenceOutputPort } from '../output/UserPersistenceOutputPort';
@@ -36,7 +37,7 @@ describe(UserManagementInputPort.name, () => {
       jest.Mocked<BcryptHashProviderOutputPort>
     > as jest.Mocked<BcryptHashProviderOutputPort>;
     userCreateQueryV1ToUserCreateQueryConverterMock = { convert: jest.fn() };
-    userPersistenceOutputPortMock = { create: jest.fn() };
+    userPersistenceOutputPortMock = { create: jest.fn(), findOne: jest.fn() };
     userToUserV1ConverterMock = { convert: jest.fn() };
     uuidProviderOutputPortMock = { generateV4: jest.fn() };
 
@@ -120,6 +121,89 @@ describe(UserManagementInputPort.name, () => {
         expect(userPersistenceOutputPortMock.create).toHaveBeenCalledTimes(1);
         expect(userPersistenceOutputPortMock.create).toHaveBeenCalledWith(
           userCreateQueryFixture,
+        );
+      });
+
+      it('should call userToUserV1Converter.convert()', () => {
+        expect(userToUserV1ConverterMock.convert).toHaveBeenCalledTimes(1);
+        expect(userToUserV1ConverterMock.convert).toHaveBeenCalledWith(
+          userFixture,
+        );
+      });
+
+      it('should return an UserV1', () => {
+        expect(result).toBe(userV1Fixture);
+      });
+    });
+  });
+
+  describe('.findOne', () => {
+    let idFixture: string;
+
+    beforeAll(() => {
+      idFixture = '83073aec-b81b-4107-97f9-baa46de5dd40';
+    });
+
+    describe('when called, and userPersistenceOutputPort.findOne() returns undefined', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        userPersistenceOutputPortMock.findOne.mockResolvedValueOnce(undefined);
+
+        result = await userManagementInputPort.findOne(idFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call userPersistenceOutputPort.findOne()', () => {
+        const expectedUserFindQuery: UserFindQuery = {
+          id: idFixture,
+        };
+
+        expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(1);
+        expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
+          expectedUserFindQuery,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called, and userPersistenceOutputPort.findOne() returns a User', () => {
+      let userFixture: User;
+      let userV1Fixture: apiModels.UserV1;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        userFixture = UserFixtures.any;
+        userV1Fixture = UserV1Fixtures.any;
+
+        userPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          userFixture,
+        );
+
+        userToUserV1ConverterMock.convert.mockReturnValueOnce(userV1Fixture);
+
+        result = await userManagementInputPort.findOne(idFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call userPersistenceOutputPort.findOne()', () => {
+        const expectedUserFindQuery: UserFindQuery = {
+          id: idFixture,
+        };
+
+        expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(1);
+        expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
+          expectedUserFindQuery,
         );
       });
 

--- a/packages/backend/services/backend-service-user/src/user/application/ports/output/UserPersistenceOutputPort.ts
+++ b/packages/backend/services/backend-service-user/src/user/application/ports/output/UserPersistenceOutputPort.ts
@@ -1,8 +1,10 @@
 import { User } from '../../../domain/models/User';
 import { UserCreateQuery } from '../../../domain/models/UserCreateQuery';
+import { UserFindQuery } from '../../../domain/models/UserFindQuery';
 
 export interface UserPersistenceOutputPort {
   create(userCreateQuery: UserCreateQuery): Promise<User>;
+  findOne(userFindQuery: UserFindQuery): Promise<User | undefined>;
 }
 
 export const userPersistenceOutputPortSymbol: symbol = Symbol.for(

--- a/packages/backend/services/backend-service-user/src/user/domain/fixtures/UserFindQueryFixtures.ts
+++ b/packages/backend/services/backend-service-user/src/user/domain/fixtures/UserFindQueryFixtures.ts
@@ -1,0 +1,17 @@
+import { UserFindQuery } from '../models/UserFindQuery';
+
+export class UserFindQueryFixtures {
+  public static get withId(): UserFindQuery {
+    const fixture: UserFindQuery = {
+      id: '83073aec-b81b-4107-97f9-baa46de5dd40',
+    };
+
+    return fixture;
+  }
+
+  public static get withNoProperties(): UserFindQuery {
+    const fixture: UserFindQuery = {};
+
+    return fixture;
+  }
+}

--- a/packages/backend/services/backend-service-user/src/user/domain/models/UserFindQuery.ts
+++ b/packages/backend/services/backend-service-user/src/user/domain/models/UserFindQuery.ts
@@ -1,0 +1,3 @@
+export interface UserFindQuery {
+  id?: string;
+}


### PR DESCRIPTION
### Added
- Added `UserFindQuery`.
- Added `UserFindQueryToUserFindQueryTypeOrmConverter`.
- Added `FindUserTypeOrmService`.

### Changed
- Updated `FindTypeOrmService` with more flexible contracts.
- Updated `UserPersistenceOutputPort` with `findOne` method.
- Updated `UserManagementInputPort` with `findOne` method.