### PR TITLE
Update GameManagementInputPort with updateOne

### DIFF
--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/models/GameDb.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/models/GameDb.ts
@@ -93,7 +93,6 @@ export class GameDb {
     () => GameSlotDb,
     (gameSlotDb: GameSlotDb): GameDb => gameSlotDb.game,
     {
-      cascade: true,
       eager: true,
     },
   )

--- a/packages/backend/apps/game/backend-game-application/src/games/adapter/nest/modules/GameApplicationModule.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/adapter/nest/modules/GameApplicationModule.ts
@@ -17,6 +17,7 @@ import { GameSpecV1FromGameCardSpecsBuilder } from '../../../application/builder
 import { GameV1FromGameBuilder } from '../../../application/builders/GameV1FromGameBuilder';
 import { NonStartedGameSlotV1FromNonStartedGameSlotBuilder } from '../../../application/builders/NonStartedGameSlotV1FromNonStartedGameSlotBuilder';
 import { GameCreatedEventHandler } from '../../../application/handlers/GameCreatedEventHandler';
+import { GameIdPassTurnQueryV1Handler } from '../../../application/handlers/GameIdPassTurnQueryV1Handler';
 import { NonStartedGameFilledEventHandler } from '../../../application/handlers/NonStartedGameFilledEventHandler';
 import { GameManagementInputPort } from '../../../application/ports/input/GameManagementInputPort';
 import { GameOptionsManagementInputPort } from '../../../application/ports/input/GameOptionsManagementInputPort';
@@ -47,6 +48,7 @@ export class GameApplicationModule {
         GameCreateQueryFromGameCreateQueryV1Builder,
         GameCreateQueryFromGameCreateQueryV1Builder,
         GameDirectionV1FromGameDirectionBuilder,
+        GameIdPassTurnQueryV1Handler,
         GameManagementInputPort,
         GameOptionsCreateQueryFromGameOptionsV1Builder,
         GameOptionsManagementInputPort,

--- a/packages/backend/apps/game/backend-game-application/src/games/application/fixtures/GameIdPassTurnQueryV1Fixtures.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/fixtures/GameIdPassTurnQueryV1Fixtures.ts
@@ -1,0 +1,24 @@
+import { models as apiModels } from '@cornie-js/api-models';
+
+export class GameIdPassTurnQueryV1Fixtures {
+  public static get any(): apiModels.GameIdPassTurnQueryV1 {
+    return {
+      kind: 'passTurn',
+      slotIndex: 0,
+    };
+  }
+
+  public static get withSlotIndexZero(): apiModels.GameIdPassTurnQueryV1 {
+    return {
+      kind: 'passTurn',
+      slotIndex: 0,
+    };
+  }
+
+  public static get withUnexistingSlotIndex(): apiModels.GameIdPassTurnQueryV1 {
+    return {
+      kind: 'passTurn',
+      slotIndex: -1,
+    };
+  }
+}

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPassTurnQueryV1Handler.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPassTurnQueryV1Handler.spec.ts
@@ -1,0 +1,676 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { models as apiModels } from '@cornie-js/api-models';
+import { AppError, AppErrorKind } from '@cornie-js/backend-common';
+import {
+  ActiveGame,
+  GameFindQuery,
+  GameOptions,
+  GameOptionsFindQuery,
+  GameService,
+  GameUpdateQuery,
+  PlayerCanPassTurnSpec,
+} from '@cornie-js/backend-game-domain/games';
+import {
+  ActiveGameFixtures,
+  ActiveGameSlotFixtures,
+  GameOptionsFixtures,
+  GameUpdateQueryFixtures,
+} from '@cornie-js/backend-game-domain/games/fixtures';
+
+import { UserV1Fixtures } from '../../../users/application/fixtures/models/UserV1Fixtures';
+import { GameIdPassTurnQueryV1Fixtures } from '../fixtures/GameIdPassTurnQueryV1Fixtures';
+import { GameOptionsPersistenceOutputPort } from '../ports/output/GameOptionsPersistenceOutputPort';
+import { GamePersistenceOutputPort } from '../ports/output/GamePersistenceOutputPort';
+import { GameIdPassTurnQueryV1Handler } from './GameIdPassTurnQueryV1Handler';
+
+describe(GameIdPassTurnQueryV1Handler.name, () => {
+  let gameOptionsPersistenceOutputPortMock: jest.Mocked<GameOptionsPersistenceOutputPort>;
+  let gamePersistenceOutputPortMock: jest.Mocked<GamePersistenceOutputPort>;
+  let gameServiceMock: jest.Mocked<GameService>;
+  let playerCanPassTurnSpecMock: jest.Mocked<PlayerCanPassTurnSpec>;
+
+  let gameIdPassTurnQueryV1Handler: GameIdPassTurnQueryV1Handler;
+
+  beforeAll(() => {
+    gameOptionsPersistenceOutputPortMock = {
+      findOne: jest.fn(),
+    } as Partial<
+      jest.Mocked<GameOptionsPersistenceOutputPort>
+    > as jest.Mocked<GameOptionsPersistenceOutputPort>;
+    gamePersistenceOutputPortMock = {
+      findOne: jest.fn(),
+      update: jest.fn(),
+    } as Partial<
+      jest.Mocked<GamePersistenceOutputPort>
+    > as jest.Mocked<GamePersistenceOutputPort>;
+    gameServiceMock = {
+      buildPassTurnGameUpdateQuery: jest.fn(),
+    } as Partial<jest.Mocked<GameService>> as jest.Mocked<GameService>;
+    playerCanPassTurnSpecMock = {
+      isSatisfiedBy: jest.fn(),
+    } as Partial<
+      jest.Mocked<PlayerCanPassTurnSpec>
+    > as jest.Mocked<PlayerCanPassTurnSpec>;
+
+    gameIdPassTurnQueryV1Handler = new GameIdPassTurnQueryV1Handler(
+      gameOptionsPersistenceOutputPortMock,
+      gamePersistenceOutputPortMock,
+      gameServiceMock,
+      playerCanPassTurnSpecMock,
+    );
+  });
+
+  describe('having a gameId', () => {
+    let gameIdFixture: string;
+    let gameIdPassTurnQueryV1Fixture: apiModels.GameIdPassTurnQueryV1;
+    let userV1Fixture: apiModels.UserV1;
+
+    beforeAll(() => {
+      gameIdFixture = ActiveGameFixtures.any.id;
+      gameIdPassTurnQueryV1Fixture = GameIdPassTurnQueryV1Fixtures.any;
+      userV1Fixture = UserV1Fixtures.any;
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    describe('when called, and gamePersistenceOutputPort.findOne() returns undefined', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        gamePersistenceOutputPortMock.findOne.mockResolvedValueOnce(undefined);
+        gameOptionsPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          GameOptionsFixtures.any,
+        );
+
+        try {
+          await gameIdPassTurnQueryV1Handler.handle(
+            gameIdFixture,
+            gameIdPassTurnQueryV1Fixture,
+            userV1Fixture,
+          );
+        } catch (error) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call gamePersistenceOutputPort.findOne()', () => {
+        const expectedGameFindQuery: GameFindQuery = {
+          id: gameIdFixture,
+        };
+
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(1);
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
+          expectedGameFindQuery,
+        );
+      });
+
+      it('should call gameOptionsPersistenceOutputPort.findOne()', () => {
+        const expectedGameOptionsFindQuery: GameOptionsFindQuery = {
+          gameId: gameIdFixture,
+        };
+
+        expect(
+          gameOptionsPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          gameOptionsPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledWith(expectedGameOptionsFindQuery);
+      });
+
+      it('should throw an Error', () => {
+        const expectedErrorProperties: Partial<AppError> = {
+          kind: AppErrorKind.entityNotFound,
+          message: `Game "${gameIdFixture}" not found`,
+        };
+
+        expect(result).toBeInstanceOf(AppError);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProperties),
+        );
+      });
+    });
+
+    describe('when called, and gameOptionsPersistenceOutputPort.findOne() returns undefined', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        gamePersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          ActiveGameFixtures.any,
+        );
+        gameOptionsPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          undefined,
+        );
+
+        try {
+          await gameIdPassTurnQueryV1Handler.handle(
+            gameIdFixture,
+            gameIdPassTurnQueryV1Fixture,
+            userV1Fixture,
+          );
+        } catch (error) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call gamePersistenceOutputPort.findOne()', () => {
+        const expectedGameFindQuery: GameFindQuery = {
+          id: gameIdFixture,
+        };
+
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(1);
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
+          expectedGameFindQuery,
+        );
+      });
+
+      it('should call gameOptionsPersistenceOutputPort.findOne()', () => {
+        const expectedGameOptionsFindQuery: GameOptionsFindQuery = {
+          gameId: gameIdFixture,
+        };
+
+        expect(
+          gameOptionsPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          gameOptionsPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledWith(expectedGameOptionsFindQuery);
+      });
+
+      it('should throw an Error', () => {
+        const expectedErrorProperties: Partial<AppError> = {
+          kind: AppErrorKind.unknown,
+          message: `Expecting game "${gameIdFixture}" to have options, none found`,
+        };
+
+        expect(result).toBeInstanceOf(AppError);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProperties),
+        );
+      });
+    });
+  });
+
+  describe('having a gameId, and gameIdPassTurnQueryV1 with unexisting slotIndex', () => {
+    let gameIdFixture: string;
+    let gameIdPassTurnQueryV1Fixture: apiModels.GameIdPassTurnQueryV1;
+    let userV1Fixture: apiModels.UserV1;
+
+    beforeAll(() => {
+      gameIdFixture = ActiveGameFixtures.any.id;
+      gameIdPassTurnQueryV1Fixture =
+        GameIdPassTurnQueryV1Fixtures.withUnexistingSlotIndex;
+      userV1Fixture = UserV1Fixtures.any;
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    describe('when called, and gamePersistenceOutputPort.findOne() returns Game and gameOptionsPersistenceOutputPort.findOne() returns GameOptions', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        gamePersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          ActiveGameFixtures.any,
+        );
+        gameOptionsPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          GameOptionsFixtures.any,
+        );
+
+        try {
+          await gameIdPassTurnQueryV1Handler.handle(
+            gameIdFixture,
+            gameIdPassTurnQueryV1Fixture,
+            userV1Fixture,
+          );
+        } catch (error) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call gamePersistenceOutputPort.findOne()', () => {
+        const expectedGameFindQuery: GameFindQuery = {
+          id: gameIdFixture,
+        };
+
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(1);
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
+          expectedGameFindQuery,
+        );
+      });
+
+      it('should call gameOptionsPersistenceOutputPort.findOne()', () => {
+        const expectedGameOptionsFindQuery: GameOptionsFindQuery = {
+          gameId: gameIdFixture,
+        };
+
+        expect(
+          gameOptionsPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          gameOptionsPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledWith(expectedGameOptionsFindQuery);
+      });
+
+      it('should throw an Error', () => {
+        const expectedErrorProperties: Partial<AppError> = {
+          kind: AppErrorKind.unprocessableOperation,
+          message: `Player is not eligible for this operation. Reason: game slot "${gameIdPassTurnQueryV1Fixture.slotIndex}" does not exist`,
+        };
+
+        expect(result).toBeInstanceOf(AppError);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProperties),
+        );
+      });
+    });
+  });
+
+  describe('having a gameId, and gameIdPassTurnQueryV1 with existing slotIndex and an user', () => {
+    let gameIdFixture: string;
+    let gameIdPassTurnQueryV1Fixture: apiModels.GameIdPassTurnQueryV1;
+    let userV1Fixture: apiModels.UserV1;
+
+    beforeAll(() => {
+      gameIdFixture = ActiveGameFixtures.any.id;
+      gameIdPassTurnQueryV1Fixture =
+        GameIdPassTurnQueryV1Fixtures.withSlotIndexZero;
+      userV1Fixture = UserV1Fixtures.any;
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    describe('when called, and gamePersistenceOutputPort.findOne() returns Game whose slot targeted by gameIdPassTurnQueryV1 does not match user and gameOptionsPersistenceOutputPort.findOne() returns GameOptions', () => {
+      let activeGameFixture: ActiveGame;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        const anyFixtures: ActiveGame = ActiveGameFixtures.any;
+
+        activeGameFixture = {
+          ...anyFixtures,
+          state: {
+            ...anyFixtures.state,
+            currentPlayingSlotIndex: 0,
+            slots: [
+              {
+                ...ActiveGameSlotFixtures.withPositionZero,
+                userId: 'different-user-id',
+              },
+              ActiveGameSlotFixtures.withPositionOne,
+            ],
+          },
+        };
+
+        gamePersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          activeGameFixture,
+        );
+        gameOptionsPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          GameOptionsFixtures.any,
+        );
+
+        try {
+          await gameIdPassTurnQueryV1Handler.handle(
+            gameIdFixture,
+            gameIdPassTurnQueryV1Fixture,
+            userV1Fixture,
+          );
+        } catch (error) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call gamePersistenceOutputPort.findOne()', () => {
+        const expectedGameFindQuery: GameFindQuery = {
+          id: gameIdFixture,
+        };
+
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(1);
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
+          expectedGameFindQuery,
+        );
+      });
+
+      it('should call gameOptionsPersistenceOutputPort.findOne()', () => {
+        const expectedGameOptionsFindQuery: GameOptionsFindQuery = {
+          gameId: gameIdFixture,
+        };
+
+        expect(
+          gameOptionsPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          gameOptionsPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledWith(expectedGameOptionsFindQuery);
+      });
+
+      it('should throw an Error', () => {
+        const expectedErrorProperties: Partial<AppError> = {
+          kind: AppErrorKind.unprocessableOperation,
+          message: `Player is not eligible for this operation. Reason: user "${userV1Fixture.id}" does not own game slot "${gameIdPassTurnQueryV1Fixture.slotIndex}"`,
+        };
+
+        expect(result).toBeInstanceOf(AppError);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProperties),
+        );
+      });
+    });
+
+    describe('when called, and gamePersistenceOutputPort.findOne() returns Game with active slot different than gameIdPassTurnQueryV1, whose slot targeted by gameIdPassTurnQueryV1 matches user and gameOptionsPersistenceOutputPort.findOne() returns GameOptions', () => {
+      let activeGameFixture: ActiveGame;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        const anyFixtures: ActiveGame = ActiveGameFixtures.any;
+
+        activeGameFixture = {
+          ...anyFixtures,
+          state: {
+            ...anyFixtures.state,
+            currentPlayingSlotIndex: 1,
+            slots: [
+              {
+                ...ActiveGameSlotFixtures.withPositionZero,
+                userId: userV1Fixture.id,
+              },
+              ActiveGameSlotFixtures.withPositionOne,
+            ],
+          },
+        };
+
+        gamePersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          activeGameFixture,
+        );
+        gameOptionsPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          GameOptionsFixtures.any,
+        );
+
+        try {
+          await gameIdPassTurnQueryV1Handler.handle(
+            gameIdFixture,
+            gameIdPassTurnQueryV1Fixture,
+            userV1Fixture,
+          );
+        } catch (error) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call gamePersistenceOutputPort.findOne()', () => {
+        const expectedGameFindQuery: GameFindQuery = {
+          id: gameIdFixture,
+        };
+
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(1);
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
+          expectedGameFindQuery,
+        );
+      });
+
+      it('should call gameOptionsPersistenceOutputPort.findOne()', () => {
+        const expectedGameOptionsFindQuery: GameOptionsFindQuery = {
+          gameId: gameIdFixture,
+        };
+
+        expect(
+          gameOptionsPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          gameOptionsPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledWith(expectedGameOptionsFindQuery);
+      });
+
+      it('should throw an Error', () => {
+        const expectedErrorProperties: Partial<AppError> = {
+          kind: AppErrorKind.unprocessableOperation,
+          message:
+            "Player is not eligible for this operation. Reason: it is not the player's turn",
+        };
+
+        expect(result).toBeInstanceOf(AppError);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProperties),
+        );
+      });
+    });
+
+    describe('when called, and gamePersistenceOutputPort.findOne() returns Game with active slot equals to gameIdPassTurnQueryV1, whose slot targeted by gameIdPassTurnQueryV1 matches user and gameOptionsPersistenceOutputPort.findOne() returns GameOptions and playerCanPassTurnSpec.isSatisfiedBy returns false', () => {
+      let activeGameFixture: ActiveGame;
+      let gameOptionsFixture: GameOptions;
+      let gameUpdateQueryFixture: GameUpdateQuery;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        const anyFixtures: ActiveGame = ActiveGameFixtures.any;
+
+        activeGameFixture = {
+          ...anyFixtures,
+          state: {
+            ...anyFixtures.state,
+            currentPlayingSlotIndex: 0,
+            slots: [
+              {
+                ...ActiveGameSlotFixtures.withPositionZero,
+                userId: userV1Fixture.id,
+              },
+              ActiveGameSlotFixtures.withPositionOne,
+            ],
+          },
+        };
+        gameOptionsFixture = GameOptionsFixtures.any;
+        gameUpdateQueryFixture = GameUpdateQueryFixtures.any;
+
+        gamePersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          activeGameFixture,
+        );
+        gameOptionsPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          gameOptionsFixture,
+        );
+
+        gameServiceMock.buildPassTurnGameUpdateQuery.mockReturnValueOnce(
+          gameUpdateQueryFixture,
+        );
+
+        playerCanPassTurnSpecMock.isSatisfiedBy.mockReturnValueOnce(false);
+
+        try {
+          await gameIdPassTurnQueryV1Handler.handle(
+            gameIdFixture,
+            gameIdPassTurnQueryV1Fixture,
+            userV1Fixture,
+          );
+        } catch (error) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call gamePersistenceOutputPort.findOne()', () => {
+        const expectedGameFindQuery: GameFindQuery = {
+          id: gameIdFixture,
+        };
+
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(1);
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
+          expectedGameFindQuery,
+        );
+      });
+
+      it('should call gameOptionsPersistenceOutputPort.findOne()', () => {
+        const expectedGameOptionsFindQuery: GameOptionsFindQuery = {
+          gameId: gameIdFixture,
+        };
+
+        expect(
+          gameOptionsPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          gameOptionsPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledWith(expectedGameOptionsFindQuery);
+      });
+
+      it('playerCanPassTurnSpec.isSatisfiedBy()', () => {
+        expect(playerCanPassTurnSpecMock.isSatisfiedBy).toHaveBeenCalledTimes(
+          1,
+        );
+        expect(playerCanPassTurnSpecMock.isSatisfiedBy).toHaveBeenCalledWith(
+          activeGameFixture,
+          gameOptionsFixture,
+          gameIdPassTurnQueryV1Fixture.slotIndex,
+        );
+      });
+
+      it('should throw an Error', () => {
+        const expectedErrorProperties: Partial<AppError> = {
+          kind: AppErrorKind.unprocessableOperation,
+          message:
+            'Player cannot end the turn. Reason: there is a pending action preventing the turn to be ended',
+        };
+
+        expect(result).toBeInstanceOf(AppError);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProperties),
+        );
+      });
+    });
+
+    describe('when called, and gamePersistenceOutputPort.findOne() returns Game with active slot equals to gameIdPassTurnQueryV1, whose slot targeted by gameIdPassTurnQueryV1 matches user and gameOptionsPersistenceOutputPort.findOne() returns GameOptions and playerCanPassTurnSpec.isSatisfiedBy returns true', () => {
+      let activeGameFixture: ActiveGame;
+      let gameOptionsFixture: GameOptions;
+      let gameUpdateQueryFixture: GameUpdateQuery;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        const anyFixtures: ActiveGame = ActiveGameFixtures.any;
+
+        activeGameFixture = {
+          ...anyFixtures,
+          state: {
+            ...anyFixtures.state,
+            currentPlayingSlotIndex: 0,
+            slots: [
+              {
+                ...ActiveGameSlotFixtures.withPositionZero,
+                userId: userV1Fixture.id,
+              },
+              ActiveGameSlotFixtures.withPositionOne,
+            ],
+          },
+        };
+        gameOptionsFixture = GameOptionsFixtures.any;
+        gameUpdateQueryFixture = GameUpdateQueryFixtures.any;
+
+        gamePersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          activeGameFixture,
+        );
+        gameOptionsPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          gameOptionsFixture,
+        );
+
+        gameServiceMock.buildPassTurnGameUpdateQuery.mockReturnValueOnce(
+          gameUpdateQueryFixture,
+        );
+
+        playerCanPassTurnSpecMock.isSatisfiedBy.mockReturnValueOnce(true);
+
+        result = await gameIdPassTurnQueryV1Handler.handle(
+          gameIdFixture,
+          gameIdPassTurnQueryV1Fixture,
+          userV1Fixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call gamePersistenceOutputPort.findOne()', () => {
+        const expectedGameFindQuery: GameFindQuery = {
+          id: gameIdFixture,
+        };
+
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(1);
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
+          expectedGameFindQuery,
+        );
+      });
+
+      it('should call gameOptionsPersistenceOutputPort.findOne()', () => {
+        const expectedGameOptionsFindQuery: GameOptionsFindQuery = {
+          gameId: gameIdFixture,
+        };
+
+        expect(
+          gameOptionsPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          gameOptionsPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledWith(expectedGameOptionsFindQuery);
+      });
+
+      it('playerCanPassTurnSpec.isSatisfiedBy()', () => {
+        expect(playerCanPassTurnSpecMock.isSatisfiedBy).toHaveBeenCalledTimes(
+          1,
+        );
+        expect(playerCanPassTurnSpecMock.isSatisfiedBy).toHaveBeenCalledWith(
+          activeGameFixture,
+          gameOptionsFixture,
+          gameIdPassTurnQueryV1Fixture.slotIndex,
+        );
+      });
+
+      it('should call gameService.buildPassTurnGameUpdateQuery()', () => {
+        expect(
+          gameServiceMock.buildPassTurnGameUpdateQuery,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          gameServiceMock.buildPassTurnGameUpdateQuery,
+        ).toHaveBeenCalledWith(activeGameFixture);
+      });
+
+      it('should call gamePersistenceOutputPort.update()', () => {
+        expect(gamePersistenceOutputPortMock.update).toHaveBeenCalledTimes(1);
+        expect(gamePersistenceOutputPortMock.update).toHaveBeenCalledWith(
+          gameUpdateQueryFixture,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPassTurnQueryV1Handler.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPassTurnQueryV1Handler.ts
@@ -1,0 +1,164 @@
+import { models as apiModels } from '@cornie-js/api-models';
+import { AppError, AppErrorKind, Handler } from '@cornie-js/backend-common';
+import {
+  ActiveGame,
+  ActiveGameSlot,
+  Game,
+  GameFindQuery,
+  GameOptions,
+  GameOptionsFindQuery,
+  GameService,
+  GameUpdateQuery,
+  PlayerCanPassTurnSpec,
+} from '@cornie-js/backend-game-domain/games';
+import { Inject, Injectable } from '@nestjs/common';
+
+import {
+  GameOptionsPersistenceOutputPort,
+  gameOptionsPersistenceOutputPortSymbol,
+} from '../ports/output/GameOptionsPersistenceOutputPort';
+import {
+  GamePersistenceOutputPort,
+  gamePersistenceOutputPortSymbol,
+} from '../ports/output/GamePersistenceOutputPort';
+
+@Injectable()
+export class GameIdPassTurnQueryV1Handler
+  implements
+    Handler<[string, apiModels.GameIdPassTurnQueryV1, apiModels.UserV1], void>
+{
+  readonly #gameOptionsPersistenceOutputPort: GameOptionsPersistenceOutputPort;
+  readonly #gamePersistenceOutputPort: GamePersistenceOutputPort;
+  readonly #gameService: GameService;
+  readonly #playerCanPassTurnSpec: PlayerCanPassTurnSpec;
+
+  constructor(
+    @Inject(gameOptionsPersistenceOutputPortSymbol)
+    gameOptionsPersistenceOutputPort: GameOptionsPersistenceOutputPort,
+    @Inject(gamePersistenceOutputPortSymbol)
+    gamePersistenceOutputPort: GamePersistenceOutputPort,
+    @Inject(GameService)
+    gameService: GameService,
+    @Inject(PlayerCanPassTurnSpec)
+    playerCanPassTurnSpec: PlayerCanPassTurnSpec,
+  ) {
+    this.#gameOptionsPersistenceOutputPort = gameOptionsPersistenceOutputPort;
+    this.#gamePersistenceOutputPort = gamePersistenceOutputPort;
+    this.#gameService = gameService;
+    this.#playerCanPassTurnSpec = playerCanPassTurnSpec;
+  }
+
+  public async handle(
+    gameId: string,
+    gameIdPassTurnQueryV1: apiModels.GameIdPassTurnQueryV1,
+    userV1: apiModels.UserV1,
+  ): Promise<void> {
+    const [game, gameOptions]: [ActiveGame, GameOptions] =
+      await this.#getActiveGameAndOptionsOrThrow(gameId);
+
+    this.#checkRightPlayer(game, gameIdPassTurnQueryV1, userV1);
+
+    this.#checkUnprocessableOperation(game, gameOptions, gameIdPassTurnQueryV1);
+
+    const gameUpdateQuery: GameUpdateQuery =
+      this.#gameService.buildPassTurnGameUpdateQuery(game);
+
+    await this.#gamePersistenceOutputPort.update(gameUpdateQuery);
+  }
+
+  #checkRightPlayer(
+    game: ActiveGame,
+    gameIdPassTurnQueryV1: apiModels.GameIdPassTurnQueryV1,
+    userV1: apiModels.UserV1,
+  ): void {
+    const userGameSlot: ActiveGameSlot | undefined =
+      game.state.slots[gameIdPassTurnQueryV1.slotIndex];
+
+    if (userGameSlot === undefined) {
+      throw new AppError(
+        AppErrorKind.unprocessableOperation,
+        `Player is not eligible for this operation. Reason: game slot "${gameIdPassTurnQueryV1.slotIndex}" does not exist`,
+      );
+    }
+
+    if (userV1.id !== userGameSlot.userId) {
+      throw new AppError(
+        AppErrorKind.unprocessableOperation,
+        `Player is not eligible for this operation. Reason: user "${userV1.id}" does not own game slot "${gameIdPassTurnQueryV1.slotIndex}"`,
+      );
+    }
+
+    if (
+      gameIdPassTurnQueryV1.slotIndex !== game.state.currentPlayingSlotIndex
+    ) {
+      throw new AppError(
+        AppErrorKind.unprocessableOperation,
+        "Player is not eligible for this operation. Reason: it is not the player's turn",
+      );
+    }
+  }
+
+  #checkUnprocessableOperation(
+    game: ActiveGame,
+    gameOptions: GameOptions,
+    gameIdPassTurnQueryV1: apiModels.GameIdPassTurnQueryV1,
+  ): void {
+    if (
+      !this.#playerCanPassTurnSpec.isSatisfiedBy(
+        game,
+        gameOptions,
+        gameIdPassTurnQueryV1.slotIndex,
+      )
+    ) {
+      throw new AppError(
+        AppErrorKind.unprocessableOperation,
+        'Player cannot end the turn. Reason: there is a pending action preventing the turn to be ended',
+      );
+    }
+  }
+
+  async #getActiveGameAndOptionsOrThrow(
+    gameId: string,
+  ): Promise<[ActiveGame, GameOptions]> {
+    const gameFindQuery: GameFindQuery = {
+      id: gameId,
+    };
+
+    const gameOptionsFindQuery: GameOptionsFindQuery = {
+      gameId,
+    };
+
+    const [game, gameOptions]: [Game | undefined, GameOptions | undefined] =
+      await Promise.all([
+        this.#gamePersistenceOutputPort.findOne(gameFindQuery),
+        this.#gameOptionsPersistenceOutputPort.findOne(gameOptionsFindQuery),
+      ]);
+
+    if (game === undefined) {
+      throw new AppError(
+        AppErrorKind.entityNotFound,
+        `Game "${gameId}" not found`,
+      );
+    }
+
+    if (gameOptions === undefined) {
+      throw new AppError(
+        AppErrorKind.unknown,
+        `Expecting game "${gameId}" to have options, none found`,
+      );
+    }
+
+    if (!this.#isActiveGame(game)) {
+      throw new AppError(
+        AppErrorKind.unprocessableOperation,
+        `Game "${gameId}" is not eligible for this operation. Reason: the game is not active`,
+      );
+    }
+
+    return [game, gameOptions];
+  }
+
+  #isActiveGame(game: Game): game is ActiveGame {
+    return game.state.active;
+  }
+}

--- a/packages/backend/apps/game/backend-game-application/src/games/application/ports/input/GameManagementInputPort.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/ports/input/GameManagementInputPort.ts
@@ -3,7 +3,12 @@ import {
   UuidProviderOutputPort,
   uuidProviderOutputPortSymbol,
 } from '@cornie-js/backend-app-uuid';
-import { Builder, Handler } from '@cornie-js/backend-common';
+import {
+  AppError,
+  AppErrorKind,
+  Builder,
+  Handler,
+} from '@cornie-js/backend-common';
 import {
   Game,
   GameCreateQuery,
@@ -14,6 +19,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { GameCreateQueryFromGameCreateQueryV1Builder } from '../../builders/GameCreateQueryFromGameCreateQueryV1Builder';
 import { GameV1FromGameBuilder } from '../../builders/GameV1FromGameBuilder';
 import { GameCreatedEventHandler } from '../../handlers/GameCreatedEventHandler';
+import { GameIdPassTurnQueryV1Handler } from '../../handlers/GameIdPassTurnQueryV1Handler';
 import { GameCreatedEvent } from '../../models/GameCreatedEvent';
 import { GameCreateQueryContext } from '../../models/GameCreateQueryContext';
 import {
@@ -29,6 +35,10 @@ export class GameManagementInputPort {
   >;
 
   readonly #gameCreatedEventHandler: Handler<[GameCreatedEvent], void>;
+  readonly #gameIdPassTurnQueryV1Handler: Handler<
+    [string, apiModels.GameIdPassTurnQueryV1, apiModels.UserV1],
+    void
+  >;
   readonly #gameV1FromGameBuilder: Builder<apiModels.GameV1, [Game]>;
   readonly #gamePersistenceOutputPort: GamePersistenceOutputPort;
   readonly #uuidProviderOutputPort: UuidProviderOutputPort;
@@ -41,6 +51,11 @@ export class GameManagementInputPort {
       GameCreateQuery,
       [apiModels.GameCreateQueryV1, GameCreateQueryContext]
     >,
+    @Inject(GameIdPassTurnQueryV1Handler)
+    gameIdPassTurnQueryV1Handler: Handler<
+      [string, apiModels.GameIdPassTurnQueryV1, apiModels.UserV1],
+      void
+    >,
     @Inject(GameV1FromGameBuilder)
     gameV1FromGameBuilder: Builder<apiModels.GameV1, [Game]>,
     @Inject(gamePersistenceOutputPortSymbol)
@@ -51,6 +66,7 @@ export class GameManagementInputPort {
     this.#gameCreatedEventHandler = gameCreatedEventHandler;
     this.#gameCreateQueryFromGameCreateQueryV1Builder =
       gameCreateQueryFromGameCreateQueryV1Builder;
+    this.#gameIdPassTurnQueryV1Handler = gameIdPassTurnQueryV1Handler;
     this.#gameV1FromGameBuilder = gameV1FromGameBuilder;
     this.#gamePersistenceOutputPort = gamePersistenceOutputPort;
     this.#uuidProviderOutputPort = uuidProviderOutputPort;
@@ -91,10 +107,46 @@ export class GameManagementInputPort {
     }
   }
 
+  public async updateOne(
+    id: string,
+    gameIdUpdateQueryV1: apiModels.GameIdUpdateQueryV1,
+    userV1: apiModels.UserV1,
+  ): Promise<apiModels.GameV1> {
+    switch (gameIdUpdateQueryV1.kind) {
+      case 'passTurn':
+        await this.#gameIdPassTurnQueryV1Handler.handle(
+          id,
+          gameIdUpdateQueryV1,
+          userV1,
+        );
+        break;
+      case 'playCards':
+        throw new AppError(
+          AppErrorKind.unknown,
+          'Operation currently not available',
+        );
+    }
+
+    return this.#getGameOrThrow(id);
+  }
+
   #createGameCreationQueryContext(): GameCreateQueryContext {
     return {
       gameOptionsId: this.#uuidProviderOutputPort.generateV4(),
       uuid: this.#uuidProviderOutputPort.generateV4(),
     };
+  }
+
+  async #getGameOrThrow(id: string): Promise<apiModels.GameV1> {
+    const game: apiModels.GameV1 | undefined = await this.findOne(id);
+
+    if (game === undefined) {
+      throw new AppError(
+        AppErrorKind.unknown,
+        `Expecting game "${id}" to be found`,
+      );
+    }
+
+    return game;
   }
 }

--- a/packages/backend/apps/game/backend-game-domain/src/games/adapter/nest/GameDomainModule.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/adapter/nest/GameDomainModule.ts
@@ -12,6 +12,7 @@ import { PlayerCanPassTurnSpec } from '../../domain/specs/PlayerCanPassTurnSpec'
     GameCanHoldMoreGameSlotsSpec,
     GameCanHoldOnlyOneMoreGameSlotSpec,
     CardCanBePlayedSpec,
+    PlayerCanPassTurnSpec,
   ],
   providers: [
     GameService,

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/ActiveGameFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/ActiveGameFixtures.ts
@@ -149,6 +149,25 @@ export class ActiveGameFixtures {
     };
   }
 
+  public static get withGameSlotsAmountTwoAndDeckWithSpecOneWithAmount120(): ActiveGame {
+    const anyActiveGameFixture: ActiveGame = ActiveGameFixtures.any;
+
+    return {
+      ...anyActiveGameFixture,
+      gameSlotsAmount: 2,
+      spec: {
+        cards: [GameCardSpecFixtures.withAmount120],
+      },
+      state: {
+        ...anyActiveGameFixture.state,
+        slots: [
+          ActiveGameSlotFixtures.withPositionZero,
+          ActiveGameSlotFixtures.withPositionOne,
+        ],
+      },
+    };
+  }
+
   public static get withSlotsOne(): ActiveGame {
     const anyActiveGameFixture: ActiveGame = ActiveGameFixtures.any;
 

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/ActiveGameSlotFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/ActiveGameSlotFixtures.ts
@@ -10,6 +10,13 @@ export class ActiveGameSlotFixtures {
     };
   }
 
+  public static get withPositionOne(): ActiveGameSlot {
+    return {
+      ...ActiveGameSlotFixtures.any,
+      position: 1,
+    };
+  }
+
   public static get withPositionZero(): ActiveGameSlot {
     return {
       ...ActiveGameSlotFixtures.any,

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/index.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/index.ts
@@ -21,6 +21,7 @@ import { GameUpdateQuery } from './query/GameUpdateQuery';
 import { GameService } from './services/GameService';
 import { GameCanHoldMoreGameSlotsSpec } from './specs/GameCanHoldMoreGameSlotsSpec';
 import { GameCanHoldOnlyOneMoreGameSlotSpec } from './specs/GameCanHoldOnlyOneMoreGameSlotSpec';
+import { PlayerCanPassTurnSpec } from './specs/PlayerCanPassTurnSpec';
 
 export type {
   ActiveGame,
@@ -49,4 +50,5 @@ export {
   GameCanHoldOnlyOneMoreGameSlotSpec,
   GameDirection,
   GameService,
+  PlayerCanPassTurnSpec,
 };

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/services/GameService.spec.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/services/GameService.spec.ts
@@ -2,16 +2,16 @@ import { beforeAll, describe, expect, it } from '@jest/globals';
 
 import { AppError, AppErrorKind } from '@cornie-js/backend-common';
 
-import { CardFixtures } from '../../../cards/domain/fixtures/CardFixtures';
 import { Card } from '../../../cards/domain/models/Card';
-import { ColoredCard } from '../../../cards/domain/models/ColoredCard';
+import { CardColor } from '../../../cards/domain/models/CardColor';
 import { ActiveGameFixtures } from '../fixtures/ActiveGameFixtures';
 import { NonStartedGameFixtures } from '../fixtures/NonStartedGameFixtures';
 import { ActiveGame } from '../models/ActiveGame';
+import { ActiveGameSlot } from '../models/ActiveGameSlot';
 import { GameCardSpec } from '../models/GameCardSpec';
 import { GameDirection } from '../models/GameDirection';
-import { GameInitialDraws } from '../models/GameInitialDraws';
 import { NonStartedGame } from '../models/NonStartedGame';
+import { GameUpdateQuery } from '../query/GameUpdateQuery';
 import { GameService } from './GameService';
 
 describe(GameService.name, () => {
@@ -21,29 +21,182 @@ describe(GameService.name, () => {
     gameService = new GameService();
   });
 
-  describe('.getInitialCardColor', () => {
-    describe('having a colored card', () => {
-      let coloredCardFixture: Card & ColoredCard;
+  describe('.buildPassTurnGameUpdateQuery', () => {
+    describe('having a Game with two players and enough cards and currentTurnCardsPlayed false and currentPlayingSlotIndex 1 and drawCount 0', () => {
+      let gameFixture: ActiveGame;
+
+      let deckCardSpec: GameCardSpec;
 
       beforeAll(() => {
-        coloredCardFixture = CardFixtures.reverseCard;
+        const baseFixture: ActiveGame =
+          ActiveGameFixtures.withGameSlotsAmountTwoAndDeckWithSpecOneWithAmount120;
+
+        gameFixture = {
+          ...baseFixture,
+          state: {
+            ...baseFixture.state,
+            currentPlayingSlotIndex: 1,
+            currentTurnCardsPlayed: false,
+            drawCount: 0,
+          },
+        };
+
+        [deckCardSpec] = gameFixture.spec.cards as [GameCardSpec];
       });
 
       describe('when called', () => {
         let result: unknown;
 
         beforeAll(() => {
-          result = gameService.getInitialCardColor(coloredCardFixture);
+          result = gameService.buildPassTurnGameUpdateQuery(gameFixture);
         });
 
-        it('should return a CardColor', () => {
-          expect(result).toBe(coloredCardFixture.color);
+        it('should return a GameUpdateQuery', () => {
+          const currentPlayingGameSlotCards: Card[] = (
+            gameFixture.state.slots[
+              gameFixture.state.currentPlayingSlotIndex
+            ] as ActiveGameSlot
+          ).cards;
+
+          const expectedGameUpdateQuery: GameUpdateQuery = {
+            currentPlayingSlotIndex: 0,
+            currentTurnCardsPlayed: false,
+            deck: [
+              {
+                amount: deckCardSpec.amount - 1,
+                card: deckCardSpec.card,
+              },
+            ],
+            drawCount: 0,
+            gameFindQuery: {
+              id: gameFixture.id,
+            },
+            gameSlotUpdateQueries: [
+              {
+                cards: [...currentPlayingGameSlotCards, deckCardSpec.card],
+                gameSlotFindQuery: {
+                  gameId: gameFixture.id,
+                  position: gameFixture.state.currentPlayingSlotIndex,
+                },
+              },
+            ],
+          };
+
+          expect(result).toStrictEqual(expectedGameUpdateQuery);
+        });
+      });
+    });
+
+    describe('having a Game with two players and enough cards and currentTurnCardsPlayed false and currentPlayingSlotIndex 1 and drawCount 2', () => {
+      let gameFixture: ActiveGame;
+
+      let deckCardSpec: GameCardSpec;
+
+      beforeAll(() => {
+        const baseFixture: ActiveGame =
+          ActiveGameFixtures.withGameSlotsAmountTwoAndDeckWithSpecOneWithAmount120;
+
+        gameFixture = {
+          ...baseFixture,
+          state: {
+            ...baseFixture.state,
+            currentPlayingSlotIndex: 1,
+            currentTurnCardsPlayed: false,
+            drawCount: 2,
+          },
+        };
+
+        [deckCardSpec] = gameFixture.spec.cards as [GameCardSpec];
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = gameService.buildPassTurnGameUpdateQuery(gameFixture);
+        });
+
+        it('should return a GameUpdateQuery', () => {
+          const currentPlayingGameSlotCards: Card[] = (
+            gameFixture.state.slots[
+              gameFixture.state.currentPlayingSlotIndex
+            ] as ActiveGameSlot
+          ).cards;
+
+          const expectedGameUpdateQuery: GameUpdateQuery = {
+            currentPlayingSlotIndex: 0,
+            currentTurnCardsPlayed: false,
+            deck: [
+              {
+                amount: deckCardSpec.amount - 2,
+                card: deckCardSpec.card,
+              },
+            ],
+            drawCount: 0,
+            gameFindQuery: {
+              id: gameFixture.id,
+            },
+            gameSlotUpdateQueries: [
+              {
+                cards: [
+                  ...currentPlayingGameSlotCards,
+                  deckCardSpec.card,
+                  deckCardSpec.card,
+                ],
+                gameSlotFindQuery: {
+                  gameId: gameFixture.id,
+                  position: gameFixture.state.currentPlayingSlotIndex,
+                },
+              },
+            ],
+          };
+
+          expect(result).toStrictEqual(expectedGameUpdateQuery);
+        });
+      });
+    });
+
+    describe('having a Game with two players and enough cards and currentTurnCardsPlayed true and currentPlayingSlotIndex 0', () => {
+      let gameFixture: ActiveGame;
+
+      beforeAll(() => {
+        const baseFixture: ActiveGame =
+          ActiveGameFixtures.withGameSlotsAmountTwoAndDeckWithSpecOneWithAmount120;
+
+        gameFixture = {
+          ...baseFixture,
+          state: {
+            ...baseFixture.state,
+            currentPlayingSlotIndex: 0,
+            currentTurnCardsPlayed: true,
+          },
+        };
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = gameService.buildPassTurnGameUpdateQuery(gameFixture);
+        });
+
+        it('should return a GameUpdateQuery', () => {
+          const expectedGameUpdateQuery: GameUpdateQuery = {
+            currentPlayingSlotIndex: 1,
+            currentTurnCardsPlayed: false,
+            drawCount: 0,
+            gameFindQuery: {
+              id: gameFixture.id,
+            },
+          };
+
+          expect(result).toStrictEqual(expectedGameUpdateQuery);
         });
       });
     });
   });
 
-  describe('.getInitialCardsDraw', () => {
+  describe('.buildStartGameUpdateQuery', () => {
     describe('having a Game with enough cards', () => {
       let gameFixture: NonStartedGame;
       let deckCardSpec: GameCardSpec;
@@ -59,15 +212,10 @@ describe(GameService.name, () => {
         let result: unknown;
 
         beforeAll(() => {
-          result = gameService.getInitialCardsDraw(gameFixture);
+          result = gameService.buildStartGameUpdateQuery(gameFixture);
         });
 
-        it('should return an array of cards and game card spec with the remaining deck cards', () => {
-          const expectedCards: Card[][] = [
-            new Array<Card>(7).fill(deckCardSpec.card),
-            new Array<Card>(7).fill(deckCardSpec.card),
-          ];
-
+        it('should return a GameUpdateQuery', () => {
           const expectedDeckSpec: GameCardSpec[] = [
             {
               amount: deckCardSpec.amount - 15,
@@ -75,13 +223,39 @@ describe(GameService.name, () => {
             },
           ];
 
-          const expectedGameInitialDraws: GameInitialDraws = {
+          const expectedGameUpdateQueryProperties: Partial<GameUpdateQuery> = {
+            active: true,
             currentCard: deckCardSpec.card,
-            playersCards: expectedCards,
-            remainingDeck: expectedDeckSpec,
+            currentColor: expect.any(String) as unknown as CardColor,
+            currentDirection: GameDirection.antiClockwise,
+            currentPlayingSlotIndex: 0,
+            currentTurnCardsPlayed: false,
+            deck: expectedDeckSpec,
+            drawCount: 0,
+            gameFindQuery: {
+              id: gameFixture.id,
+            },
+            gameSlotUpdateQueries: [
+              {
+                cards: new Array<Card>(7).fill(deckCardSpec.card),
+                gameSlotFindQuery: {
+                  gameId: gameFixture.id,
+                  position: 0,
+                },
+              },
+              {
+                cards: new Array<Card>(7).fill(deckCardSpec.card),
+                gameSlotFindQuery: {
+                  gameId: gameFixture.id,
+                  position: 1,
+                },
+              },
+            ],
           };
 
-          expect(result).toStrictEqual(expectedGameInitialDraws);
+          expect(result).toStrictEqual(
+            expect.objectContaining(expectedGameUpdateQueryProperties),
+          );
         });
       });
     });
@@ -99,7 +273,7 @@ describe(GameService.name, () => {
 
         beforeAll(() => {
           try {
-            gameService.getInitialCardsDraw(gameFixture);
+            gameService.buildStartGameUpdateQuery(gameFixture);
           } catch (error) {
             result = error;
           }
@@ -115,92 +289,6 @@ describe(GameService.name, () => {
           expect(result).toStrictEqual(
             expect.objectContaining(expectedErrorProperties),
           );
-        });
-      });
-    });
-  });
-
-  describe('.getInitialDirection', () => {
-    describe('when called', () => {
-      let result: unknown;
-
-      beforeAll(() => {
-        result = gameService.getInitialDirection();
-      });
-
-      it('should return a GameDirection', () => {
-        expect(result).toBe(GameDirection.antiClockwise);
-      });
-    });
-  });
-
-  describe('.getInitialDrawCount', () => {
-    describe('when called', () => {
-      let result: unknown;
-
-      beforeAll(() => {
-        result = gameService.getInitialDrawCount();
-      });
-
-      it('should return a number', () => {
-        expect(result).toBe(0);
-      });
-    });
-  });
-
-  describe('.getInitialPlayingSlotIndex', () => {
-    describe('when called', () => {
-      let result: unknown;
-
-      beforeAll(() => {
-        result = gameService.getInitialPlayingSlotIndex();
-      });
-
-      it('should return a number', () => {
-        expect(result).toBe(0);
-      });
-    });
-  });
-
-  describe('.getNextTurnPlayerIndex', () => {
-    describe('having an active game with one player and current direction anticlockwise', () => {
-      let gameFixture: ActiveGame;
-
-      beforeAll(() => {
-        gameFixture =
-          ActiveGameFixtures.withSlotsOneAndCurrentDirectionAntiClockwise;
-      });
-
-      describe('when called', () => {
-        let result: unknown;
-
-        beforeAll(() => {
-          result = gameService.getNextTurnPlayerIndex(gameFixture);
-        });
-
-        it('should return the only player index', () => {
-          expect(result).toBe(0);
-        });
-      });
-    });
-
-    describe('having an active game with one player and current direction clockwise', () => {
-      let gameFixture: ActiveGame;
-
-      beforeAll(() => {
-        gameFixture =
-          ActiveGameFixtures.withSlotsOneAndCurrentDirectionClockwise;
-      });
-
-      describe('when called', () => {
-        let result: unknown;
-
-        beforeAll(() => {
-          result = gameService.getNextTurnPlayerIndex(gameFixture);
-        });
-
-        it('should return the only player index', () => {
-          expect(result).toBe(0);
         });
       });
     });


### PR DESCRIPTION
### Changed
- Exposed `PlayerCanPassTurnSpec`.
- Updated `GameManagementInputPort` with `updateOne`.
- Updated `GameService` with `buildPassTurnGameUpdateQuery` and `buildStartGameUpdateQuery`.