### PR TITLE
Update game service pass turn update query to handle deck refill

### DIFF
--- a/packages/backend/apps/common/backend-adapter-nodemailer/.gitignore
+++ b/packages/backend/apps/common/backend-adapter-nodemailer/.gitignore
@@ -4,6 +4,9 @@
 # node modules
 /node_modules/
 
+# test coverage reports
+/coverage
+
 # Turborepo files
 .turbo/
 

--- a/packages/backend/apps/common/backend-app-jwt/.gitignore
+++ b/packages/backend/apps/common/backend-app-jwt/.gitignore
@@ -4,6 +4,9 @@
 # node modules
 /node_modules/
 
+# test coverage reports
+/coverage
+
 # Turborepo files
 .turbo/
 

--- a/packages/backend/apps/common/backend-app-uuid/.gitignore
+++ b/packages/backend/apps/common/backend-app-uuid/.gitignore
@@ -4,6 +4,9 @@
 # node modules
 /node_modules/
 
+# test coverage reports
+/coverage
+
 # Turborepo files
 .turbo/
 

--- a/packages/backend/apps/game/backend-app-game-env/.gitignore
+++ b/packages/backend/apps/game/backend-app-game-env/.gitignore
@@ -4,6 +4,9 @@
 # node modules
 /node_modules/
 
+# test coverage reports
+/coverage
+
 # Turborepo files
 .turbo/
 

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/.gitignore
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/.gitignore
@@ -4,6 +4,9 @@
 # node modules
 /node_modules/
 
+# test coverage reports
+/coverage
+
 # Turborepo files
 .turbo/
 

--- a/packages/backend/apps/game/backend-game-application/.gitignore
+++ b/packages/backend/apps/game/backend-game-application/.gitignore
@@ -4,6 +4,9 @@
 # node modules
 /node_modules/
 
+# test coverage reports
+/coverage
+
 # Turborepo files
 .turbo/
 

--- a/packages/backend/apps/game/backend-game-domain/.gitignore
+++ b/packages/backend/apps/game/backend-game-domain/.gitignore
@@ -4,6 +4,9 @@
 # node modules
 /node_modules/
 
+# test coverage reports
+/coverage
+
 # Turborepo files
 .turbo/
 

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/ActiveGameFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/ActiveGameFixtures.ts
@@ -149,7 +149,7 @@ export class ActiveGameFixtures {
     };
   }
 
-  public static get withGameSlotsAmountTwoAndDeckWithSpecOneWithAmount120(): ActiveGame {
+  public static get withGameSlotsAmountTwoAndSpecWithCardsWithSpecOneWithAmount120(): ActiveGame {
     const anyActiveGameFixture: ActiveGame = ActiveGameFixtures.any;
 
     return {
@@ -160,6 +160,47 @@ export class ActiveGameFixtures {
       },
       state: {
         ...anyActiveGameFixture.state,
+        slots: [
+          ActiveGameSlotFixtures.withPositionZero,
+          ActiveGameSlotFixtures.withPositionOne,
+        ],
+      },
+    };
+  }
+
+  public static get withGameSlotsAmountTwoAndStateWithDeckWithSpecOneWithAmount120(): ActiveGame {
+    const anyActiveGameFixture: ActiveGame = ActiveGameFixtures.any;
+
+    return {
+      ...anyActiveGameFixture,
+      spec: {
+        cards: [GameCardSpecFixtures.withAmount120],
+        gameSlotsAmount: 2,
+      },
+      state: {
+        ...anyActiveGameFixture.state,
+        deck: [GameCardSpecFixtures.withAmount120],
+        slots: [
+          ActiveGameSlotFixtures.withPositionZero,
+          ActiveGameSlotFixtures.withPositionOne,
+        ],
+      },
+    };
+  }
+
+  public static get withGameSlotsAmountTwoAndStateWithDeckEmptyAndDiscardPileWithSpecOneWithAmount120(): ActiveGame {
+    const anyActiveGameFixture: ActiveGame = ActiveGameFixtures.any;
+
+    return {
+      ...anyActiveGameFixture,
+      spec: {
+        cards: [GameCardSpecFixtures.withAmount120],
+        gameSlotsAmount: 2,
+      },
+      state: {
+        ...anyActiveGameFixture.state,
+        deck: [],
+        discardPile: [GameCardSpecFixtures.withAmount120],
         slots: [
           ActiveGameSlotFixtures.withPositionZero,
           ActiveGameSlotFixtures.withPositionOne,

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/services/GameService.spec.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/services/GameService.spec.ts
@@ -41,7 +41,7 @@ describe(GameService.name, () => {
 
       beforeAll(() => {
         const baseFixture: ActiveGame =
-          ActiveGameFixtures.withGameSlotsAmountTwoAndDeckWithSpecOneWithAmount120;
+          ActiveGameFixtures.withGameSlotsAmountTwoAndStateWithDeckWithSpecOneWithAmount120;
 
         gameFixture = {
           ...baseFixture,
@@ -110,7 +110,7 @@ describe(GameService.name, () => {
 
       beforeAll(() => {
         const baseFixture: ActiveGame =
-          ActiveGameFixtures.withGameSlotsAmountTwoAndDeckWithSpecOneWithAmount120;
+          ActiveGameFixtures.withGameSlotsAmountTwoAndStateWithDeckWithSpecOneWithAmount120;
 
         gameFixture = {
           ...baseFixture,
@@ -176,12 +176,86 @@ describe(GameService.name, () => {
       });
     });
 
+    describe('having a Game with two players and not enough deck cards and enouth discard pile cards and currentTurnCardsPlayed false and currentPlayingSlotIndex 1 and drawCount 2', () => {
+      let gameFixture: ActiveGame;
+
+      let deckCardSpec: GameCardSpec;
+
+      beforeAll(() => {
+        const baseFixture: ActiveGame =
+          ActiveGameFixtures.withGameSlotsAmountTwoAndStateWithDeckEmptyAndDiscardPileWithSpecOneWithAmount120;
+
+        gameFixture = {
+          ...baseFixture,
+          state: {
+            ...baseFixture.state,
+            currentPlayingSlotIndex: 1,
+            currentTurnCardsPlayed: false,
+            drawCount: 2,
+          },
+        };
+
+        [deckCardSpec] = gameFixture.spec.cards as [GameCardSpec];
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = gameService.buildPassTurnGameUpdateQuery(gameFixture);
+        });
+
+        it('should return a GameUpdateQuery', () => {
+          const currentPlayingGameSlotCards: Card[] = (
+            gameFixture.state.slots[
+              gameFixture.state.currentPlayingSlotIndex
+            ] as ActiveGameSlot
+          ).cards;
+
+          const expectedGameUpdateQuery: GameUpdateQuery = {
+            currentPlayingSlotIndex: 0,
+            currentTurnCardsPlayed: false,
+            deck: [
+              {
+                amount: deckCardSpec.amount - 2,
+                card: deckCardSpec.card,
+              },
+            ],
+            discardPile: [],
+            drawCount: 0,
+            gameFindQuery: {
+              id: gameFixture.id,
+              state: {
+                currentPlayingSlotIndex:
+                  gameFixture.state.currentPlayingSlotIndex,
+              },
+            },
+            gameSlotUpdateQueries: [
+              {
+                cards: [
+                  ...currentPlayingGameSlotCards,
+                  deckCardSpec.card,
+                  deckCardSpec.card,
+                ],
+                gameSlotFindQuery: {
+                  gameId: gameFixture.id,
+                  position: gameFixture.state.currentPlayingSlotIndex,
+                },
+              },
+            ],
+          };
+
+          expect(result).toStrictEqual(expectedGameUpdateQuery);
+        });
+      });
+    });
+
     describe('having a Game with two players and enough cards and currentTurnCardsPlayed true and currentPlayingSlotIndex 0', () => {
       let gameFixture: ActiveGame;
 
       beforeAll(() => {
         const baseFixture: ActiveGame =
-          ActiveGameFixtures.withGameSlotsAmountTwoAndDeckWithSpecOneWithAmount120;
+          ActiveGameFixtures.withGameSlotsAmountTwoAndStateWithDeckWithSpecOneWithAmount120;
 
         gameFixture = {
           ...baseFixture,

--- a/packages/backend/apps/user/backend-app-user-env/.gitignore
+++ b/packages/backend/apps/user/backend-app-user-env/.gitignore
@@ -4,6 +4,9 @@
 # node modules
 /node_modules/
 
+# test coverage reports
+/coverage
+
 # Turborepo files
 .turbo/
 

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/.gitignore
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/.gitignore
@@ -4,6 +4,9 @@
 # node modules
 /node_modules/
 
+# test coverage reports
+/coverage
+
 # Turborepo files
 .turbo/
 

--- a/packages/backend/apps/user/backend-user-application/.gitignore
+++ b/packages/backend/apps/user/backend-user-application/.gitignore
@@ -4,6 +4,9 @@
 # node modules
 /node_modules/
 
+# test coverage reports
+/coverage
+
 # Turborepo files
 .turbo/
 

--- a/packages/backend/apps/user/backend-user-domain/.gitignore
+++ b/packages/backend/apps/user/backend-user-domain/.gitignore
@@ -4,6 +4,9 @@
 # node modules
 /node_modules/
 
+# test coverage reports
+/coverage
+
 # Turborepo files
 .turbo/
 

--- a/packages/backend/libraries/backend-common/src/error/application/models/AppError.ts
+++ b/packages/backend/libraries/backend-common/src/error/application/models/AppError.ts
@@ -20,4 +20,11 @@ export class AppError extends Error {
       (value as Record<string | symbol, unknown>)[isAppErrorSymbol] === true
     );
   }
+
+  public static isAppErrorOfKind(
+    value: unknown,
+    kind: AppErrorKind,
+  ): value is AppError {
+    return AppError.isAppError(value) && value.kind === kind;
+  }
 }

--- a/packages/backend/libraries/backend-db/.gitignore
+++ b/packages/backend/libraries/backend-db/.gitignore
@@ -4,6 +4,9 @@
 # node modules
 /node_modules/
 
+# test coverage reports
+/coverage
+
 # Turborepo files
 .turbo/
 

--- a/packages/backend/libraries/backend-env/.gitignore
+++ b/packages/backend/libraries/backend-env/.gitignore
@@ -4,6 +4,9 @@
 # node modules
 /node_modules/
 
+# test coverage reports
+/coverage
+
 # Turborepo files
 .turbo/
 

--- a/packages/backend/libraries/backend-http/.gitignore
+++ b/packages/backend/libraries/backend-http/.gitignore
@@ -4,5 +4,8 @@
 # node modules
 /node_modules/
 
+# test coverage reports
+/coverage
+
 # Turborepo files
 .turbo/

--- a/packages/backend/libraries/backend-jwt/.gitignore
+++ b/packages/backend/libraries/backend-jwt/.gitignore
@@ -4,5 +4,8 @@
 # node modules
 /node_modules/
 
+# test coverage reports
+/coverage
+
 # Turborepo files
 .turbo/

--- a/packages/backend/services/backend-service-game/.gitignore
+++ b/packages/backend/services/backend-service-game/.gitignore
@@ -7,6 +7,9 @@
 # node modules
 /node_modules/
 
+# test coverage reports
+/coverage
+
 # Turborepo files
 .turbo/
 

--- a/packages/backend/services/backend-service-user/.gitignore
+++ b/packages/backend/services/backend-service-user/.gitignore
@@ -7,6 +7,9 @@
 # node modules
 /node_modules/
 
+# test coverage reports
+/coverage
+
 # Turborepo files
 .turbo/
 

--- a/packages/backend/tools/backend-jest-config/lib/config/getJestProjectConfig.js
+++ b/packages/backend/tools/backend-jest-config/lib/config/getJestProjectConfig.js
@@ -10,7 +10,7 @@ function getJestProjectConfig(projectName, testMatch, testPathIgnorePatterns) {
   /** @type { !import("@jest/types").Config.InitialProjectOptions } */
   const projectConfig = {
     displayName: projectName,
-    coveragePathIgnorePatterns: ['/node_modules/'],
+    coveragePathIgnorePatterns: ['/fixtures/', '/node_modules/'],
     coverageThreshold: {
       global: {
         branches: 70,


### PR DESCRIPTION
### Changed
- Update `GameService.buildPassTurnGameUpdateQuery` to handle card deck refill.
- Updated `AppError` with `isAppErrorOfKind`.
- Updated jest base config to avoid covering fixtures.
- Update `gitignore` files with coverage folder.