### PR TITLE
Fix get affected projects script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         run: echo "packages=$(pnpm exec backend-get-affected-projects test:js origin/${{github.base_ref}})" >> $GITHUB_OUTPUT
 
       - name: Compile source files
-        run: pnpm run build:all
+        run: pnpm run build
 
       - name: Lint affected source files
         run: pnpm run lint:all --filter=[origin/${{github.base_ref}}]
@@ -129,7 +129,7 @@ jobs:
             ts-build-${{ steps.get-git-commit-hash.outputs.gitCommitHash }}
 
       - name: Build on cache miss
-        run: pnpm run build:all --filter ${{ matrix.package }}
+        run: pnpm run build --filter ${{ matrix.package }}
         if: ${{ !steps.ts-build-cache.outputs.cache-hit }}
 
       - name: Launch Unit Tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         run: pnpm run build
 
       - name: Lint affected source files
-        run: pnpm run lint:all --filter=[origin/${{github.base_ref}}]
+        run: pnpm run lint --filter=[origin/${{github.base_ref}}]
 
       - name: Get current git commit hash
         id: get-git-commit-hash

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "git+https://github.com/notaphplover/one-game.git"
   },
   "scripts": {
-    "build:all": "turbo run build",
+    "build": "turbo run build",
     "lint:all": "turbo run lint",
     "prepare": "husky install",
     "serve": "trap '' INT TERM; turbo run serve",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "build": "turbo run build",
-    "lint:all": "turbo run lint",
+    "lint": "turbo run lint",
     "prepare": "husky install",
     "serve": "trap '' INT TERM; turbo run serve",
     "test:integration:js": "turbo test:integration:js",

--- a/packages/backend/libraries/backend-scripts/bin/getAffectedProjects.js
+++ b/packages/backend/libraries/backend-scripts/bin/getAffectedProjects.js
@@ -6,8 +6,6 @@ import { promisifiedExec } from '../src/promisifiedExec.js';
 const TURBOREPO_ROOT_PACKAGE_NAME = '//';
 const TURBOREPO_TASK_NOT_FOUND_MAGIC_STRING = '\u003cNONEXISTENT\u003e';
 
-const PACKAGES_DIRECTORY_PREFIX = 'packages/';
-
 const taskToDryRun = argv[2];
 const baseRef = argv[3];
 
@@ -35,8 +33,6 @@ const tasks = dryRunResult.tasks.filter((task) =>
 );
 
 /** @type {Array.<string>} */
-const packageNames = tasks.map((task) =>
-  task.directory.replace(PACKAGES_DIRECTORY_PREFIX, ''),
-);
+const packageNames = tasks.map((task) => task.package);
 
 console.log(JSON.stringify(packageNames));


### PR DESCRIPTION
### Changed
- Updated `getAffectedProjects` script to return the right project ids.
- Renamed `build:all` script to `build`. 
- Renamed `lint:all` script to `lint`. 