### PR TITLE
Update PlayerCanPlayCardsSpec to rely on CardCanBePlayedSpec

### DIFF
--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPlayCardsQueryV1Handler.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPlayCardsQueryV1Handler.spec.ts
@@ -4,12 +4,12 @@ import { models as apiModels } from '@cornie-js/api-models';
 import { AppError, AppErrorKind } from '@cornie-js/backend-common';
 import {
   ActiveGame,
+  CurrentPlayerCanPlayCardsSpec,
   GameFindQuery,
   GameOptions,
   GameOptionsFindQuery,
   GameService,
   GameUpdateQuery,
-  PlayerCanPlayCardsSpec,
   PlayerCanUpdateGameSpec,
 } from '@cornie-js/backend-game-domain/games';
 import {
@@ -30,7 +30,7 @@ describe(GameIdPlayCardsQueryV1Handler.name, () => {
   let gamePersistenceOutputPortMock: jest.Mocked<GamePersistenceOutputPort>;
   let gameServiceMock: jest.Mocked<GameService>;
   let playerCanUpdateGameSpecMock: jest.Mocked<PlayerCanUpdateGameSpec>;
-  let playerCanPlayCardsSpecMock: jest.Mocked<PlayerCanPlayCardsSpec>;
+  let currentPlayerCanPlayCardsSpecMock: jest.Mocked<CurrentPlayerCanPlayCardsSpec>;
 
   let gameIdPlayCardsQueryV1Handler: GameIdPlayCardsQueryV1Handler;
 
@@ -52,18 +52,18 @@ describe(GameIdPlayCardsQueryV1Handler.name, () => {
     playerCanUpdateGameSpecMock = {
       isSatisfiedBy: jest.fn(),
     };
-    playerCanPlayCardsSpecMock = {
+    currentPlayerCanPlayCardsSpecMock = {
       isSatisfiedBy: jest.fn(),
     } as Partial<
-      jest.Mocked<PlayerCanPlayCardsSpec>
-    > as jest.Mocked<PlayerCanPlayCardsSpec>;
+      jest.Mocked<CurrentPlayerCanPlayCardsSpec>
+    > as jest.Mocked<CurrentPlayerCanPlayCardsSpec>;
 
     gameIdPlayCardsQueryV1Handler = new GameIdPlayCardsQueryV1Handler(
       gameOptionsPersistenceOutputPortMock,
       gamePersistenceOutputPortMock,
       gameServiceMock,
       playerCanUpdateGameSpecMock,
-      playerCanPlayCardsSpecMock,
+      currentPlayerCanPlayCardsSpecMock,
     );
   });
 
@@ -362,7 +362,9 @@ describe(GameIdPlayCardsQueryV1Handler.name, () => {
 
         playerCanUpdateGameSpecMock.isSatisfiedBy.mockReturnValueOnce(true);
 
-        playerCanPlayCardsSpecMock.isSatisfiedBy.mockReturnValueOnce(false);
+        currentPlayerCanPlayCardsSpecMock.isSatisfiedBy.mockReturnValueOnce(
+          false,
+        );
 
         try {
           await gameIdPlayCardsQueryV1Handler.handle(
@@ -415,13 +417,13 @@ describe(GameIdPlayCardsQueryV1Handler.name, () => {
       });
 
       it('should call playerCanPlayCardsSpec.isSatisfiedBy()', () => {
-        expect(playerCanPlayCardsSpecMock.isSatisfiedBy).toHaveBeenCalledTimes(
-          1,
-        );
-        expect(playerCanPlayCardsSpecMock.isSatisfiedBy).toHaveBeenCalledWith(
-          activeGameFixture.state.slots[
-            gameIdPlayCardsQueryV1Fixture.slotIndex
-          ],
+        expect(
+          currentPlayerCanPlayCardsSpecMock.isSatisfiedBy,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          currentPlayerCanPlayCardsSpecMock.isSatisfiedBy,
+        ).toHaveBeenCalledWith(
+          activeGameFixture,
           gameOptionsFixture,
           gameIdPlayCardsQueryV1Fixture.cardIndexes,
         );
@@ -480,7 +482,9 @@ describe(GameIdPlayCardsQueryV1Handler.name, () => {
 
         playerCanUpdateGameSpecMock.isSatisfiedBy.mockReturnValueOnce(true);
 
-        playerCanPlayCardsSpecMock.isSatisfiedBy.mockReturnValueOnce(true);
+        currentPlayerCanPlayCardsSpecMock.isSatisfiedBy.mockReturnValueOnce(
+          true,
+        );
 
         result = await gameIdPlayCardsQueryV1Handler.handle(
           gameIdFixture,
@@ -529,13 +533,13 @@ describe(GameIdPlayCardsQueryV1Handler.name, () => {
       });
 
       it('should call playerCanPlayCardsSpec.isSatisfiedBy()', () => {
-        expect(playerCanPlayCardsSpecMock.isSatisfiedBy).toHaveBeenCalledTimes(
-          1,
-        );
-        expect(playerCanPlayCardsSpecMock.isSatisfiedBy).toHaveBeenCalledWith(
-          activeGameFixture.state.slots[
-            gameIdPlayCardsQueryV1Fixture.slotIndex
-          ],
+        expect(
+          currentPlayerCanPlayCardsSpecMock.isSatisfiedBy,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          currentPlayerCanPlayCardsSpecMock.isSatisfiedBy,
+        ).toHaveBeenCalledWith(
+          activeGameFixture,
           gameOptionsFixture,
           gameIdPlayCardsQueryV1Fixture.cardIndexes,
         );

--- a/packages/backend/apps/game/backend-game-domain/src/games/adapter/nest/GameDomainModule.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/adapter/nest/GameDomainModule.ts
@@ -3,10 +3,10 @@ import { Module } from '@nestjs/common';
 import { CardDomainModule } from '../../../cards/adapter/nest/CardDomainModule';
 import { GameService } from '../../domain/services/GameService';
 import { CardCanBePlayedSpec } from '../../domain/specs/CardCanBePlayedSpec';
+import { CurrentPlayerCanPlayCardsSpec } from '../../domain/specs/CurrentPlayerCanPlayCardsSpec';
 import { GameCanHoldMoreGameSlotsSpec } from '../../domain/specs/GameCanHoldMoreGameSlotsSpec';
 import { GameCanHoldOnlyOneMoreGameSlotSpec } from '../../domain/specs/GameCanHoldOnlyOneMoreGameSlotSpec';
 import { PlayerCanPassTurnSpec } from '../../domain/specs/PlayerCanPassTurnSpec';
-import { PlayerCanPlayCardsSpec } from '../../domain/specs/PlayerCanPlayCardsSpec';
 import { PlayerCanUpdateGameSpec } from '../../domain/specs/PlayerCanUpdateGameSpec';
 
 @Module({
@@ -16,7 +16,7 @@ import { PlayerCanUpdateGameSpec } from '../../domain/specs/PlayerCanUpdateGameS
     GameCanHoldOnlyOneMoreGameSlotSpec,
     CardCanBePlayedSpec,
     PlayerCanPassTurnSpec,
-    PlayerCanPlayCardsSpec,
+    CurrentPlayerCanPlayCardsSpec,
     PlayerCanUpdateGameSpec,
   ],
   imports: [CardDomainModule],
@@ -26,7 +26,7 @@ import { PlayerCanUpdateGameSpec } from '../../domain/specs/PlayerCanUpdateGameS
     GameCanHoldOnlyOneMoreGameSlotSpec,
     CardCanBePlayedSpec,
     PlayerCanPassTurnSpec,
-    PlayerCanPlayCardsSpec,
+    CurrentPlayerCanPlayCardsSpec,
     PlayerCanUpdateGameSpec,
   ],
 })

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/index.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/index.ts
@@ -21,10 +21,10 @@ import { GameSlotUpdateQuery } from './query/GameSlotUpdateQuery';
 import { GameSpecCreateQuery } from './query/GameSpecCreateQuery';
 import { GameUpdateQuery } from './query/GameUpdateQuery';
 import { GameService } from './services/GameService';
+import { CurrentPlayerCanPlayCardsSpec } from './specs/CurrentPlayerCanPlayCardsSpec';
 import { GameCanHoldMoreGameSlotsSpec } from './specs/GameCanHoldMoreGameSlotsSpec';
 import { GameCanHoldOnlyOneMoreGameSlotSpec } from './specs/GameCanHoldOnlyOneMoreGameSlotSpec';
 import { PlayerCanPassTurnSpec } from './specs/PlayerCanPassTurnSpec';
-import { PlayerCanPlayCardsSpec } from './specs/PlayerCanPlayCardsSpec';
 import { PlayerCanUpdateGameSpec } from './specs/PlayerCanUpdateGameSpec';
 
 export type {
@@ -57,6 +57,6 @@ export {
   GameService,
   GameStatus,
   PlayerCanPassTurnSpec,
-  PlayerCanPlayCardsSpec,
+  CurrentPlayerCanPlayCardsSpec,
   PlayerCanUpdateGameSpec,
 };


### PR DESCRIPTION
### Changed
- Renamed `PlayerCanPlayCardsSpec` to `CurrentPlayerCanPlayCardsSpec`.
- Updated `PlayerCanPlayCardsSpec` to rely on `CardCanBePlayedSpec`.