### PR TITLE
Update GameFindQuery with additional filters

### DIFF
--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameFindQueryToGameFindQueryTypeOrmConverter.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameFindQueryToGameFindQueryTypeOrmConverter.spec.ts
@@ -63,17 +63,27 @@ describe(GameFindQueryToGameFindQueryTypeOrmConverter.name, () => {
   });
 
   describe('.convert', () => {
-    let queryBuilderFixture: jest.Mocked<
-      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder
-    >;
+    let queryFixture: string;
+    let queryBuilderFixture: jest.Mocked<SelectQueryBuilder<ObjectLiteral>>;
 
     beforeAll(() => {
+      queryFixture = '(query fixture)';
+
       queryBuilderFixture = {
         andWhere: jest.fn().mockReturnThis(),
+        distinct: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        getParameters: jest.fn().mockReturnThis(),
+        getQuery: jest.fn().mockReturnValue(queryFixture),
         leftJoinAndSelect: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        offset: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        setParameters: jest.fn().mockReturnThis(),
+        subQuery: jest.fn().mockReturnThis(),
       } as Partial<
-        jest.Mocked<QueryBuilder<ObjectLiteral> & WhereExpressionBuilder>
-      > as jest.Mocked<QueryBuilder<ObjectLiteral> & WhereExpressionBuilder>;
+        jest.Mocked<SelectQueryBuilder<ObjectLiteral>>
+      > as jest.Mocked<SelectQueryBuilder<ObjectLiteral>>;
     });
 
     describe('having a GameFindQuery with id', () => {
@@ -87,9 +97,9 @@ describe(GameFindQueryToGameFindQueryTypeOrmConverter.name, () => {
         let result: unknown;
 
         beforeAll(() => {
-          (InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock)
-            .mockReturnValueOnce(true)
-            .mockReturnValueOnce(true);
+          (
+            InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock
+          ).mockReturnValue(true);
 
           result = gameFindQueryToGameFindQueryTypeOrmConverter.convert(
             gameFindQueryFixture,
@@ -99,6 +109,10 @@ describe(GameFindQueryToGameFindQueryTypeOrmConverter.name, () => {
 
         afterAll(() => {
           jest.clearAllMocks();
+
+          (
+            InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock
+          ).mockReset();
         });
 
         it('should call queryBuilder.andWhere()', () => {
@@ -128,9 +142,9 @@ describe(GameFindQueryToGameFindQueryTypeOrmConverter.name, () => {
         let result: unknown;
 
         beforeAll(() => {
-          (InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock)
-            .mockReturnValueOnce(true)
-            .mockReturnValueOnce(true);
+          (
+            InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock
+          ).mockReturnValue(true);
 
           gameSlotFindQueryToGameSlotFindQueryTypeOrmConverterMock.convert.mockReturnValueOnce(
             queryBuilderFixture,
@@ -144,6 +158,10 @@ describe(GameFindQueryToGameFindQueryTypeOrmConverter.name, () => {
 
         afterAll(() => {
           jest.clearAllMocks();
+
+          (
+            InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock
+          ).mockReset();
         });
 
         it('should call gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.convert()', () => {
@@ -155,6 +173,135 @@ describe(GameFindQueryToGameFindQueryTypeOrmConverter.name, () => {
           ).toHaveBeenCalledWith(
             gameFindQueryFixture.gameSlotFindQuery,
             queryBuilderFixture,
+          );
+        });
+
+        it('should return a QueryBuilder', () => {
+          expect(result).toBe(queryBuilderFixture);
+        });
+      });
+    });
+
+    describe('having a GameFindQuery with limit', () => {
+      let gameFindQueryFixture: GameFindQuery;
+
+      beforeAll(() => {
+        gameFindQueryFixture = GameFindQueryFixtures.withLimit;
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          (
+            InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock
+          ).mockReturnValue(true);
+
+          result = gameFindQueryToGameFindQueryTypeOrmConverter.convert(
+            gameFindQueryFixture,
+            queryBuilderFixture,
+          );
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+
+          (
+            InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock
+          ).mockReset();
+        });
+
+        it('should call queryBuilder.limit()', () => {
+          expect(queryBuilderFixture.limit).toHaveBeenCalledTimes(1);
+          expect(queryBuilderFixture.limit).toHaveBeenCalledWith(
+            gameFindQueryFixture.limit,
+          );
+        });
+
+        it('should return a QueryBuilder', () => {
+          expect(result).toBe(queryBuilderFixture);
+        });
+      });
+    });
+
+    describe('having a GameFindQuery with offset', () => {
+      let gameFindQueryFixture: GameFindQuery;
+
+      beforeAll(() => {
+        gameFindQueryFixture = GameFindQueryFixtures.withOffset;
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          (
+            InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock
+          ).mockReturnValue(true);
+
+          result = gameFindQueryToGameFindQueryTypeOrmConverter.convert(
+            gameFindQueryFixture,
+            queryBuilderFixture,
+          );
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+
+          (
+            InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock
+          ).mockReset();
+        });
+
+        it('should call queryBuilder.offset()', () => {
+          expect(queryBuilderFixture.offset).toHaveBeenCalledTimes(1);
+          expect(queryBuilderFixture.offset).toHaveBeenCalledWith(
+            gameFindQueryFixture.offset,
+          );
+        });
+
+        it('should return a QueryBuilder', () => {
+          expect(result).toBe(queryBuilderFixture);
+        });
+      });
+    });
+
+    describe('having a GameFindQuery with status', () => {
+      let gameFindQueryFixture: GameFindQuery;
+
+      beforeAll(() => {
+        gameFindQueryFixture = GameFindQueryFixtures.withStatusActive;
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          (
+            InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock
+          ).mockReturnValue(true);
+
+          result = gameFindQueryToGameFindQueryTypeOrmConverter.convert(
+            gameFindQueryFixture,
+            queryBuilderFixture,
+          );
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+
+          (
+            InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock
+          ).mockReset();
+        });
+
+        it('should call queryBuilder.andWhere()', () => {
+          expect(queryBuilderFixture.andWhere).toHaveBeenCalled();
+          expect(queryBuilderFixture.andWhere).toHaveBeenCalledWith(
+            `${GameDb.name}.status = :${GameDb.name}status`,
+            {
+              [`${GameDb.name}status`]: gameFindQueryFixture.status,
+            },
           );
         });
 

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameFindQueryToGameFindQueryTypeOrmConverter.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/converters/GameFindQueryToGameFindQueryTypeOrmConverter.ts
@@ -1,4 +1,4 @@
-import { Converter } from '@cornie-js/backend-common';
+import { AppError, AppErrorKind, Converter } from '@cornie-js/backend-common';
 import {
   GameFindQuery,
   GameSlotFindQuery,
@@ -8,6 +8,7 @@ import {
   InstanceChecker,
   ObjectLiteral,
   QueryBuilder,
+  SelectQueryBuilder,
   WhereExpressionBuilder,
 } from 'typeorm';
 
@@ -56,16 +57,8 @@ export class GameFindQueryToGameFindQueryTypeOrmConverter
     if (InstanceChecker.isSelectQueryBuilder(queryBuilder)) {
       queryBuilder = queryBuilder.leftJoinAndSelect(
         `${gamePropertiesPrefix}gameSlotsDb`,
-        GameSlotDb.name,
+        `${GameSlotDb.name}Joined`,
       );
-
-      if (gameFindQuery.gameSlotFindQuery !== undefined) {
-        queryBuilder =
-          this.#gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.convert(
-            gameFindQuery.gameSlotFindQuery,
-            queryBuilder,
-          );
-      }
     }
 
     if (gameFindQuery.id !== undefined) {
@@ -77,6 +70,72 @@ export class GameFindQueryToGameFindQueryTypeOrmConverter
       );
     }
 
+    if (gameFindQuery.limit !== undefined) {
+      this.#assertSelectQueryBuilderIsUsedForSelectFilters(queryBuilder);
+      queryBuilder = queryBuilder.limit(gameFindQuery.limit);
+    }
+
+    if (gameFindQuery.gameSlotFindQuery !== undefined) {
+      this.#assertSelectQueryBuilderIsUsedForSelectFilters(queryBuilder);
+
+      queryBuilder = this.#findByGameSlotFindQuery(
+        gameFindQuery.gameSlotFindQuery,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        queryBuilder,
+      );
+    }
+
+    if (gameFindQuery.status !== undefined) {
+      queryBuilder = queryBuilder.andWhere(
+        `${gamePropertiesPrefix}status = :${GameDb.name}status`,
+        {
+          [`${GameDb.name}status`]: gameFindQuery.status,
+        },
+      );
+    }
+
+    if (gameFindQuery.offset !== undefined) {
+      this.#assertSelectQueryBuilderIsUsedForSelectFilters(queryBuilder);
+      queryBuilder = queryBuilder.offset(gameFindQuery.offset);
+    }
+
     return queryBuilder;
+  }
+
+  #assertSelectQueryBuilderIsUsedForSelectFilters(
+    queryBuilder: QueryBuilder<ObjectLiteral>,
+  ): asserts queryBuilder is SelectQueryBuilder<ObjectLiteral> {
+    if (!InstanceChecker.isSelectQueryBuilder(queryBuilder)) {
+      throw new AppError(
+        AppErrorKind.unprocessableOperation,
+        `Error trying to filter a game with slot filter conditions in a non search context`,
+      );
+    }
+  }
+
+  #findByGameSlotFindQuery(
+    gameSlotFindQuery: GameSlotFindQuery,
+    selectQueryBuilder: SelectQueryBuilder<ObjectLiteral>,
+  ): SelectQueryBuilder<ObjectLiteral> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    let subQueryBuilder: SelectQueryBuilder<ObjectLiteral> = selectQueryBuilder
+      .subQuery()
+      .select(`${GameSlotDb.name}.gameId`)
+      .distinct(true)
+      .from(GameSlotDb, GameSlotDb.name);
+
+    subQueryBuilder =
+      this.#gameSlotFindQueryToGameSlotFindQueryTypeOrmConverter.convert(
+        gameSlotFindQuery,
+        subQueryBuilder,
+      ) as SelectQueryBuilder<ObjectLiteral>;
+
+    selectQueryBuilder = selectQueryBuilder.andWhere(
+      `${GameDb.name}.id IN (${subQueryBuilder.getQuery()})`,
+    );
+
+    selectQueryBuilder.setParameters(subQueryBuilder.getParameters());
+
+    return selectQueryBuilder;
   }
 }

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameFindQueryFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameFindQueryFixtures.ts
@@ -1,3 +1,4 @@
+import { GameStatus } from '../models/GameStatus';
 import { GameFindQuery } from '../query/GameFindQuery';
 import { GameSlotFindQueryFixtures } from './GameSlotFindQueryFixtures';
 
@@ -17,6 +18,27 @@ export class GameFindQueryFixtures {
     return {
       ...GameFindQueryFixtures.any,
       gameSlotFindQuery: GameSlotFindQueryFixtures.any,
+    };
+  }
+
+  public static get withLimit(): GameFindQuery {
+    return {
+      ...GameFindQueryFixtures.any,
+      limit: 10,
+    };
+  }
+
+  public static get withOffset(): GameFindQuery {
+    return {
+      ...GameFindQueryFixtures.any,
+      offset: 10,
+    };
+  }
+
+  public static get withStatusActive(): GameFindQuery {
+    return {
+      ...GameFindQueryFixtures.any,
+      status: GameStatus.active,
     };
   }
 }

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/query/GameFindQuery.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/query/GameFindQuery.ts
@@ -1,6 +1,10 @@
+import { GameStatus } from '../models/GameStatus';
 import { GameSlotFindQuery } from './GameSlotFindQuery';
 
 export interface GameFindQuery {
   gameSlotFindQuery?: GameSlotFindQuery;
   id?: string;
+  limit?: number;
+  offset?: number;
+  status?: GameStatus;
 }


### PR DESCRIPTION
### Changed
- Updated `GameFindQuery` with additional filters.
- Updated `GameFindQueryToGameFindQueryTypeOrmConverter` to handle game filtering on top of game slots filters in such a way no game slots are lost in the way.
- Updated `GameFindQueryToGameFindQueryTypeOrmConverter` to handle `GameFindQuery` new filters.