### PR TITLE
Update GameFindQuery with gameSlotFindQuery property

### DIFF
--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameFindQueryToGameFindQueryTypeOrmConverter.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameFindQueryToGameFindQueryTypeOrmConverter.spec.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 jest.mock('typeorm', () => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
@@ -24,10 +24,15 @@ jest.mock('typeorm', () => {
   };
 });
 
-import { GameFindQuery } from '@cornie-js/backend-game-domain/games';
+import { Converter } from '@cornie-js/backend-common';
+import {
+  GameFindQuery,
+  GameSlotFindQuery,
+} from '@cornie-js/backend-game-domain/games';
 import { GameFindQueryFixtures } from '@cornie-js/backend-game-domain/games/fixtures';
 import {
   InstanceChecker,
+  ObjectLiteral,
   QueryBuilder,
   SelectQueryBuilder,
   WhereExpressionBuilder,
@@ -37,24 +42,38 @@ import { GameDb } from '../models/GameDb';
 import { GameFindQueryToGameFindQueryTypeOrmConverter } from './GameFindQueryToGameFindQueryTypeOrmConverter';
 
 describe(GameFindQueryToGameFindQueryTypeOrmConverter.name, () => {
+  let gameSlotFindQueryToGameSlotFindQueryTypeOrmConverterMock: jest.Mocked<
+    Converter<
+      GameSlotFindQuery,
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
+    >
+  >;
   let gameFindQueryToGameFindQueryTypeOrmConverter: GameFindQueryToGameFindQueryTypeOrmConverter;
 
   beforeAll(() => {
+    gameSlotFindQueryToGameSlotFindQueryTypeOrmConverterMock = {
+      convert: jest.fn(),
+    };
+
     gameFindQueryToGameFindQueryTypeOrmConverter =
-      new GameFindQueryToGameFindQueryTypeOrmConverter();
+      new GameFindQueryToGameFindQueryTypeOrmConverter(
+        gameSlotFindQueryToGameSlotFindQueryTypeOrmConverterMock,
+      );
   });
 
   describe('.convert', () => {
     let queryBuilderFixture: jest.Mocked<
-      QueryBuilder<GameDb> & WhereExpressionBuilder
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
     >;
 
     beforeAll(() => {
       queryBuilderFixture = {
         andWhere: jest.fn().mockReturnThis(),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
       } as Partial<
-        jest.Mocked<QueryBuilder<GameDb> & WhereExpressionBuilder>
-      > as jest.Mocked<QueryBuilder<GameDb> & WhereExpressionBuilder>;
+        jest.Mocked<QueryBuilder<ObjectLiteral> & WhereExpressionBuilder>
+      > as jest.Mocked<QueryBuilder<ObjectLiteral> & WhereExpressionBuilder>;
     });
 
     describe('having a GameFindQuery with id', () => {
@@ -68,14 +87,18 @@ describe(GameFindQueryToGameFindQueryTypeOrmConverter.name, () => {
         let result: unknown;
 
         beforeAll(() => {
-          (
-            InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock
-          ).mockReturnValueOnce(true);
+          (InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock)
+            .mockReturnValueOnce(true)
+            .mockReturnValueOnce(true);
 
           result = gameFindQueryToGameFindQueryTypeOrmConverter.convert(
             gameFindQueryFixture,
             queryBuilderFixture,
           );
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
         });
 
         it('should call queryBuilder.andWhere()', () => {
@@ -85,6 +108,53 @@ describe(GameFindQueryToGameFindQueryTypeOrmConverter.name, () => {
             {
               [`${GameDb.name}id`]: gameFindQueryFixture.id,
             },
+          );
+        });
+
+        it('should return a QueryBuilder', () => {
+          expect(result).toBe(queryBuilderFixture);
+        });
+      });
+    });
+
+    describe('having a GameFindQuery with GameSlotFindQuery', () => {
+      let gameFindQueryFixture: GameFindQuery;
+
+      beforeAll(() => {
+        gameFindQueryFixture = GameFindQueryFixtures.withGameSlotFindQuery;
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          (InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock)
+            .mockReturnValueOnce(true)
+            .mockReturnValueOnce(true);
+
+          gameSlotFindQueryToGameSlotFindQueryTypeOrmConverterMock.convert.mockReturnValueOnce(
+            queryBuilderFixture,
+          );
+
+          result = gameFindQueryToGameFindQueryTypeOrmConverter.convert(
+            gameFindQueryFixture,
+            queryBuilderFixture,
+          );
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.convert()', () => {
+          expect(
+            gameSlotFindQueryToGameSlotFindQueryTypeOrmConverterMock.convert,
+          ).toHaveBeenCalled();
+          expect(
+            gameSlotFindQueryToGameSlotFindQueryTypeOrmConverterMock.convert,
+          ).toHaveBeenCalledWith(
+            gameFindQueryFixture.gameSlotFindQuery,
+            queryBuilderFixture,
           );
         });
 

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameFindQueryToGameFindQueryTypeOrmConverter.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameFindQueryToGameFindQueryTypeOrmConverter.ts
@@ -1,7 +1,15 @@
 import { Converter } from '@cornie-js/backend-common';
-import { GameFindQuery } from '@cornie-js/backend-game-domain/games';
+import {
+  GameFindQuery,
+  GameSlotFindQuery,
+} from '@cornie-js/backend-game-domain/games';
 import { Injectable } from '@nestjs/common';
-import { InstanceChecker, QueryBuilder, WhereExpressionBuilder } from 'typeorm';
+import {
+  InstanceChecker,
+  ObjectLiteral,
+  QueryBuilder,
+  WhereExpressionBuilder,
+} from 'typeorm';
 
 import { BaseFindQueryToFindQueryTypeOrmConverter } from '../../../../foundation/db/adapter/typeorm/converters/BaseFindQueryToFindQueryTypeOrmConverter';
 import { GameDb } from '../models/GameDb';
@@ -13,14 +21,33 @@ export class GameFindQueryToGameFindQueryTypeOrmConverter
   implements
     Converter<
       GameFindQuery,
-      QueryBuilder<GameDb> & WhereExpressionBuilder,
-      QueryBuilder<GameDb> & WhereExpressionBuilder
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
     >
 {
+  readonly #gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter: Converter<
+    GameSlotFindQuery,
+    QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+    QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
+  >;
+
+  constructor(
+    gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter: Converter<
+      GameSlotFindQuery,
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
+    >,
+  ) {
+    super();
+
+    this.#gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter =
+      gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter;
+  }
+
   public convert(
     gameFindQuery: GameFindQuery,
-    queryBuilder: QueryBuilder<GameDb> & WhereExpressionBuilder,
-  ): QueryBuilder<GameDb> & WhereExpressionBuilder {
+    queryBuilder: QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+  ): QueryBuilder<ObjectLiteral> & WhereExpressionBuilder {
     const gamePropertiesPrefix: string = this._getEntityPrefix(
       queryBuilder,
       GameDb,
@@ -31,6 +58,14 @@ export class GameFindQueryToGameFindQueryTypeOrmConverter
         `${gamePropertiesPrefix}gameSlotsDb`,
         GameSlotDb.name,
       );
+
+      if (gameFindQuery.gameSlotFindQuery !== undefined) {
+        queryBuilder =
+          this.#gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.convert(
+            gameFindQuery.gameSlotFindQuery,
+            queryBuilder,
+          );
+      }
     }
 
     if (gameFindQuery.id !== undefined) {

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.spec.ts
@@ -28,6 +28,7 @@ import { GameSlotFindQuery } from '@cornie-js/backend-game-domain/games';
 import { GameSlotFindQueryFixtures } from '@cornie-js/backend-game-domain/games/fixtures';
 import {
   InstanceChecker,
+  ObjectLiteral,
   QueryBuilder,
   SelectQueryBuilder,
   WhereExpressionBuilder,
@@ -46,15 +47,15 @@ describe(GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.name, () => {
 
   describe('.convert', () => {
     let queryBuilderMock: jest.Mocked<
-      QueryBuilder<GameSlotDb> & WhereExpressionBuilder
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
     >;
 
     beforeAll(() => {
       queryBuilderMock = {
         andWhere: jest.fn().mockReturnThis(),
       } as Partial<
-        jest.Mocked<QueryBuilder<GameSlotDb> & WhereExpressionBuilder>
-      > as jest.Mocked<QueryBuilder<GameSlotDb> & WhereExpressionBuilder>;
+        jest.Mocked<QueryBuilder<ObjectLiteral> & WhereExpressionBuilder>
+      > as jest.Mocked<QueryBuilder<ObjectLiteral> & WhereExpressionBuilder>;
     });
 
     describe('having a GameSlotFindQuery with gameId', () => {

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.ts
@@ -1,7 +1,7 @@
 import { Converter } from '@cornie-js/backend-common';
 import { GameSlotFindQuery } from '@cornie-js/backend-game-domain/games';
 import { Injectable } from '@nestjs/common';
-import { QueryBuilder, WhereExpressionBuilder } from 'typeorm';
+import { ObjectLiteral, QueryBuilder, WhereExpressionBuilder } from 'typeorm';
 
 import { BaseFindQueryToFindQueryTypeOrmConverter } from '../../../../foundation/db/adapter/typeorm/converters/BaseFindQueryToFindQueryTypeOrmConverter';
 import { GameSlotDb } from '../models/GameSlotDb';
@@ -12,14 +12,14 @@ export class GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter
   implements
     Converter<
       GameSlotFindQuery,
-      QueryBuilder<GameSlotDb> & WhereExpressionBuilder,
-      QueryBuilder<GameSlotDb> & WhereExpressionBuilder
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
     >
 {
   public convert(
     gameSlotFindQuery: GameSlotFindQuery,
-    queryBuilder: QueryBuilder<GameSlotDb> & WhereExpressionBuilder,
-  ): QueryBuilder<GameSlotDb> & WhereExpressionBuilder {
+    queryBuilder: QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+  ): QueryBuilder<ObjectLiteral> & WhereExpressionBuilder {
     const gameSlotPropertiesPrefix: string = this._getEntityPrefix(
       queryBuilder,
       GameSlotDb,

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter.spec.ts
@@ -6,17 +6,16 @@ import {
   GameSlotUpdateQuery,
 } from '@cornie-js/backend-game-domain/games';
 import { GameSlotUpdateQueryFixtures } from '@cornie-js/backend-game-domain/games/fixtures';
-import { QueryBuilder, WhereExpressionBuilder } from 'typeorm';
+import { ObjectLiteral, QueryBuilder, WhereExpressionBuilder } from 'typeorm';
 
-import { GameSlotDb } from '../models/GameSlotDb';
 import { GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter } from './GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter';
 
 describe(GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter.name, () => {
   let gameSlotFindQueryToGameSlotFindQueryTypeOrmConverterMock: jest.Mocked<
     Converter<
       GameSlotFindQuery,
-      QueryBuilder<GameSlotDb> & WhereExpressionBuilder,
-      QueryBuilder<GameSlotDb> & WhereExpressionBuilder
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
     >
   >;
 
@@ -35,11 +34,12 @@ describe(GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter.name, () => {
 
   describe('.convert', () => {
     let gameSlotUpdateQueryFixture: GameSlotUpdateQuery;
-    let queryBuilderFixture: QueryBuilder<GameSlotDb> & WhereExpressionBuilder;
+    let queryBuilderFixture: QueryBuilder<ObjectLiteral> &
+      WhereExpressionBuilder;
 
     beforeAll(() => {
       gameSlotUpdateQueryFixture = GameSlotUpdateQueryFixtures.any;
-      queryBuilderFixture = Symbol() as unknown as QueryBuilder<GameSlotDb> &
+      queryBuilderFixture = Symbol() as unknown as QueryBuilder<ObjectLiteral> &
         WhereExpressionBuilder;
     });
 

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter.ts
@@ -4,9 +4,8 @@ import {
   GameSlotUpdateQuery,
 } from '@cornie-js/backend-game-domain/games';
 import { Inject, Injectable } from '@nestjs/common';
-import { QueryBuilder, WhereExpressionBuilder } from 'typeorm';
+import { ObjectLiteral, QueryBuilder, WhereExpressionBuilder } from 'typeorm';
 
-import { GameSlotDb } from '../models/GameSlotDb';
 import { GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter } from './GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter';
 
 @Injectable()
@@ -14,22 +13,22 @@ export class GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter
   implements
     Converter<
       GameSlotUpdateQuery,
-      QueryBuilder<GameSlotDb> & WhereExpressionBuilder,
-      QueryBuilder<GameSlotDb> & WhereExpressionBuilder
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
     >
 {
   readonly #gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter: Converter<
     GameSlotFindQuery,
-    QueryBuilder<GameSlotDb> & WhereExpressionBuilder,
-    QueryBuilder<GameSlotDb> & WhereExpressionBuilder
+    QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+    QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
   >;
 
   constructor(
     @Inject(GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter)
     gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter: Converter<
       GameSlotFindQuery,
-      QueryBuilder<GameSlotDb> & WhereExpressionBuilder,
-      QueryBuilder<GameSlotDb> & WhereExpressionBuilder
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
     >,
   ) {
     this.#gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter =
@@ -38,8 +37,8 @@ export class GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter
 
   public convert(
     gameSlotUpdateQuery: GameSlotUpdateQuery,
-    queryBuilder: QueryBuilder<GameSlotDb> & WhereExpressionBuilder,
-  ): QueryBuilder<GameSlotDb> & WhereExpressionBuilder {
+    queryBuilder: QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+  ): QueryBuilder<ObjectLiteral> & WhereExpressionBuilder {
     return this.#gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.convert(
       gameSlotUpdateQuery.gameSlotFindQuery,
       queryBuilder,

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameUpdateQueryToGameFindQueryTypeOrmConverter.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameUpdateQueryToGameFindQueryTypeOrmConverter.spec.ts
@@ -6,17 +6,16 @@ import {
   GameUpdateQuery,
 } from '@cornie-js/backend-game-domain/games';
 import { GameUpdateQueryFixtures } from '@cornie-js/backend-game-domain/games/fixtures';
-import { QueryBuilder, WhereExpressionBuilder } from 'typeorm';
+import { ObjectLiteral, QueryBuilder, WhereExpressionBuilder } from 'typeorm';
 
-import { GameDb } from '../models/GameDb';
 import { GameUpdateQueryToGameFindQueryTypeOrmConverter } from './GameUpdateQueryToGameFindQueryTypeOrmConverter';
 
 describe(GameUpdateQueryToGameFindQueryTypeOrmConverter.name, () => {
   let gameFindQueryToGameFindQueryTypeOrmConverterMock: jest.Mocked<
     Converter<
       GameFindQuery,
-      QueryBuilder<GameDb> & WhereExpressionBuilder,
-      QueryBuilder<GameDb> & WhereExpressionBuilder
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
     >
   >;
 
@@ -35,11 +34,12 @@ describe(GameUpdateQueryToGameFindQueryTypeOrmConverter.name, () => {
 
   describe('.convert', () => {
     let gameUpdateQueryFixture: GameUpdateQuery;
-    let queryBuilderFixture: QueryBuilder<GameDb> & WhereExpressionBuilder;
+    let queryBuilderFixture: QueryBuilder<ObjectLiteral> &
+      WhereExpressionBuilder;
 
     beforeAll(() => {
       gameUpdateQueryFixture = GameUpdateQueryFixtures.any;
-      queryBuilderFixture = Symbol() as unknown as QueryBuilder<GameDb> &
+      queryBuilderFixture = Symbol() as unknown as QueryBuilder<ObjectLiteral> &
         WhereExpressionBuilder;
     });
 

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameUpdateQueryToGameFindQueryTypeOrmConverter.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameUpdateQueryToGameFindQueryTypeOrmConverter.ts
@@ -4,9 +4,8 @@ import {
   GameUpdateQuery,
 } from '@cornie-js/backend-game-domain/games';
 import { Inject, Injectable } from '@nestjs/common';
-import { QueryBuilder, WhereExpressionBuilder } from 'typeorm';
+import { ObjectLiteral, QueryBuilder, WhereExpressionBuilder } from 'typeorm';
 
-import { GameDb } from '../models/GameDb';
 import { GameFindQueryToGameFindQueryTypeOrmConverter } from './GameFindQueryToGameFindQueryTypeOrmConverter';
 
 @Injectable()
@@ -14,22 +13,22 @@ export class GameUpdateQueryToGameFindQueryTypeOrmConverter
   implements
     Converter<
       GameUpdateQuery,
-      QueryBuilder<GameDb> & WhereExpressionBuilder,
-      QueryBuilder<GameDb> & WhereExpressionBuilder
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
     >
 {
   readonly #gameFindQueryToGameFindQueryTypeOrmConverter: Converter<
     GameFindQuery,
-    QueryBuilder<GameDb> & WhereExpressionBuilder,
-    QueryBuilder<GameDb> & WhereExpressionBuilder
+    QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+    QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
   >;
 
   constructor(
     @Inject(GameFindQueryToGameFindQueryTypeOrmConverter)
     gameFindQueryToGameFindQueryTypeOrmConverter: Converter<
       GameFindQuery,
-      QueryBuilder<GameDb> & WhereExpressionBuilder,
-      QueryBuilder<GameDb> & WhereExpressionBuilder
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
     >,
   ) {
     this.#gameFindQueryToGameFindQueryTypeOrmConverter =
@@ -38,8 +37,8 @@ export class GameUpdateQueryToGameFindQueryTypeOrmConverter
 
   public convert(
     gameUpdateQuery: GameUpdateQuery,
-    queryBuilder: QueryBuilder<GameDb> & WhereExpressionBuilder,
-  ): QueryBuilder<GameDb> & WhereExpressionBuilder {
+    queryBuilder: QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+  ): QueryBuilder<ObjectLiteral> & WhereExpressionBuilder {
     return this.#gameFindQueryToGameFindQueryTypeOrmConverter.convert(
       gameUpdateQuery.gameFindQuery,
       queryBuilder,

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/services/FindGameTypeOrmService.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/services/FindGameTypeOrmService.ts
@@ -3,7 +3,12 @@ import { FindTypeOrmService } from '@cornie-js/backend-db';
 import { Game, GameFindQuery } from '@cornie-js/backend-game-domain/games';
 import { Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { QueryBuilder, Repository, WhereExpressionBuilder } from 'typeorm';
+import {
+  ObjectLiteral,
+  QueryBuilder,
+  Repository,
+  WhereExpressionBuilder,
+} from 'typeorm';
 
 import { GameDbToGameConverter } from '../converters/GameDbToGameConverter';
 import { GameFindQueryToGameFindQueryTypeOrmConverter } from '../converters/GameFindQueryToGameFindQueryTypeOrmConverter';
@@ -23,8 +28,8 @@ export class FindGameTypeOrmService extends FindTypeOrmService<
     @Inject(GameFindQueryToGameFindQueryTypeOrmConverter)
     gameFindQueryToGameFindQueryTypeOrmConverter: Converter<
       GameFindQuery,
-      QueryBuilder<GameDb> & WhereExpressionBuilder,
-      QueryBuilder<GameDb> & WhereExpressionBuilder
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
     >,
   ) {
     super(

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/services/UpdateGameSlotTypeOrmService.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/services/UpdateGameSlotTypeOrmService.ts
@@ -3,7 +3,12 @@ import { UpdateTypeOrmService } from '@cornie-js/backend-db';
 import { GameSlotUpdateQuery } from '@cornie-js/backend-game-domain/games';
 import { Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { QueryBuilder, Repository, WhereExpressionBuilder } from 'typeorm';
+import {
+  ObjectLiteral,
+  QueryBuilder,
+  Repository,
+  WhereExpressionBuilder,
+} from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity.js';
 
 import { GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter } from '../converters/GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter';
@@ -21,8 +26,8 @@ export class UpdateGameSlotTypeOrmService extends UpdateTypeOrmService<
     @Inject(GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter)
     gameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter: Converter<
       GameSlotUpdateQuery,
-      QueryBuilder<GameSlotDb> & WhereExpressionBuilder,
-      QueryBuilder<GameSlotDb> & WhereExpressionBuilder
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
     >,
     @Inject(GameSlotUpdateQueryToGameSlotSetQueryTypeOrmConverter)
     gameSlotUpdateQueryToGameSlotSetQueryTypeOrmConverter: Converter<

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameFindQueryFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameFindQueryFixtures.ts
@@ -1,4 +1,5 @@
 import { GameFindQuery } from '../query/GameFindQuery';
+import { GameSlotFindQueryFixtures } from './GameSlotFindQueryFixtures';
 
 export class GameFindQueryFixtures {
   public static get any(): GameFindQuery {
@@ -9,6 +10,13 @@ export class GameFindQueryFixtures {
     return {
       ...GameFindQueryFixtures.any,
       id: 'e6b54159-a4ef-41fc-994a-20709526bdaa',
+    };
+  }
+
+  public static get withGameSlotFindQuery(): GameFindQuery {
+    return {
+      ...GameFindQueryFixtures.any,
+      gameSlotFindQuery: GameSlotFindQueryFixtures.any,
     };
   }
 }

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/query/GameFindQuery.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/query/GameFindQuery.ts
@@ -1,3 +1,6 @@
+import { GameSlotFindQuery } from './GameSlotFindQuery';
+
 export interface GameFindQuery {
+  gameSlotFindQuery?: GameSlotFindQuery;
   id?: string;
 }

--- a/packages/backend/libraries/backend-db/src/persistence/converters/typeorm/QueryToFindQueryTypeOrmConverter.ts
+++ b/packages/backend/libraries/backend-db/src/persistence/converters/typeorm/QueryToFindQueryTypeOrmConverter.ts
@@ -14,11 +14,11 @@ export type QueryToFindQueryTypeOrmConverter<
   | ConverterAsync<TQuery, FindManyOptions<TModelDb>>
   | Converter<
       TQuery,
-      QueryBuilder<TModelDb> & WhereExpressionBuilder,
-      QueryBuilder<TModelDb> & WhereExpressionBuilder
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
     >
   | ConverterAsync<
       TQuery,
-      QueryBuilder<TModelDb> & WhereExpressionBuilder,
-      QueryBuilder<TModelDb> & WhereExpressionBuilder
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
     >;


### PR DESCRIPTION
### Changed
- Updated `GameFindQuery` with `gameSlotFindQuery` property.
- Updated `GameFindQueryToGameFindQueryTypeOrmConverter` to handle `gameSlotFindQuery` property.
- Updated Query builder based converters to rely on an `ObjectLiteral` based query builder.