### PR TITLE
Extract draw initial cards logic to GameDrawService

### DIFF
--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameInitialDrawsMutationFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameInitialDrawsMutationFixtures.ts
@@ -1,0 +1,20 @@
+import { CardFixtures } from '../../../cards/domain/fixtures';
+import { GameInitialDrawsMutation } from '../valueObjects/GameInitialDrawsMutation';
+import { GameCardSpecFixtures } from './GameCardSpecFixtures';
+
+export class GameInitialDrawsMutationFixtures {
+  public static get any(): GameInitialDrawsMutation {
+    return {
+      cards: [[CardFixtures.any]],
+      currentCard: CardFixtures.any,
+      deck: [GameCardSpecFixtures.any],
+    };
+  }
+
+  public static get withCardsOneCardArray(): GameInitialDrawsMutation {
+    return {
+      ...GameInitialDrawsMutationFixtures.any,
+      cards: [[CardFixtures.any]],
+    };
+  }
+}

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/valueObjects/GameInitialDrawsMutation.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/valueObjects/GameInitialDrawsMutation.ts
@@ -1,8 +1,8 @@
 import { Card } from '../../../cards/domain/valueObjects/Card';
 import { GameCardSpec } from './GameCardSpec';
 
-export interface GameInitialDraws {
+export interface GameInitialDrawsMutation {
   currentCard: Card;
-  playersCards: Card[][];
-  remainingDeck: GameCardSpec[];
+  cards: Card[][];
+  deck: GameCardSpec[];
 }


### PR DESCRIPTION
### Changed
- Updated `GameDrawService` with `calculateInitialCardsDrawMutation`.
- Updated `GameService` to rely on `GameDrawService.calculateInitialCardsDrawMutation`.