### PR TITLE
Update game find flows to rely on query builder api

### DIFF
--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/foundation/db/adapter/typeorm/converters/BaseFindQueryToFindQueryTypeOrmConverter.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/foundation/db/adapter/typeorm/converters/BaseFindQueryToFindQueryTypeOrmConverter.ts
@@ -1,0 +1,25 @@
+import {
+  InstanceChecker,
+  ObjectLiteral,
+  QueryBuilder,
+  WhereExpressionBuilder,
+} from 'typeorm';
+
+export abstract class BaseFindQueryToFindQueryTypeOrmConverter {
+  protected _getEntityPrefix(
+    queryBuilder: QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    entityType: Function,
+  ): string {
+    let gamePropertiesPrefix: string;
+
+    if (InstanceChecker.isSelectQueryBuilder(queryBuilder)) {
+      gamePropertiesPrefix = `${entityType.name}.`;
+    } else {
+      // No prefix should be used due to https://github.com/typeorm/typeorm/issues/1798
+      gamePropertiesPrefix = '';
+    }
+
+    return gamePropertiesPrefix;
+  }
+}

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameFindQueryToGameFindQueryTypeOrmConverter.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameFindQueryToGameFindQueryTypeOrmConverter.spec.ts
@@ -1,8 +1,37 @@
-import { beforeAll, describe, expect, it } from '@jest/globals';
+import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('typeorm', () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+  const originalTypeOrmModule: any = jest.requireActual('typeorm');
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const originalInstanceChecker: typeof InstanceChecker =
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    originalTypeOrmModule.InstanceChecker;
+
+  const instanceCheckerMock: typeof InstanceChecker = {
+    ...originalInstanceChecker,
+    isSelectQueryBuilder: jest.fn() as unknown as (
+      obj: unknown,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) => obj is SelectQueryBuilder<any>,
+  } as typeof InstanceChecker;
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return {
+    ...originalTypeOrmModule,
+    InstanceChecker: instanceCheckerMock,
+  };
+});
 
 import { GameFindQuery } from '@cornie-js/backend-game-domain/games';
 import { GameFindQueryFixtures } from '@cornie-js/backend-game-domain/games/fixtures';
-import { FindManyOptions, FindOptionsWhere } from 'typeorm';
+import {
+  InstanceChecker,
+  QueryBuilder,
+  SelectQueryBuilder,
+  WhereExpressionBuilder,
+} from 'typeorm';
 
 import { GameDb } from '../models/GameDb';
 import { GameFindQueryToGameFindQueryTypeOrmConverter } from './GameFindQueryToGameFindQueryTypeOrmConverter';
@@ -16,6 +45,18 @@ describe(GameFindQueryToGameFindQueryTypeOrmConverter.name, () => {
   });
 
   describe('.convert', () => {
+    let queryBuilderFixture: jest.Mocked<
+      QueryBuilder<GameDb> & WhereExpressionBuilder
+    >;
+
+    beforeAll(() => {
+      queryBuilderFixture = {
+        andWhere: jest.fn().mockReturnThis(),
+      } as Partial<
+        jest.Mocked<QueryBuilder<GameDb> & WhereExpressionBuilder>
+      > as jest.Mocked<QueryBuilder<GameDb> & WhereExpressionBuilder>;
+    });
+
     describe('having a GameFindQuery with id', () => {
       let gameFindQueryFixture: GameFindQuery;
 
@@ -27,20 +68,28 @@ describe(GameFindQueryToGameFindQueryTypeOrmConverter.name, () => {
         let result: unknown;
 
         beforeAll(() => {
-          result =
-            gameFindQueryToGameFindQueryTypeOrmConverter.convert(
-              gameFindQueryFixture,
-            );
+          (
+            InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock
+          ).mockReturnValueOnce(true);
+
+          result = gameFindQueryToGameFindQueryTypeOrmConverter.convert(
+            gameFindQueryFixture,
+            queryBuilderFixture,
+          );
         });
 
-        it('should return a FindManyOptions<GameDb>', () => {
-          const expected: FindManyOptions<GameDb> = {
-            where: expect.objectContaining({
-              id: gameFindQueryFixture.id,
-            }) as FindOptionsWhere<GameDb>,
-          };
+        it('should call queryBuilder.andWhere()', () => {
+          expect(queryBuilderFixture.andWhere).toHaveBeenCalled();
+          expect(queryBuilderFixture.andWhere).toHaveBeenCalledWith(
+            `${GameDb.name}.id = :${GameDb.name}id`,
+            {
+              [`${GameDb.name}id`]: gameFindQueryFixture.id,
+            },
+          );
+        });
 
-          expect(result).toStrictEqual(expected);
+        it('should return a QueryBuilder', () => {
+          expect(result).toBe(queryBuilderFixture);
         });
       });
     });

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.spec.ts
@@ -1,8 +1,37 @@
-import { beforeAll, describe, expect, it } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('typeorm', () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+  const originalTypeOrmModule: any = jest.requireActual('typeorm');
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const originalInstanceChecker: typeof InstanceChecker =
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    originalTypeOrmModule.InstanceChecker;
+
+  const instanceCheckerMock: typeof InstanceChecker = {
+    ...originalInstanceChecker,
+    isSelectQueryBuilder: jest.fn() as unknown as (
+      obj: unknown,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) => obj is SelectQueryBuilder<any>,
+  } as typeof InstanceChecker;
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return {
+    ...originalTypeOrmModule,
+    InstanceChecker: instanceCheckerMock,
+  };
+});
 
 import { GameSlotFindQuery } from '@cornie-js/backend-game-domain/games';
 import { GameSlotFindQueryFixtures } from '@cornie-js/backend-game-domain/games/fixtures';
-import { FindManyOptions } from 'typeorm';
+import {
+  InstanceChecker,
+  QueryBuilder,
+  SelectQueryBuilder,
+  WhereExpressionBuilder,
+} from 'typeorm';
 
 import { GameSlotDb } from '../models/GameSlotDb';
 import { GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter } from './GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter';
@@ -16,6 +45,18 @@ describe(GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.name, () => {
   });
 
   describe('.convert', () => {
+    let queryBuilderMock: jest.Mocked<
+      QueryBuilder<GameSlotDb> & WhereExpressionBuilder
+    >;
+
+    beforeAll(() => {
+      queryBuilderMock = {
+        andWhere: jest.fn().mockReturnThis(),
+      } as Partial<
+        jest.Mocked<QueryBuilder<GameSlotDb> & WhereExpressionBuilder>
+      > as jest.Mocked<QueryBuilder<GameSlotDb> & WhereExpressionBuilder>;
+    });
+
     describe('having a GameSlotFindQuery with gameId', () => {
       let gameSlotFindQueryFixture: GameSlotFindQuery;
 
@@ -27,21 +68,32 @@ describe(GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.name, () => {
         let result: unknown;
 
         beforeAll(() => {
+          (
+            InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock
+          ).mockReturnValueOnce(true);
+
           result = gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.convert(
             gameSlotFindQueryFixture,
+            queryBuilderMock,
           );
         });
 
-        it('should return a FindManyOptions<GameSlotDb>', () => {
-          const expected: FindManyOptions<GameSlotDb> = {
-            where: {
-              game: {
-                id: gameSlotFindQueryFixture.gameId as string,
-              },
-            },
-          };
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
 
-          expect(result).toStrictEqual(expected);
+        it('should call queryBuilder.andWhere()', () => {
+          expect(queryBuilderMock.andWhere).toHaveBeenCalled();
+          expect(queryBuilderMock.andWhere).toHaveBeenCalledWith(
+            `${GameSlotDb.name}.game = :${GameSlotDb.name}gameId`,
+            {
+              [`${GameSlotDb.name}gameId`]: gameSlotFindQueryFixture.gameId,
+            },
+          );
+        });
+
+        it('should return a QueryBuilder', () => {
+          expect(result).toBe(queryBuilderMock);
         });
       });
     });
@@ -57,19 +109,32 @@ describe(GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.name, () => {
         let result: unknown;
 
         beforeAll(() => {
+          (
+            InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock
+          ).mockReturnValueOnce(true);
+
           result = gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.convert(
             gameSlotFindQueryFixture,
+            queryBuilderMock,
           );
         });
 
-        it('should return a FindManyOptions<GameSlotDb>', () => {
-          const expected: FindManyOptions<GameSlotDb> = {
-            where: {
-              position: gameSlotFindQueryFixture.position as number,
-            },
-          };
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
 
-          expect(result).toStrictEqual(expected);
+        it('should call queryBuilder.andWhere()', () => {
+          expect(queryBuilderMock.andWhere).toHaveBeenCalled();
+          expect(queryBuilderMock.andWhere).toHaveBeenCalledWith(
+            `${GameSlotDb.name}.position = :${GameSlotDb.name}position`,
+            {
+              [`${GameSlotDb.name}position`]: gameSlotFindQueryFixture.position,
+            },
+          );
+        });
+
+        it('should return a QueryBuilder', () => {
+          expect(result).toBe(queryBuilderMock);
         });
       });
     });
@@ -85,19 +150,32 @@ describe(GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.name, () => {
         let result: unknown;
 
         beforeAll(() => {
+          (
+            InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock
+          ).mockReturnValueOnce(true);
+
           result = gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.convert(
             gameSlotFindQueryFixture,
+            queryBuilderMock,
           );
         });
 
-        it('should return a FindManyOptions<GameSlotDb>', () => {
-          const expected: FindManyOptions<GameSlotDb> = {
-            where: {
-              userId: gameSlotFindQueryFixture.userId as string,
-            },
-          };
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
 
-          expect(result).toStrictEqual(expected);
+        it('should call queryBuilder.andWhere()', () => {
+          expect(queryBuilderMock.andWhere).toHaveBeenCalled();
+          expect(queryBuilderMock.andWhere).toHaveBeenCalledWith(
+            `${GameSlotDb.name}.userId = :${GameSlotDb.name}userId`,
+            {
+              [`${GameSlotDb.name}userId`]: gameSlotFindQueryFixture.userId,
+            },
+          );
+        });
+
+        it('should return a QueryBuilder', () => {
+          expect(result).toBe(queryBuilderMock);
         });
       });
     });

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.ts
@@ -1,38 +1,57 @@
-import { Converter, Writable } from '@cornie-js/backend-common';
+import { Converter } from '@cornie-js/backend-common';
 import { GameSlotFindQuery } from '@cornie-js/backend-game-domain/games';
 import { Injectable } from '@nestjs/common';
-import { FindManyOptions, FindOptionsWhere } from 'typeorm';
+import { QueryBuilder, WhereExpressionBuilder } from 'typeorm';
 
+import { BaseFindQueryToFindQueryTypeOrmConverter } from '../../../../foundation/db/adapter/typeorm/converters/BaseFindQueryToFindQueryTypeOrmConverter';
 import { GameSlotDb } from '../models/GameSlotDb';
 
 @Injectable()
 export class GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter
-  implements Converter<GameSlotFindQuery, FindManyOptions<GameSlotDb>>
+  extends BaseFindQueryToFindQueryTypeOrmConverter
+  implements
+    Converter<
+      GameSlotFindQuery,
+      QueryBuilder<GameSlotDb> & WhereExpressionBuilder,
+      QueryBuilder<GameSlotDb> & WhereExpressionBuilder
+    >
 {
   public convert(
     gameSlotFindQuery: GameSlotFindQuery,
-  ): FindManyOptions<GameSlotDb> {
-    const gameFindQueryTypeOrmWhere: Writable<FindOptionsWhere<GameSlotDb>> =
-      {};
-
-    const gameFindQueryTypeOrm: FindManyOptions<GameSlotDb> = {
-      where: gameFindQueryTypeOrmWhere,
-    };
+    queryBuilder: QueryBuilder<GameSlotDb> & WhereExpressionBuilder,
+  ): QueryBuilder<GameSlotDb> & WhereExpressionBuilder {
+    const gameSlotPropertiesPrefix: string = this._getEntityPrefix(
+      queryBuilder,
+      GameSlotDb,
+    );
 
     if (gameSlotFindQuery.gameId !== undefined) {
-      gameFindQueryTypeOrmWhere.game = {
-        id: gameSlotFindQuery.gameId,
-      };
+      queryBuilder = queryBuilder.andWhere(
+        `${gameSlotPropertiesPrefix}game = :${GameSlotDb.name}gameId`,
+        {
+          [`${GameSlotDb.name}gameId`]: gameSlotFindQuery.gameId,
+        },
+      );
     }
 
     if (gameSlotFindQuery.position !== undefined) {
-      gameFindQueryTypeOrmWhere.position = gameSlotFindQuery.position;
+      queryBuilder = queryBuilder.andWhere(
+        `${gameSlotPropertiesPrefix}position = :${GameSlotDb.name}position`,
+        {
+          [`${GameSlotDb.name}position`]: gameSlotFindQuery.position,
+        },
+      );
     }
 
     if (gameSlotFindQuery.userId !== undefined) {
-      gameFindQueryTypeOrmWhere.userId = gameSlotFindQuery.userId;
+      queryBuilder = queryBuilder.andWhere(
+        `${gameSlotPropertiesPrefix}userId = :${GameSlotDb.name}userId`,
+        {
+          [`${GameSlotDb.name}userId`]: gameSlotFindQuery.userId,
+        },
+      );
     }
 
-    return gameFindQueryTypeOrm;
+    return queryBuilder;
   }
 }

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter.spec.ts
@@ -6,14 +6,18 @@ import {
   GameSlotUpdateQuery,
 } from '@cornie-js/backend-game-domain/games';
 import { GameSlotUpdateQueryFixtures } from '@cornie-js/backend-game-domain/games/fixtures';
-import { FindManyOptions } from 'typeorm';
+import { QueryBuilder, WhereExpressionBuilder } from 'typeorm';
 
 import { GameSlotDb } from '../models/GameSlotDb';
 import { GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter } from './GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter';
 
 describe(GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter.name, () => {
   let gameSlotFindQueryToGameSlotFindQueryTypeOrmConverterMock: jest.Mocked<
-    Converter<GameSlotFindQuery, FindManyOptions<GameSlotDb>>
+    Converter<
+      GameSlotFindQuery,
+      QueryBuilder<GameSlotDb> & WhereExpressionBuilder,
+      QueryBuilder<GameSlotDb> & WhereExpressionBuilder
+    >
   >;
 
   let gameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter: GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter;
@@ -31,26 +35,25 @@ describe(GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter.name, () => {
 
   describe('.convert', () => {
     let gameSlotUpdateQueryFixture: GameSlotUpdateQuery;
+    let queryBuilderFixture: QueryBuilder<GameSlotDb> & WhereExpressionBuilder;
 
     beforeAll(() => {
       gameSlotUpdateQueryFixture = GameSlotUpdateQueryFixtures.any;
+      queryBuilderFixture = Symbol() as unknown as QueryBuilder<GameSlotDb> &
+        WhereExpressionBuilder;
     });
 
     describe('when called', () => {
-      let gameSlotFindQueryTypeOrmFixture: FindManyOptions<GameSlotDb>;
-
       let result: unknown;
 
       beforeAll(() => {
-        gameSlotFindQueryTypeOrmFixture =
-          Symbol() as unknown as FindManyOptions<GameSlotDb>;
-
         gameSlotFindQueryToGameSlotFindQueryTypeOrmConverterMock.convert.mockReturnValueOnce(
-          gameSlotFindQueryTypeOrmFixture,
+          queryBuilderFixture,
         );
 
         result = gameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter.convert(
           gameSlotUpdateQueryFixture,
+          queryBuilderFixture,
         );
       });
 
@@ -64,11 +67,14 @@ describe(GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter.name, () => {
         ).toHaveBeenCalledTimes(1);
         expect(
           gameSlotFindQueryToGameSlotFindQueryTypeOrmConverterMock.convert,
-        ).toHaveBeenCalledWith(gameSlotUpdateQueryFixture.gameSlotFindQuery);
+        ).toHaveBeenCalledWith(
+          gameSlotUpdateQueryFixture.gameSlotFindQuery,
+          queryBuilderFixture,
+        );
       });
 
-      it('should return a FindManyOptions<GameSLotDb>', () => {
-        expect(result).toBe(gameSlotFindQueryTypeOrmFixture);
+      it('should return a QueryBuilder', () => {
+        expect(result).toBe(queryBuilderFixture);
       });
     });
   });

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter.ts
@@ -4,25 +4,32 @@ import {
   GameSlotUpdateQuery,
 } from '@cornie-js/backend-game-domain/games';
 import { Inject, Injectable } from '@nestjs/common';
-import { FindManyOptions } from 'typeorm';
+import { QueryBuilder, WhereExpressionBuilder } from 'typeorm';
 
 import { GameSlotDb } from '../models/GameSlotDb';
 import { GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter } from './GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter';
 
 @Injectable()
 export class GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter
-  implements Converter<GameSlotUpdateQuery, FindManyOptions<GameSlotDb>>
+  implements
+    Converter<
+      GameSlotUpdateQuery,
+      QueryBuilder<GameSlotDb> & WhereExpressionBuilder,
+      QueryBuilder<GameSlotDb> & WhereExpressionBuilder
+    >
 {
   readonly #gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter: Converter<
     GameSlotFindQuery,
-    FindManyOptions<GameSlotDb>
+    QueryBuilder<GameSlotDb> & WhereExpressionBuilder,
+    QueryBuilder<GameSlotDb> & WhereExpressionBuilder
   >;
 
   constructor(
     @Inject(GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter)
     gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter: Converter<
       GameSlotFindQuery,
-      FindManyOptions<GameSlotDb>
+      QueryBuilder<GameSlotDb> & WhereExpressionBuilder,
+      QueryBuilder<GameSlotDb> & WhereExpressionBuilder
     >,
   ) {
     this.#gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter =
@@ -31,9 +38,11 @@ export class GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter
 
   public convert(
     gameSlotUpdateQuery: GameSlotUpdateQuery,
-  ): FindManyOptions<GameSlotDb> {
+    queryBuilder: QueryBuilder<GameSlotDb> & WhereExpressionBuilder,
+  ): QueryBuilder<GameSlotDb> & WhereExpressionBuilder {
     return this.#gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.convert(
       gameSlotUpdateQuery.gameSlotFindQuery,
+      queryBuilder,
     );
   }
 }

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameUpdateQueryToGameFindQueryTypeOrmConverter.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameUpdateQueryToGameFindQueryTypeOrmConverter.spec.ts
@@ -6,14 +6,18 @@ import {
   GameUpdateQuery,
 } from '@cornie-js/backend-game-domain/games';
 import { GameUpdateQueryFixtures } from '@cornie-js/backend-game-domain/games/fixtures';
-import { FindManyOptions } from 'typeorm';
+import { QueryBuilder, WhereExpressionBuilder } from 'typeorm';
 
 import { GameDb } from '../models/GameDb';
 import { GameUpdateQueryToGameFindQueryTypeOrmConverter } from './GameUpdateQueryToGameFindQueryTypeOrmConverter';
 
 describe(GameUpdateQueryToGameFindQueryTypeOrmConverter.name, () => {
   let gameFindQueryToGameFindQueryTypeOrmConverterMock: jest.Mocked<
-    Converter<GameFindQuery, FindManyOptions<GameDb>>
+    Converter<
+      GameFindQuery,
+      QueryBuilder<GameDb> & WhereExpressionBuilder,
+      QueryBuilder<GameDb> & WhereExpressionBuilder
+    >
   >;
 
   let gameUpdateQueryToGameFindQueryTypeOrmConverter: GameUpdateQueryToGameFindQueryTypeOrmConverter;
@@ -31,25 +35,25 @@ describe(GameUpdateQueryToGameFindQueryTypeOrmConverter.name, () => {
 
   describe('.convert', () => {
     let gameUpdateQueryFixture: GameUpdateQuery;
+    let queryBuilderFixture: QueryBuilder<GameDb> & WhereExpressionBuilder;
 
     beforeAll(() => {
       gameUpdateQueryFixture = GameUpdateQueryFixtures.any;
+      queryBuilderFixture = Symbol() as unknown as QueryBuilder<GameDb> &
+        WhereExpressionBuilder;
     });
 
     describe('when called', () => {
-      let gameFindQueryTypeOrmFixture: FindManyOptions<GameDb>;
-
       let result: unknown;
 
       beforeAll(() => {
-        gameFindQueryTypeOrmFixture = {};
-
         gameFindQueryToGameFindQueryTypeOrmConverterMock.convert.mockReturnValueOnce(
-          gameFindQueryTypeOrmFixture,
+          queryBuilderFixture,
         );
 
         result = gameUpdateQueryToGameFindQueryTypeOrmConverter.convert(
           gameUpdateQueryFixture,
+          queryBuilderFixture,
         );
       });
 
@@ -63,11 +67,14 @@ describe(GameUpdateQueryToGameFindQueryTypeOrmConverter.name, () => {
         ).toHaveBeenCalledTimes(1);
         expect(
           gameFindQueryToGameFindQueryTypeOrmConverterMock.convert,
-        ).toHaveBeenCalledWith(gameUpdateQueryFixture.gameFindQuery);
+        ).toHaveBeenCalledWith(
+          gameUpdateQueryFixture.gameFindQuery,
+          queryBuilderFixture,
+        );
       });
 
-      it('should return FindManyOptions<GameDb>', () => {
-        expect(result).toBe(gameFindQueryTypeOrmFixture);
+      it('should return a QueryBuilder', () => {
+        expect(result).toBe(queryBuilderFixture);
       });
     });
   });

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameUpdateQueryToGameFindQueryTypeOrmConverter.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameUpdateQueryToGameFindQueryTypeOrmConverter.ts
@@ -4,34 +4,45 @@ import {
   GameUpdateQuery,
 } from '@cornie-js/backend-game-domain/games';
 import { Inject, Injectable } from '@nestjs/common';
-import { FindManyOptions } from 'typeorm';
+import { QueryBuilder, WhereExpressionBuilder } from 'typeorm';
 
 import { GameDb } from '../models/GameDb';
 import { GameFindQueryToGameFindQueryTypeOrmConverter } from './GameFindQueryToGameFindQueryTypeOrmConverter';
 
 @Injectable()
 export class GameUpdateQueryToGameFindQueryTypeOrmConverter
-  implements Converter<GameUpdateQuery, FindManyOptions<GameDb>>
+  implements
+    Converter<
+      GameUpdateQuery,
+      QueryBuilder<GameDb> & WhereExpressionBuilder,
+      QueryBuilder<GameDb> & WhereExpressionBuilder
+    >
 {
   readonly #gameFindQueryToGameFindQueryTypeOrmConverter: Converter<
     GameFindQuery,
-    FindManyOptions<GameDb>
+    QueryBuilder<GameDb> & WhereExpressionBuilder,
+    QueryBuilder<GameDb> & WhereExpressionBuilder
   >;
 
   constructor(
     @Inject(GameFindQueryToGameFindQueryTypeOrmConverter)
     gameFindQueryToGameFindQueryTypeOrmConverter: Converter<
       GameFindQuery,
-      FindManyOptions<GameDb>
+      QueryBuilder<GameDb> & WhereExpressionBuilder,
+      QueryBuilder<GameDb> & WhereExpressionBuilder
     >,
   ) {
     this.#gameFindQueryToGameFindQueryTypeOrmConverter =
       gameFindQueryToGameFindQueryTypeOrmConverter;
   }
 
-  public convert(gameUpdateQuery: GameUpdateQuery): FindManyOptions<GameDb> {
+  public convert(
+    gameUpdateQuery: GameUpdateQuery,
+    queryBuilder: QueryBuilder<GameDb> & WhereExpressionBuilder,
+  ): QueryBuilder<GameDb> & WhereExpressionBuilder {
     return this.#gameFindQueryToGameFindQueryTypeOrmConverter.convert(
       gameUpdateQuery.gameFindQuery,
+      queryBuilder,
     );
   }
 }

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/services/FindGameTypeOrmService.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/services/FindGameTypeOrmService.ts
@@ -3,7 +3,7 @@ import { FindTypeOrmService } from '@cornie-js/backend-db';
 import { Game, GameFindQuery } from '@cornie-js/backend-game-domain/games';
 import { Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindManyOptions, Repository } from 'typeorm';
+import { QueryBuilder, Repository, WhereExpressionBuilder } from 'typeorm';
 
 import { GameDbToGameConverter } from '../converters/GameDbToGameConverter';
 import { GameFindQueryToGameFindQueryTypeOrmConverter } from '../converters/GameFindQueryToGameFindQueryTypeOrmConverter';
@@ -23,7 +23,8 @@ export class FindGameTypeOrmService extends FindTypeOrmService<
     @Inject(GameFindQueryToGameFindQueryTypeOrmConverter)
     gameFindQueryToGameFindQueryTypeOrmConverter: Converter<
       GameFindQuery,
-      FindManyOptions<GameDb>
+      QueryBuilder<GameDb> & WhereExpressionBuilder,
+      QueryBuilder<GameDb> & WhereExpressionBuilder
     >,
   ) {
     super(

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/services/UpdateGameSlotTypeOrmService.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/services/UpdateGameSlotTypeOrmService.ts
@@ -3,7 +3,7 @@ import { UpdateTypeOrmService } from '@cornie-js/backend-db';
 import { GameSlotUpdateQuery } from '@cornie-js/backend-game-domain/games';
 import { Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindManyOptions, Repository } from 'typeorm';
+import { QueryBuilder, Repository, WhereExpressionBuilder } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity.js';
 
 import { GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter } from '../converters/GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter';
@@ -21,7 +21,8 @@ export class UpdateGameSlotTypeOrmService extends UpdateTypeOrmService<
     @Inject(GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter)
     gameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter: Converter<
       GameSlotUpdateQuery,
-      FindManyOptions<GameSlotDb>
+      QueryBuilder<GameSlotDb> & WhereExpressionBuilder,
+      QueryBuilder<GameSlotDb> & WhereExpressionBuilder
     >,
     @Inject(GameSlotUpdateQueryToGameSlotSetQueryTypeOrmConverter)
     gameSlotUpdateQueryToGameSlotSetQueryTypeOrmConverter: Converter<

--- a/packages/backend/libraries/backend-db/src/persistence/services/typeorm/UpdateTypeOrmService.ts
+++ b/packages/backend/libraries/backend-db/src/persistence/services/typeorm/UpdateTypeOrmService.ts
@@ -41,6 +41,11 @@ export class UpdateTypeOrmService<TModelDb extends ObjectLiteral, TQuery> {
 
   public async update(query: TQuery): Promise<void> {
     const updateQueryBuilder: UpdateQueryBuilder<TModelDb> = this.#repository
+      /*
+       * https://github.com/typeorm/typeorm/issues/1798 prevents us from using instead:
+       *
+       * .createQueryBuilder(this.#repository.metadata.name)
+       */
       .createQueryBuilder()
       .update();
     const findQueryTypeOrmOrQueryBuilder:


### PR DESCRIPTION
### Added
- Added `BaseFindQueryToFindQueryTypeOrmConverter`.

### Changed
- Updated game db converters to rely on query builder API.