### PR TITLE
Add UserCodePersistenceTypeOrmAdapter

### DIFF
--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/nest/UserDbModule.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/nest/UserDbModule.ts
@@ -5,11 +5,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { DbModuleOptions } from '../../../foundation/db/adapter/nest/models/DbModuleOptions';
 import { DbModule } from '../../../foundation/db/adapter/nest/modules/DbModule';
 import { UserPersistenceTypeOrmAdapter } from '../typeorm/adapters/UserPersistenceTypeOrmAdapter';
+import { UserCodeDbToUserCodeConverter } from '../typeorm/converters/UserCodeDbToUserCodeConverter';
 import { UserCreateQueryToUserCreateQueryTypeOrmConverter } from '../typeorm/converters/UserCreateQueryToUserCreateQueryTypeOrmConverter';
 import { UserDbToUserConverter } from '../typeorm/converters/UserDbToUserConverter';
 import { UserFindQueryToUserFindQueryTypeOrmConverter } from '../typeorm/converters/UserFindQueryToUserFindQueryTypeOrmConverter';
 import { UserUpdateQueryToUserFindQueryTypeOrmConverter } from '../typeorm/converters/UserUpdateQueryToUserFindQueryTypeOrmConverter';
 import { UserUpdateQueryToUserSetQueryTypeOrmConverter } from '../typeorm/converters/UserUpdateQueryToUserSetQueryTypeOrmConverter';
+import { UserCodeDb } from '../typeorm/models/UserCodeDb';
 import { UserDb } from '../typeorm/models/UserDb';
 import { CreateUserTypeOrmService } from '../typeorm/services/CreateUserTypeOrmService';
 import { DeleteUserTypeOrmService } from '../typeorm/services/DeleteUserTypeOrmService';
@@ -24,7 +26,7 @@ export class UserDbModule {
       global: false,
       imports: [
         DbModule.forRootAsync(dbModuleOptions),
-        TypeOrmModule.forFeature([UserDb]),
+        TypeOrmModule.forFeature([UserCodeDb, UserDb]),
       ],
       module: UserDbModule,
       providers: [
@@ -32,6 +34,7 @@ export class UserDbModule {
         DeleteUserTypeOrmService,
         FindUserTypeOrmService,
         UpdateUserTypeOrmService,
+        UserCodeDbToUserCodeConverter,
         UserCreateQueryToUserCreateQueryTypeOrmConverter,
         UserFindQueryToUserFindQueryTypeOrmConverter,
         UserDbToUserConverter,

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/nest/UserDbModule.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/nest/UserDbModule.ts
@@ -17,6 +17,7 @@ import { UserCodeDb } from '../typeorm/models/UserCodeDb';
 import { UserDb } from '../typeorm/models/UserDb';
 import { CreateUserCodeTypeOrmService } from '../typeorm/services/CreateUserCodeTypeOrmService';
 import { CreateUserTypeOrmService } from '../typeorm/services/CreateUserTypeOrmService';
+import { DeleteUserCodeTypeOrmService } from '../typeorm/services/DeleteUserCodeTypeOrmService';
 import { DeleteUserTypeOrmService } from '../typeorm/services/DeleteUserTypeOrmService';
 import { FindUserCodeTypeOrmService } from '../typeorm/services/FindUserCodeTypeOrmService';
 import { FindUserTypeOrmService } from '../typeorm/services/FindUserTypeOrmService';
@@ -36,6 +37,7 @@ export class UserDbModule {
       providers: [
         CreateUserCodeTypeOrmService,
         CreateUserTypeOrmService,
+        DeleteUserCodeTypeOrmService,
         DeleteUserTypeOrmService,
         FindUserCodeTypeOrmService,
         FindUserTypeOrmService,

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/nest/UserDbModule.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/nest/UserDbModule.ts
@@ -1,9 +1,13 @@
-import { userPersistenceOutputPortSymbol } from '@cornie-js/backend-user-application/users';
+import {
+  userCodePersistenceOutputPortSymbol,
+  userPersistenceOutputPortSymbol,
+} from '@cornie-js/backend-user-application/users';
 import { DynamicModule, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { DbModuleOptions } from '../../../foundation/db/adapter/nest/models/DbModuleOptions';
 import { DbModule } from '../../../foundation/db/adapter/nest/modules/DbModule';
+import { UserCodePersistenceTypeOrmAdapter } from '../typeorm/adapters/UserCodePersistenceTypeOrmAdapter';
 import { UserPersistenceTypeOrmAdapter } from '../typeorm/adapters/UserPersistenceTypeOrmAdapter';
 import { UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter } from '../typeorm/converters/UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter';
 import { UserCodeDbToUserCodeConverter } from '../typeorm/converters/UserCodeDbToUserCodeConverter';
@@ -48,6 +52,10 @@ export class UserDbModule {
         UserCreateQueryToUserCreateQueryTypeOrmConverter,
         UserFindQueryToUserFindQueryTypeOrmConverter,
         UserDbToUserConverter,
+        {
+          provide: userCodePersistenceOutputPortSymbol,
+          useClass: UserCodePersistenceTypeOrmAdapter,
+        },
         {
           provide: userPersistenceOutputPortSymbol,
           useClass: UserPersistenceTypeOrmAdapter,

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/nest/UserDbModule.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/nest/UserDbModule.ts
@@ -6,6 +6,7 @@ import { DbModuleOptions } from '../../../foundation/db/adapter/nest/models/DbMo
 import { DbModule } from '../../../foundation/db/adapter/nest/modules/DbModule';
 import { UserPersistenceTypeOrmAdapter } from '../typeorm/adapters/UserPersistenceTypeOrmAdapter';
 import { UserCodeDbToUserCodeConverter } from '../typeorm/converters/UserCodeDbToUserCodeConverter';
+import { UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter } from '../typeorm/converters/UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter';
 import { UserCreateQueryToUserCreateQueryTypeOrmConverter } from '../typeorm/converters/UserCreateQueryToUserCreateQueryTypeOrmConverter';
 import { UserDbToUserConverter } from '../typeorm/converters/UserDbToUserConverter';
 import { UserFindQueryToUserFindQueryTypeOrmConverter } from '../typeorm/converters/UserFindQueryToUserFindQueryTypeOrmConverter';
@@ -35,6 +36,7 @@ export class UserDbModule {
         FindUserTypeOrmService,
         UpdateUserTypeOrmService,
         UserCodeDbToUserCodeConverter,
+        UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter,
         UserCreateQueryToUserCreateQueryTypeOrmConverter,
         UserFindQueryToUserFindQueryTypeOrmConverter,
         UserDbToUserConverter,

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/nest/UserDbModule.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/nest/UserDbModule.ts
@@ -18,6 +18,7 @@ import { UserDb } from '../typeorm/models/UserDb';
 import { CreateUserCodeTypeOrmService } from '../typeorm/services/CreateUserCodeTypeOrmService';
 import { CreateUserTypeOrmService } from '../typeorm/services/CreateUserTypeOrmService';
 import { DeleteUserTypeOrmService } from '../typeorm/services/DeleteUserTypeOrmService';
+import { FindUserCodeTypeOrmService } from '../typeorm/services/FindUserCodeTypeOrmService';
 import { FindUserTypeOrmService } from '../typeorm/services/FindUserTypeOrmService';
 import { UpdateUserTypeOrmService } from '../typeorm/services/UpdateUserTypeOrmService';
 
@@ -36,6 +37,7 @@ export class UserDbModule {
         CreateUserCodeTypeOrmService,
         CreateUserTypeOrmService,
         DeleteUserTypeOrmService,
+        FindUserCodeTypeOrmService,
         FindUserTypeOrmService,
         UpdateUserTypeOrmService,
         UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter,

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/nest/UserDbModule.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/nest/UserDbModule.ts
@@ -15,6 +15,7 @@ import { UserUpdateQueryToUserFindQueryTypeOrmConverter } from '../typeorm/conve
 import { UserUpdateQueryToUserSetQueryTypeOrmConverter } from '../typeorm/converters/UserUpdateQueryToUserSetQueryTypeOrmConverter';
 import { UserCodeDb } from '../typeorm/models/UserCodeDb';
 import { UserDb } from '../typeorm/models/UserDb';
+import { CreateUserCodeTypeOrmService } from '../typeorm/services/CreateUserCodeTypeOrmService';
 import { CreateUserTypeOrmService } from '../typeorm/services/CreateUserTypeOrmService';
 import { DeleteUserTypeOrmService } from '../typeorm/services/DeleteUserTypeOrmService';
 import { FindUserTypeOrmService } from '../typeorm/services/FindUserTypeOrmService';
@@ -32,6 +33,7 @@ export class UserDbModule {
       ],
       module: UserDbModule,
       providers: [
+        CreateUserCodeTypeOrmService,
         CreateUserTypeOrmService,
         DeleteUserTypeOrmService,
         FindUserTypeOrmService,

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/nest/UserDbModule.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/nest/UserDbModule.ts
@@ -5,6 +5,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { DbModuleOptions } from '../../../foundation/db/adapter/nest/models/DbModuleOptions';
 import { DbModule } from '../../../foundation/db/adapter/nest/modules/DbModule';
 import { UserPersistenceTypeOrmAdapter } from '../typeorm/adapters/UserPersistenceTypeOrmAdapter';
+import { UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter } from '../typeorm/converters/UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter';
 import { UserCodeDbToUserCodeConverter } from '../typeorm/converters/UserCodeDbToUserCodeConverter';
 import { UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter } from '../typeorm/converters/UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter';
 import { UserCreateQueryToUserCreateQueryTypeOrmConverter } from '../typeorm/converters/UserCreateQueryToUserCreateQueryTypeOrmConverter';
@@ -35,6 +36,7 @@ export class UserDbModule {
         DeleteUserTypeOrmService,
         FindUserTypeOrmService,
         UpdateUserTypeOrmService,
+        UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter,
         UserCodeDbToUserCodeConverter,
         UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter,
         UserCreateQueryToUserCreateQueryTypeOrmConverter,

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/adapters/UserCodePersistenceTypeOrmAdapter.spec.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/adapters/UserCodePersistenceTypeOrmAdapter.spec.ts
@@ -1,0 +1,166 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import {
+  UserCode,
+  UserCodeCreateQuery,
+  UserCodeFindQuery,
+} from '@cornie-js/backend-user-domain/users';
+import {
+  UserCodeCreateQueryFixtures,
+  UserCodeFindQueryFixtures,
+  UserCodeFixtures,
+} from '@cornie-js/backend-user-domain/users/fixtures';
+
+import { CreateUserCodeTypeOrmService } from '../services/CreateUserCodeTypeOrmService';
+import { DeleteUserCodeTypeOrmService } from '../services/DeleteUserCodeTypeOrmService';
+import { FindUserCodeTypeOrmService } from '../services/FindUserCodeTypeOrmService';
+import { UserCodePersistenceTypeOrmAdapter } from './UserCodePersistenceTypeOrmAdapter';
+
+describe(UserCodePersistenceTypeOrmAdapter, () => {
+  let createUserCodeTypeOrmServiceMock: jest.Mocked<CreateUserCodeTypeOrmService>;
+  let deleteUserCodeTypeOrmServiceMock: jest.Mocked<DeleteUserCodeTypeOrmService>;
+  let findUserCodeTypeOrmServiceMock: jest.Mocked<FindUserCodeTypeOrmService>;
+
+  let userCodePersistenceTypeOrmAdapter: UserCodePersistenceTypeOrmAdapter;
+
+  beforeAll(() => {
+    createUserCodeTypeOrmServiceMock = {
+      insertOne: jest.fn(),
+    } as Partial<
+      jest.Mocked<CreateUserCodeTypeOrmService>
+    > as jest.Mocked<CreateUserCodeTypeOrmService>;
+
+    deleteUserCodeTypeOrmServiceMock = {
+      delete: jest.fn(),
+    } as Partial<
+      jest.Mocked<DeleteUserCodeTypeOrmService>
+    > as jest.Mocked<DeleteUserCodeTypeOrmService>;
+
+    findUserCodeTypeOrmServiceMock = {
+      findOne: jest.fn(),
+    } as Partial<
+      jest.Mocked<FindUserCodeTypeOrmService>
+    > as jest.Mocked<FindUserCodeTypeOrmService>;
+
+    userCodePersistenceTypeOrmAdapter = new UserCodePersistenceTypeOrmAdapter(
+      createUserCodeTypeOrmServiceMock,
+      deleteUserCodeTypeOrmServiceMock,
+      findUserCodeTypeOrmServiceMock,
+    );
+  });
+
+  describe('.create', () => {
+    describe('when called', () => {
+      let userCodeCreateQueryFixture: UserCodeCreateQuery;
+      let userCodeFixture: UserCode;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        userCodeCreateQueryFixture = UserCodeCreateQueryFixtures.any;
+        userCodeFixture = Symbol() as unknown as UserCode;
+
+        createUserCodeTypeOrmServiceMock.insertOne.mockResolvedValueOnce(
+          userCodeFixture,
+        );
+
+        result = await userCodePersistenceTypeOrmAdapter.create(
+          userCodeCreateQueryFixture,
+        );
+      });
+
+      it('should call CreateUserCodeTypeOrmService.insertOne()', () => {
+        expect(
+          createUserCodeTypeOrmServiceMock.insertOne,
+        ).toHaveBeenCalledTimes(1);
+        expect(createUserCodeTypeOrmServiceMock.insertOne).toHaveBeenCalledWith(
+          userCodeCreateQueryFixture,
+        );
+      });
+
+      it('should return a UserCode', () => {
+        expect(result).toBe(userCodeFixture);
+      });
+    });
+  });
+
+  describe('.delete', () => {
+    let userCodeFindQueryFixture: UserCodeFindQuery;
+
+    beforeAll(() => {
+      userCodeFindQueryFixture = UserCodeFindQueryFixtures.any;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        deleteUserCodeTypeOrmServiceMock.delete.mockResolvedValueOnce(
+          undefined,
+        );
+
+        result = await userCodePersistenceTypeOrmAdapter.delete(
+          userCodeFindQueryFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call deleteUserCodeTypeOrmService.delete()', () => {
+        expect(deleteUserCodeTypeOrmServiceMock.delete).toHaveBeenCalledTimes(
+          1,
+        );
+        expect(deleteUserCodeTypeOrmServiceMock.delete).toHaveBeenCalledWith(
+          userCodeFindQueryFixture,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('.findOne', () => {
+    let userCodeFindQueryFixture: UserCodeFindQuery;
+
+    beforeAll(() => {
+      userCodeFindQueryFixture = UserCodeFindQueryFixtures.any;
+    });
+
+    describe('when called', () => {
+      let userCodeFixture: UserCode;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        userCodeFixture = UserCodeFixtures.any;
+
+        findUserCodeTypeOrmServiceMock.findOne.mockResolvedValueOnce(
+          userCodeFixture,
+        );
+
+        result = await userCodePersistenceTypeOrmAdapter.findOne(
+          userCodeFindQueryFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call findUserCodeTypeOrmService.findOne()', () => {
+        expect(findUserCodeTypeOrmServiceMock.findOne).toHaveBeenCalledTimes(1);
+        expect(findUserCodeTypeOrmServiceMock.findOne).toHaveBeenCalledWith(
+          userCodeFindQueryFixture,
+        );
+      });
+
+      it('should return a UserCode', () => {
+        expect(result).toBe(userCodeFixture);
+      });
+    });
+  });
+});

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/adapters/UserCodePersistenceTypeOrmAdapter.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/adapters/UserCodePersistenceTypeOrmAdapter.ts
@@ -1,0 +1,49 @@
+import { UserCodePersistenceOutputPort } from '@cornie-js/backend-user-application/users';
+import {
+  UserCode,
+  UserCodeCreateQuery,
+  UserCodeFindQuery,
+} from '@cornie-js/backend-user-domain/users';
+import { Inject, Injectable } from '@nestjs/common';
+
+import { CreateUserCodeTypeOrmService } from '../services/CreateUserCodeTypeOrmService';
+import { DeleteUserCodeTypeOrmService } from '../services/DeleteUserCodeTypeOrmService';
+import { FindUserCodeTypeOrmService } from '../services/FindUserCodeTypeOrmService';
+
+@Injectable()
+export class UserCodePersistenceTypeOrmAdapter
+  implements UserCodePersistenceOutputPort
+{
+  readonly #createUserCodeTypeOrmService: CreateUserCodeTypeOrmService;
+  readonly #deleteUserCodeTypeOrmService: DeleteUserCodeTypeOrmService;
+  readonly #findUserCodeTypeOrmService: FindUserCodeTypeOrmService;
+
+  constructor(
+    @Inject(CreateUserCodeTypeOrmService)
+    createUserCodeTypeOrmService: CreateUserCodeTypeOrmService,
+    @Inject(DeleteUserCodeTypeOrmService)
+    deleteUserCodeTypeOrmService: DeleteUserCodeTypeOrmService,
+    @Inject(FindUserCodeTypeOrmService)
+    findUserCodeTypeOrmService: FindUserCodeTypeOrmService,
+  ) {
+    this.#createUserCodeTypeOrmService = createUserCodeTypeOrmService;
+    this.#deleteUserCodeTypeOrmService = deleteUserCodeTypeOrmService;
+    this.#findUserCodeTypeOrmService = findUserCodeTypeOrmService;
+  }
+
+  public async create(
+    userCodeCreateQuery: UserCodeCreateQuery,
+  ): Promise<UserCode> {
+    return this.#createUserCodeTypeOrmService.insertOne(userCodeCreateQuery);
+  }
+
+  public async delete(userCodeFindQuery: UserCodeFindQuery): Promise<void> {
+    await this.#deleteUserCodeTypeOrmService.delete(userCodeFindQuery);
+  }
+
+  public async findOne(
+    userCodeFindQuery: UserCodeFindQuery,
+  ): Promise<UserCode | undefined> {
+    return this.#findUserCodeTypeOrmService.findOne(userCodeFindQuery);
+  }
+}

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/converters/UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter.spec.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/converters/UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter.spec.ts
@@ -1,0 +1,48 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { UserCodeCreateQuery } from '@cornie-js/backend-user-domain/users';
+import { UserCodeCreateQueryFixtures } from '@cornie-js/backend-user-domain/users/fixtures';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity.js';
+
+import { UserCodeDb } from '../models/UserCodeDb';
+import { UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter } from './UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter';
+
+describe(UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter.name, () => {
+  let userCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter: UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter;
+
+  beforeAll(() => {
+    userCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter =
+      new UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter();
+  });
+
+  describe('.convert', () => {
+    let userCodeCreateQueryFixture: UserCodeCreateQuery;
+
+    beforeAll(() => {
+      userCodeCreateQueryFixture = UserCodeCreateQueryFixtures.any;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result =
+          userCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter.convert(
+            userCodeCreateQueryFixture,
+          );
+      });
+
+      it('should return a QueryDeepPartial<UserCodeDb>', () => {
+        const expected: QueryDeepPartialEntity<UserCodeDb> = {
+          code: userCodeCreateQueryFixture.code,
+          id: userCodeCreateQueryFixture.id,
+          user: {
+            id: userCodeCreateQueryFixture.userId,
+          },
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+});

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/converters/UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/converters/UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter.ts
@@ -1,0 +1,23 @@
+import { Converter } from '@cornie-js/backend-common';
+import { UserCodeCreateQuery } from '@cornie-js/backend-user-domain/users';
+import { Injectable } from '@nestjs/common';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity.js';
+
+import { UserCodeDb } from '../models/UserCodeDb';
+
+@Injectable()
+export class UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter
+  implements Converter<UserCodeCreateQuery, QueryDeepPartialEntity<UserCodeDb>>
+{
+  public convert(
+    userCodeCreateQuery: UserCodeCreateQuery,
+  ): QueryDeepPartialEntity<UserCodeDb> {
+    return {
+      code: userCodeCreateQuery.code,
+      id: userCodeCreateQuery.id,
+      user: {
+        id: userCodeCreateQuery.userId,
+      },
+    };
+  }
+}

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/converters/UserCodeDbToUserCodeConverter.spec.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/converters/UserCodeDbToUserCodeConverter.spec.ts
@@ -1,0 +1,39 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { UserCode } from '@cornie-js/backend-user-domain/users';
+
+import { UserCodeDbFixtures } from '../fixtures/UserCodeDbFixtures';
+import { UserCodeDb } from '../models/UserCodeDb';
+import { UserCodeDbToUserCodeConverter } from './UserCodeDbToUserCodeConverter';
+
+describe(UserCodeDbToUserCodeConverter.name, () => {
+  let userCodeDbToUserCodeConverter: UserCodeDbToUserCodeConverter;
+
+  beforeAll(() => {
+    userCodeDbToUserCodeConverter = new UserCodeDbToUserCodeConverter();
+  });
+
+  describe('.convert', () => {
+    let userCodeDbFixture: UserCodeDb;
+
+    beforeAll(() => {
+      userCodeDbFixture = UserCodeDbFixtures.any;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = userCodeDbToUserCodeConverter.convert(userCodeDbFixture);
+      });
+
+      it('should return a UserCode', () => {
+        const expected: UserCode = {
+          code: userCodeDbFixture.code,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+});

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/converters/UserCodeDbToUserCodeConverter.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/converters/UserCodeDbToUserCodeConverter.ts
@@ -1,0 +1,16 @@
+import { Converter } from '@cornie-js/backend-common';
+import { UserCode } from '@cornie-js/backend-user-domain/users';
+import { Injectable } from '@nestjs/common';
+
+import { UserCodeDb } from '../models/UserCodeDb';
+
+@Injectable()
+export class UserCodeDbToUserCodeConverter
+  implements Converter<UserCodeDb, UserCode>
+{
+  public convert(userCodeDb: UserCodeDb): UserCode {
+    return {
+      code: userCodeDb.code,
+    };
+  }
+}

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/converters/UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter.spec.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/converters/UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter.spec.ts
@@ -1,0 +1,77 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { UserCodeFindQuery } from '@cornie-js/backend-user-domain/users';
+import { UserCodeFindQueryFixtures } from '@cornie-js/backend-user-domain/users/fixtures';
+import { FindManyOptions } from 'typeorm';
+
+import { UserCodeDb } from '../models/UserCodeDb';
+import { UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter } from './UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter';
+
+describe(UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter.name, () => {
+  let userCodeFindQueryToUserCodeFindQueryTypeOrmConverter: UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter;
+
+  beforeAll(() => {
+    userCodeFindQueryToUserCodeFindQueryTypeOrmConverter =
+      new UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter();
+  });
+
+  describe('.convert', () => {
+    describe('having a UserCodeFindQuery with code', () => {
+      let userCodeFindQueryFixture: UserCodeFindQuery;
+
+      beforeAll(() => {
+        userCodeFindQueryFixture = UserCodeFindQueryFixtures.withCode;
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = userCodeFindQueryToUserCodeFindQueryTypeOrmConverter.convert(
+            userCodeFindQueryFixture,
+          );
+        });
+
+        it('should return a FindManyOptions<UserCodeDb>', () => {
+          const expected: FindManyOptions<UserCodeDb> = {
+            where: {
+              code: userCodeFindQueryFixture.code as string,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a UserCodeFindQuery with userId', () => {
+      let userCodeFindQueryFixture: UserCodeFindQuery;
+
+      beforeAll(() => {
+        userCodeFindQueryFixture = UserCodeFindQueryFixtures.withUserId;
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = userCodeFindQueryToUserCodeFindQueryTypeOrmConverter.convert(
+            userCodeFindQueryFixture,
+          );
+        });
+
+        it('should return a FindManyOptions<UserCodeDb>', () => {
+          const expected: FindManyOptions<UserCodeDb> = {
+            where: {
+              user: {
+                id: userCodeFindQueryFixture.userId as string,
+              },
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+  });
+});

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/converters/UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/converters/UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter.ts
@@ -1,0 +1,34 @@
+import { Converter, Writable } from '@cornie-js/backend-common';
+import { UserCodeFindQuery } from '@cornie-js/backend-user-domain/users';
+import { Injectable } from '@nestjs/common';
+import { FindManyOptions, FindOptionsWhere } from 'typeorm';
+
+import { UserCodeDb } from '../models/UserCodeDb';
+
+@Injectable()
+export class UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter
+  implements Converter<UserCodeFindQuery, FindManyOptions<UserCodeDb>>
+{
+  public convert(
+    userCodeFindQuery: UserCodeFindQuery,
+  ): FindManyOptions<UserCodeDb> {
+    const userCodeFindQueryTypeOrmWhere: Writable<
+      FindOptionsWhere<UserCodeDb>
+    > = {};
+    const userCodeFindQueryTypeOrm: FindManyOptions<UserCodeDb> = {
+      where: userCodeFindQueryTypeOrmWhere,
+    };
+
+    if (userCodeFindQuery.code !== undefined) {
+      userCodeFindQueryTypeOrmWhere.code = userCodeFindQuery.code;
+    }
+
+    if (userCodeFindQuery.userId !== undefined) {
+      userCodeFindQueryTypeOrmWhere.user = {
+        id: userCodeFindQuery.userId,
+      };
+    }
+
+    return userCodeFindQueryTypeOrm;
+  }
+}

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/services/CreateUserCodeTypeOrmService.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/services/CreateUserCodeTypeOrmService.ts
@@ -1,0 +1,39 @@
+import { Converter } from '@cornie-js/backend-common';
+import { InsertTypeOrmPostgresService } from '@cornie-js/backend-db';
+import {
+  UserCode,
+  UserCodeCreateQuery,
+} from '@cornie-js/backend-user-domain/users';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity.js';
+
+import { UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter } from '../converters/UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter';
+import { UserCodeDbToUserCodeConverter } from '../converters/UserCodeDbToUserCodeConverter';
+import { UserCodeDb } from '../models/UserCodeDb';
+
+@Injectable()
+export class CreateUserCodeTypeOrmService extends InsertTypeOrmPostgresService<
+  UserCode,
+  UserCodeDb,
+  UserCodeCreateQuery
+> {
+  constructor(
+    @InjectRepository(UserCodeDb)
+    repository: Repository<UserCodeDb>,
+    @Inject(UserCodeDbToUserCodeConverter)
+    userCodeDbToUserCodeConverter: Converter<UserCodeDb, UserCode>,
+    @Inject(UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter)
+    userCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter: Converter<
+      UserCodeCreateQuery,
+      QueryDeepPartialEntity<UserCodeDb>
+    >,
+  ) {
+    super(
+      repository,
+      userCodeDbToUserCodeConverter,
+      userCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter,
+    );
+  }
+}

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/services/DeleteUserCodeTypeOrmService.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/services/DeleteUserCodeTypeOrmService.ts
@@ -1,0 +1,27 @@
+import { Converter } from '@cornie-js/backend-common';
+import { DeleteTypeOrmService } from '@cornie-js/backend-db';
+import { UserCodeFindQuery } from '@cornie-js/backend-user-domain/users';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { FindManyOptions, Repository } from 'typeorm';
+
+import { UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter } from '../converters/UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter';
+import { UserCodeDb } from '../models/UserCodeDb';
+
+@Injectable()
+export class DeleteUserCodeTypeOrmService extends DeleteTypeOrmService<
+  UserCodeDb,
+  UserCodeFindQuery
+> {
+  constructor(
+    @InjectRepository(UserCodeDb)
+    repository: Repository<UserCodeDb>,
+    @Inject(UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter)
+    userCodeFindQueryToUserCodeFindQueryTypeOrmConverter: Converter<
+      UserCodeFindQuery,
+      FindManyOptions<UserCodeDb>
+    >,
+  ) {
+    super(repository, userCodeFindQueryToUserCodeFindQueryTypeOrmConverter);
+  }
+}

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/services/FindUserCodeTypeOrmService.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/services/FindUserCodeTypeOrmService.ts
@@ -1,0 +1,38 @@
+import { Converter } from '@cornie-js/backend-common';
+import { FindTypeOrmService } from '@cornie-js/backend-db';
+import {
+  UserCode,
+  UserCodeFindQuery,
+} from '@cornie-js/backend-user-domain/users';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { FindManyOptions, Repository } from 'typeorm';
+
+import { UserCodeDbToUserCodeConverter } from '../converters/UserCodeDbToUserCodeConverter';
+import { UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter } from '../converters/UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter';
+import { UserCodeDb } from '../models/UserCodeDb';
+
+@Injectable()
+export class FindUserCodeTypeOrmService extends FindTypeOrmService<
+  UserCode,
+  UserCodeDb,
+  UserCodeFindQuery
+> {
+  constructor(
+    @InjectRepository(UserCodeDb)
+    repository: Repository<UserCodeDb>,
+    @Inject(UserCodeDbToUserCodeConverter)
+    userCodeDbToUserCodeConverter: Converter<UserCodeDb, UserCode>,
+    @Inject(UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter)
+    userCodeFindQueryToUserCodeFindQueryTypeOrmConverter: Converter<
+      UserCodeFindQuery,
+      FindManyOptions<UserCodeDb>
+    >,
+  ) {
+    super(
+      repository,
+      userCodeDbToUserCodeConverter,
+      userCodeFindQueryToUserCodeFindQueryTypeOrmConverter,
+    );
+  }
+}

--- a/packages/backend/apps/user/backend-user-application/src/auth/adapter/nest/modules/AuthApplicationModule.ts
+++ b/packages/backend/apps/user/backend-user-application/src/auth/adapter/nest/modules/AuthApplicationModule.ts
@@ -1,5 +1,6 @@
 import { JwtModule } from '@cornie-js/backend-app-jwt';
 import { EnvModule } from '@cornie-js/backend-app-user-env';
+import { UserDomainModule } from '@cornie-js/backend-user-domain';
 import { DynamicModule, ForwardReference, Module, Type } from '@nestjs/common';
 
 import { HashModule } from '../../../../foundation/hash/adapter/nest/modules/HashModule';
@@ -23,6 +24,7 @@ export class AuthApplicationModule {
         EnvModule,
         HashModule,
         JwtModule.forRootAsync(buildJwtModuleOptions()),
+        UserDomainModule,
         UserApplicationModule.forRootAsync(userImports),
       ],
       module: AuthApplicationModule,

--- a/packages/backend/apps/user/backend-user-application/src/users/adapter/nest/modules/UserApplicationModule.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/adapter/nest/modules/UserApplicationModule.ts
@@ -1,5 +1,4 @@
 import { UuidModule } from '@cornie-js/backend-app-uuid';
-import { UserDomainModule } from '@cornie-js/backend-user-domain';
 import { DynamicModule, ForwardReference, Module, Type } from '@nestjs/common';
 
 import { HashModule } from '../../../../foundation/hash/adapter/nest/modules/HashModule';
@@ -18,7 +17,7 @@ export class UserApplicationModule {
     return {
       exports: [UserManagementInputPort],
       global: false,
-      imports: [...(imports ?? []), HashModule, UuidModule, UserDomainModule],
+      imports: [...(imports ?? []), HashModule, UuidModule],
       module: UserApplicationModule,
       providers: [
         UserCreateQueryFromUserCreateQueryV1Builder,

--- a/packages/backend/apps/user/backend-user-application/src/users/application/index.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/index.ts
@@ -5,6 +5,10 @@ import { PatchUserV1MeHttpRequestController } from './controllers/PatchUserV1MeH
 import { PostUserV1HttpRequestController } from './controllers/PostUserV1HttpRequestController';
 import { GetUserV1UserIdRequestParamHandler } from './handlers/GetUserV1UserIdRequestParamHandler';
 import {
+  UserCodePersistenceOutputPort,
+  userCodePersistenceOutputPortSymbol,
+} from './ports/output/UserCodePersistenceOutputPort';
+import {
   UserPersistenceOutputPort,
   userPersistenceOutputPortSymbol,
 } from './ports/output/UserPersistenceOutputPort';
@@ -16,7 +20,8 @@ export {
   GetUserV1UserIdRequestParamHandler,
   PatchUserV1MeHttpRequestController,
   PostUserV1HttpRequestController,
+  userCodePersistenceOutputPortSymbol,
   userPersistenceOutputPortSymbol,
 };
 
-export type { UserPersistenceOutputPort };
+export type { UserCodePersistenceOutputPort, UserPersistenceOutputPort };

--- a/packages/backend/apps/user/backend-user-application/src/users/application/ports/output/UserCodePersistenceOutputPort.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/ports/output/UserCodePersistenceOutputPort.ts
@@ -1,0 +1,15 @@
+import {
+  UserCode,
+  UserCodeCreateQuery,
+  UserCodeFindQuery,
+} from '@cornie-js/backend-user-domain/users';
+
+export interface UserCodePersistenceOutputPort {
+  create(userCodeCreateQuery: UserCodeCreateQuery): Promise<UserCode>;
+  delete(userCodeFindQuery: UserCodeFindQuery): Promise<void>;
+  findOne(userCodeFindQuery: UserCodeFindQuery): Promise<UserCode | undefined>;
+}
+
+export const userCodePersistenceOutputPortSymbol: symbol = Symbol.for(
+  'UserCodePersistenceOutputPort',
+);

--- a/packages/backend/apps/user/backend-user-domain/src/users/domain/fixtures/UserCodeCreateQueryFixtures.ts
+++ b/packages/backend/apps/user/backend-user-domain/src/users/domain/fixtures/UserCodeCreateQueryFixtures.ts
@@ -1,0 +1,11 @@
+import { UserCodeCreateQuery } from '../query/UserCodeCreateQuery';
+
+export class UserCodeCreateQueryFixtures {
+  public static get any(): UserCodeCreateQuery {
+    return {
+      code: 'qwertyuiop',
+      id: '13073aec-b81b-4107-97f9-baa46de5dd89',
+      userId: '83073aec-b81b-4107-97f9-baa46de5dd40',
+    };
+  }
+}

--- a/packages/backend/apps/user/backend-user-domain/src/users/domain/fixtures/UserCodeFindQueryFixtures.ts
+++ b/packages/backend/apps/user/backend-user-domain/src/users/domain/fixtures/UserCodeFindQueryFixtures.ts
@@ -1,0 +1,17 @@
+import { UserCodeFindQuery } from '../query/UserCodeFindQuery';
+
+export class UserCodeFindQueryFixtures {
+  public static get any(): UserCodeFindQuery {
+    return {};
+  }
+
+  public static get withCode(): UserCodeFindQuery {
+    return { ...UserCodeFindQueryFixtures.any, code: 'qwertyuiop' };
+  }
+  public static get withUserId(): UserCodeFindQuery {
+    return {
+      ...UserCodeFindQueryFixtures.any,
+      userId: '83073aec-b81b-4107-97f9-baa46de5dd40',
+    };
+  }
+}

--- a/packages/backend/apps/user/backend-user-domain/src/users/domain/fixtures/index.ts
+++ b/packages/backend/apps/user/backend-user-domain/src/users/domain/fixtures/index.ts
@@ -1,3 +1,5 @@
+import { UserCodeCreateQueryFixtures } from './UserCodeCreateQueryFixtures';
+import { UserCodeFindQueryFixtures } from './UserCodeFindQueryFixtures';
 import { UserCodeFixtures } from './UserCodeFixtures';
 import { UserCreateQueryFixtures } from './UserCreateQueryFixtures';
 import { UserFindQueryFixtures } from './UserFindQueryFixtures';
@@ -5,6 +7,8 @@ import { UserFixtures } from './UserFixtures';
 import { UserUpdateQueryFixtures } from './UserUpdateQueryFixtures';
 
 export {
+  UserCodeCreateQueryFixtures,
+  UserCodeFindQueryFixtures,
   UserCodeFixtures,
   UserCreateQueryFixtures,
   UserFindQueryFixtures,

--- a/packages/backend/apps/user/backend-user-domain/src/users/domain/index.ts
+++ b/packages/backend/apps/user/backend-user-domain/src/users/domain/index.ts
@@ -1,10 +1,20 @@
 import { User } from './models/User';
 import { UserCode } from './models/UserCode';
+import { UserCodeCreateQuery } from './query/UserCodeCreateQuery';
+import { UserCodeFindQuery } from './query/UserCodeFindQuery';
 import { UserCreateQuery } from './query/UserCreateQuery';
 import { UserFindQuery } from './query/UserFindQuery';
 import { UserUpdateQuery } from './query/UserUpdateQuery';
 import { UserCanCreateAuthSpec } from './specs/UserCanCreateAuthSpec';
 
-export type { User, UserCode, UserCreateQuery, UserFindQuery, UserUpdateQuery };
+export type {
+  User,
+  UserCode,
+  UserCodeCreateQuery,
+  UserCodeFindQuery,
+  UserCreateQuery,
+  UserFindQuery,
+  UserUpdateQuery,
+};
 
 export { UserCanCreateAuthSpec };

--- a/packages/backend/apps/user/backend-user-domain/src/users/domain/query/UserCodeCreateQuery.ts
+++ b/packages/backend/apps/user/backend-user-domain/src/users/domain/query/UserCodeCreateQuery.ts
@@ -1,0 +1,5 @@
+export interface UserCodeCreateQuery {
+  readonly code: string;
+  readonly id: string;
+  readonly userId: string;
+}

--- a/packages/backend/apps/user/backend-user-domain/src/users/domain/query/UserCodeFindQuery.ts
+++ b/packages/backend/apps/user/backend-user-domain/src/users/domain/query/UserCodeFindQuery.ts
@@ -1,0 +1,4 @@
+export interface UserCodeFindQuery {
+  readonly code?: string;
+  readonly userId?: string;
+}


### PR DESCRIPTION
### Added
- Added `UserCodePersistenceTypeOrmAdapter`.
- Added `DeleteUserCodeTypeOrmService`.
- Added `FindUserCodeTypeOrmService`.
- Added `CreateUserCodeTypeOrmService`.
- Added `UserCodeCreateQueryToUserCodeCreateQueryTypeOrmConverter`.
- Added `UserCodeFindQueryToUserCodeFindQueryTypeOrmConverter`.
- Added `UserCodeDbToUserCodeConverter`.
- Added `UserCodePersistenceOutputPort`.
- Added `UserCodeCreateQuery`.
- Added `UserCodeFindQuery`.

### Changed
- Updated wrong module imports