### PR TITLE
Extract user create logic into use case handler

### DIFF
--- a/packages/backend/apps/user/backend-user-application/src/users/adapter/nest/modules/UserApplicationModule.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/adapter/nest/modules/UserApplicationModule.ts
@@ -10,6 +10,7 @@ import { UserCodeCreateQueryFromUserBuilder } from '../../../application/builder
 import { UserCreateQueryFromUserCreateQueryV1Builder } from '../../../application/converters/UserCreateQueryFromUserCreateQueryV1Builder';
 import { UserUpdateQueryFromUserMeUpdateQueryV1Builder } from '../../../application/converters/UserUpdateQueryFromUserMeUpdateQueryV1Builder';
 import { UserV1FromUserBuilder } from '../../../application/converters/UserV1FromUserBuilder';
+import { CreateUserUseCaseHandler } from '../../../application/handlers/CreateUserUseCaseHandler';
 import { UserCreatedEventHandler } from '../../../application/handlers/UserCreatedEventHandler';
 import { UserUpdatedEventHandler } from '../../../application/handlers/UserUpdatedEventHandler';
 import { UserCodeManagementInputPort } from '../../../application/ports/input/UserCodeManagementInputPort';
@@ -35,6 +36,7 @@ export class UserApplicationModule {
       ],
       module: UserApplicationModule,
       providers: [
+        CreateUserUseCaseHandler,
         UserActivationMailDeliveryOptionsFromUserBuilder,
         UserCodeCreateQueryFromUserBuilder,
         UserCodeManagementInputPort,

--- a/packages/backend/apps/user/backend-user-application/src/users/application/builders/UserActivationMailDeliveryOptionsFromUserBuilder.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/builders/UserActivationMailDeliveryOptionsFromUserBuilder.ts
@@ -36,7 +36,7 @@ export class UserActivationMailDeliveryOptionsFromUserBuilder
   }
 
   #buildConfirmUserUrl(userCode: UserCode): string {
-    return `${this.#frontendBaseUrl}/sign-up/confirm?code=${userCode.code}`;
+    return `${this.#frontendBaseUrl}/register/confirm?code=${userCode.code}`;
   }
 
   #buildHtmlMessage(user: User, userCode: UserCode): string {

--- a/packages/backend/apps/user/backend-user-application/src/users/application/handlers/CreateUserUseCaseHandler.spec.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/handlers/CreateUserUseCaseHandler.spec.ts
@@ -1,0 +1,163 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import {
+  AppError,
+  AppErrorKind,
+  Handler,
+  ReportBasedSpec,
+} from '@cornie-js/backend-common';
+import { User, UserCreateQuery } from '@cornie-js/backend-user-domain/users';
+import {
+  UserCreateQueryFixtures,
+  UserFixtures,
+} from '@cornie-js/backend-user-domain/users/fixtures';
+
+import { UserCreatedEvent } from '../models/UserCreatedEvent';
+import { UserPersistenceOutputPort } from '../ports/output/UserPersistenceOutputPort';
+import { CreateUserUseCaseHandler } from './CreateUserUseCaseHandler';
+
+describe(CreateUserUseCaseHandler.name, () => {
+  let isValidUserCreateQuerySpecMock: jest.Mocked<
+    ReportBasedSpec<[UserCreateQuery], string[]>
+  >;
+  let userCreatedEventHandlerMock: jest.Mocked<
+    Handler<[UserCreatedEvent], void>
+  >;
+
+  let userPersistenceOutputPortMock: jest.Mocked<UserPersistenceOutputPort>;
+
+  let createUserUseCaseHandler: CreateUserUseCaseHandler;
+
+  beforeAll(() => {
+    isValidUserCreateQuerySpecMock = {
+      isSatisfiedOrReport: jest.fn(),
+    };
+    userCreatedEventHandlerMock = {
+      handle: jest.fn(),
+    };
+    userPersistenceOutputPortMock = {
+      create: jest.fn(),
+      delete: jest.fn(),
+      findOne: jest.fn(),
+      update: jest.fn(),
+    };
+
+    createUserUseCaseHandler = new CreateUserUseCaseHandler(
+      isValidUserCreateQuerySpecMock,
+      userCreatedEventHandlerMock,
+      userPersistenceOutputPortMock,
+    );
+  });
+
+  describe('.handle', () => {
+    let userCreateQueryFixture: UserCreateQuery;
+
+    beforeAll(() => {
+      userCreateQueryFixture = UserCreateQueryFixtures.any;
+    });
+
+    describe('when called, and isValidUserCreateQuerySpecMock.isSatisfiedOrReport() returns Left', () => {
+      let errorsFixture: string[];
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        try {
+          errorsFixture = [];
+
+          isValidUserCreateQuerySpecMock.isSatisfiedOrReport.mockReturnValueOnce(
+            {
+              isRight: false,
+              value: errorsFixture,
+            },
+          );
+
+          await createUserUseCaseHandler.handle(userCreateQueryFixture);
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call isValidUserCreateQuerySpec.isSatisfiedOrReport()', () => {
+        expect(
+          isValidUserCreateQuerySpecMock.isSatisfiedOrReport,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          isValidUserCreateQuerySpecMock.isSatisfiedOrReport,
+        ).toHaveBeenCalledWith(userCreateQueryFixture);
+      });
+
+      it('should throw an Error', () => {
+        const expectedErrorProperties: Partial<AppError> = {
+          kind: AppErrorKind.unprocessableOperation,
+          message: expect.stringContaining(
+            'Invalid user create request.',
+          ) as unknown as string,
+        };
+
+        expect(result).toBeInstanceOf(AppError);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProperties),
+        );
+      });
+    });
+
+    describe('when called, and isValidUserCreateQuerySpecMock.isSatisfiedOrReport() returns Right', () => {
+      let userFixture: User;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        userFixture = UserFixtures.any;
+        isValidUserCreateQuerySpecMock.isSatisfiedOrReport.mockReturnValueOnce({
+          isRight: true,
+          value: undefined,
+        });
+        userPersistenceOutputPortMock.create.mockResolvedValueOnce(userFixture);
+        userCreatedEventHandlerMock.handle.mockResolvedValueOnce(undefined);
+
+        result = await createUserUseCaseHandler.handle(userCreateQueryFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call isValidUserCreateQuerySpec.isSatisfiedOrReport()', () => {
+        expect(
+          isValidUserCreateQuerySpecMock.isSatisfiedOrReport,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          isValidUserCreateQuerySpecMock.isSatisfiedOrReport,
+        ).toHaveBeenCalledWith(userCreateQueryFixture);
+      });
+
+      it('should call userPersistenceOutputPort.create()', () => {
+        expect(userPersistenceOutputPortMock.create).toHaveBeenCalledTimes(1);
+        expect(userPersistenceOutputPortMock.create).toHaveBeenCalledWith(
+          userCreateQueryFixture,
+        );
+      });
+
+      it('should call userCreatedEventHandler.handle()', () => {
+        const expectedUserCreatedEvent: UserCreatedEvent = {
+          user: userFixture,
+          userCreateQuery: userCreateQueryFixture,
+        };
+
+        expect(userCreatedEventHandlerMock.handle).toHaveBeenCalledTimes(1);
+        expect(userCreatedEventHandlerMock.handle).toHaveBeenCalledWith(
+          expectedUserCreatedEvent,
+        );
+      });
+
+      it('should return an UserV1', () => {
+        expect(result).toBe(userFixture);
+      });
+    });
+  });
+});

--- a/packages/backend/apps/user/backend-user-application/src/users/application/handlers/CreateUserUseCaseHandler.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/handlers/CreateUserUseCaseHandler.ts
@@ -1,0 +1,70 @@
+import {
+  AppError,
+  AppErrorKind,
+  Either,
+  Handler,
+  ReportBasedSpec,
+} from '@cornie-js/backend-common';
+import {
+  IsValidUserCreateQuerySpec,
+  User,
+  UserCreateQuery,
+} from '@cornie-js/backend-user-domain/users';
+import { Inject, Injectable } from '@nestjs/common';
+
+import { UserCreatedEvent } from '../models/UserCreatedEvent';
+import {
+  UserPersistenceOutputPort,
+  userPersistenceOutputPortSymbol,
+} from '../ports/output/UserPersistenceOutputPort';
+import { UserCreatedEventHandler } from './UserCreatedEventHandler';
+
+@Injectable()
+export class CreateUserUseCaseHandler
+  implements Handler<[UserCreateQuery], User>
+{
+  readonly #isValidUserCreateQuerySpec: ReportBasedSpec<
+    [UserCreateQuery],
+    string[]
+  >;
+  readonly #userCreatedEventHandler: Handler<[UserCreatedEvent], void>;
+  readonly #userPersistenceOutputPort: UserPersistenceOutputPort;
+
+  constructor(
+    @Inject(IsValidUserCreateQuerySpec)
+    isValidUserCreateQuerySpec: ReportBasedSpec<[UserCreateQuery], string[]>,
+    @Inject(UserCreatedEventHandler)
+    userCreatedEventHandler: Handler<[UserCreatedEvent], void>,
+    @Inject(userPersistenceOutputPortSymbol)
+    userPersistenceOutputPort: UserPersistenceOutputPort,
+  ) {
+    this.#isValidUserCreateQuerySpec = isValidUserCreateQuerySpec;
+    this.#userCreatedEventHandler = userCreatedEventHandler;
+    this.#userPersistenceOutputPort = userPersistenceOutputPort;
+  }
+
+  public async handle(userCreateQuery: UserCreateQuery): Promise<User> {
+    const isValidUserCreateQueryResult: Either<string[], undefined> =
+      this.#isValidUserCreateQuerySpec.isSatisfiedOrReport(userCreateQuery);
+
+    if (!isValidUserCreateQueryResult.isRight) {
+      throw new AppError(
+        AppErrorKind.unprocessableOperation,
+        `Invalid user create request. Reasons:
+
+${isValidUserCreateQueryResult.value.join('\n')}`,
+      );
+    }
+
+    const user: User = await this.#userPersistenceOutputPort.create(
+      userCreateQuery,
+    );
+
+    await this.#userCreatedEventHandler.handle({
+      user,
+      userCreateQuery,
+    });
+
+    return user;
+  }
+}


### PR DESCRIPTION
### Added
- Added `CreateUserUseCaseHandler`.

### Changed
- Updated `UserManagementInputPort` to use `CreateUserUseCaseHandler`.
- Updated `UserActivationMailDeliveryOptionsFromUserBuilder.build` with right frontend url.