### PR TITLE
Update typeorm services to rely on InstanceChecker

### DIFF
--- a/packages/backend/libraries/backend-db/src/persistence/services/typeorm/DeleteTypeOrmService.spec.ts
+++ b/packages/backend/libraries/backend-db/src/persistence/services/typeorm/DeleteTypeOrmService.spec.ts
@@ -1,5 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
+jest.mock('../../utils/typeorm/findManyOptionsToFindOptionsWhere');
+jest.mock('../../utils/typeorm/isQueryBuilder');
+
 import {
   FindManyOptions,
   FindOptionsWhere,
@@ -8,10 +11,9 @@ import {
   WhereExpressionBuilder,
 } from 'typeorm';
 
-jest.mock('../../utils/typeorm/findManyOptionsToFindOptionsWhere');
-
 import { QueryToFindQueryTypeOrmConverter } from '../../converters/typeorm/QueryToFindQueryTypeOrmConverter';
 import { findManyOptionsToFindOptionsWhere } from '../../utils/typeorm/findManyOptionsToFindOptionsWhere';
+import { isQueryBuilder } from '../../utils/typeorm/isQueryBuilder';
 import { DeleteTypeOrmService } from './DeleteTypeOrmService';
 
 interface ModelTest {
@@ -79,6 +81,7 @@ describe(DeleteTypeOrmService.name, () => {
           where: findOptionsWhereFixture,
         };
 
+        (isQueryBuilder as unknown as jest.Mock).mockReturnValueOnce(false);
         (
           queryToQueryTypeOrmConverterMock.convert as jest.Mock<
             (query: QueryTest) => Promise<FindManyOptions<ModelTest>>
@@ -141,6 +144,7 @@ describe(DeleteTypeOrmService.name, () => {
           fooValue: 'foo-value',
         };
 
+        (isQueryBuilder as unknown as jest.Mock).mockReturnValueOnce(true);
         (
           queryToQueryTypeOrmConverterMock.convert as jest.Mock<
             (

--- a/packages/backend/libraries/backend-db/src/persistence/services/typeorm/DeleteTypeOrmService.ts
+++ b/packages/backend/libraries/backend-db/src/persistence/services/typeorm/DeleteTypeOrmService.ts
@@ -10,6 +10,7 @@ import {
 import { QueryToFindQueryTypeOrmConverter } from '../../converters/typeorm/QueryToFindQueryTypeOrmConverter';
 import { QueryWithQueryBuilderToFindQueryTypeOrmConverter } from '../../converters/typeorm/QueryWithQueryBuilderToFindQueryTypeOrmConverter';
 import { findManyOptionsToFindOptionsWhere } from '../../utils/typeorm/findManyOptionsToFindOptionsWhere';
+import { isQueryBuilder } from '../../utils/typeorm/isQueryBuilder';
 
 export class DeleteTypeOrmService<TModelDb extends ObjectLiteral, TQuery> {
   readonly #repository: Repository<TModelDb>;
@@ -44,7 +45,7 @@ export class DeleteTypeOrmService<TModelDb extends ObjectLiteral, TQuery> {
       >
     ).convert(query, deleteQueryBuilder);
 
-    if (findQueryTypeOrmOrQueryBuilder instanceof QueryBuilder) {
+    if (isQueryBuilder<TModelDb>(findQueryTypeOrmOrQueryBuilder)) {
       await (
         findQueryTypeOrmOrQueryBuilder as DeleteQueryBuilder<TModelDb>
       ).execute();

--- a/packages/backend/libraries/backend-db/src/persistence/services/typeorm/FindTypeOrmService.spec.ts
+++ b/packages/backend/libraries/backend-db/src/persistence/services/typeorm/FindTypeOrmService.spec.ts
@@ -1,5 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
+jest.mock('../../utils/typeorm/isQueryBuilder');
+
 import { Converter, ConverterAsync } from '@cornie-js/backend-common';
 import {
   FindManyOptions,
@@ -10,6 +12,7 @@ import {
 } from 'typeorm';
 
 import { QueryToFindQueryTypeOrmConverter } from '../../converters/typeorm/QueryToFindQueryTypeOrmConverter';
+import { isQueryBuilder } from '../../utils/typeorm/isQueryBuilder';
 import { FindTypeOrmService } from './FindTypeOrmService';
 
 interface ModelTest {
@@ -33,18 +36,13 @@ describe(FindTypeOrmService.name, () => {
   let findTypeOrmService: FindTypeOrmService<ModelTest, ModelTest, QueryTest>;
 
   beforeAll(() => {
-    queryBuilderMock = Object.assign(
-      Object.create(
-        SelectQueryBuilder.prototype,
-      ) as SelectQueryBuilder<ModelTest>,
-      {
-        getMany: jest.fn(),
-        getOne: jest.fn(),
-        select: jest.fn().mockReturnThis(),
-      } as Partial<jest.Mocked<SelectQueryBuilder<ModelTest>>> as jest.Mocked<
-        SelectQueryBuilder<ModelTest>
-      >,
-    );
+    queryBuilderMock = {
+      getMany: jest.fn(),
+      getOne: jest.fn(),
+      select: jest.fn().mockReturnThis(),
+    } as Partial<jest.Mocked<SelectQueryBuilder<ModelTest>>> as jest.Mocked<
+      SelectQueryBuilder<ModelTest>
+    >;
 
     repositoryMock = {
       createQueryBuilder: jest.fn().mockReturnValue(queryBuilderMock),
@@ -94,6 +92,7 @@ describe(FindTypeOrmService.name, () => {
         };
         queryTypeOrmFixture = {};
 
+        (isQueryBuilder as unknown as jest.Mock).mockReturnValueOnce(false);
         (
           modelDbToModelConverterMock as jest.Mocked<
             ConverterAsync<ModelTest, ModelTest>
@@ -151,6 +150,7 @@ describe(FindTypeOrmService.name, () => {
         };
         queryTypeOrmFixture = {};
 
+        (isQueryBuilder as unknown as jest.Mock).mockReturnValueOnce(false);
         (
           modelDbToModelConverterMock as jest.Mocked<
             ConverterAsync<ModelTest, ModelTest>
@@ -190,6 +190,7 @@ describe(FindTypeOrmService.name, () => {
           fooValue: 'bar',
         };
 
+        (isQueryBuilder as unknown as jest.Mock).mockReturnValueOnce(true);
         (
           modelDbToModelConverterMock as jest.Mocked<
             ConverterAsync<ModelTest, ModelTest>
@@ -233,6 +234,7 @@ describe(FindTypeOrmService.name, () => {
         };
         queryTypeOrmFixture = {};
 
+        (isQueryBuilder as unknown as jest.Mock).mockReturnValueOnce(false);
         (
           queryToQueryTypeOrmConverterMock.convert as jest.Mock<
             (query: QueryTest) => Promise<FindManyOptions<ModelTest>>
@@ -288,6 +290,7 @@ describe(FindTypeOrmService.name, () => {
         };
         queryTypeOrmFixture = {};
 
+        (isQueryBuilder as unknown as jest.Mock).mockReturnValueOnce(false);
         (
           modelDbToModelConverterMock as jest.Mocked<
             ConverterAsync<ModelTest, ModelTest>
@@ -347,6 +350,7 @@ describe(FindTypeOrmService.name, () => {
           fooValue: 'bar',
         };
 
+        (isQueryBuilder as unknown as jest.Mock).mockReturnValueOnce(true);
         (
           queryToQueryTypeOrmConverterMock.convert as jest.Mock<
             (
@@ -401,6 +405,7 @@ describe(FindTypeOrmService.name, () => {
           fooValue: 'bar',
         };
 
+        (isQueryBuilder as unknown as jest.Mock).mockReturnValueOnce(true);
         (
           queryToQueryTypeOrmConverterMock.convert as jest.Mock<
             (

--- a/packages/backend/libraries/backend-db/src/persistence/services/typeorm/FindTypeOrmService.ts
+++ b/packages/backend/libraries/backend-db/src/persistence/services/typeorm/FindTypeOrmService.ts
@@ -10,6 +10,7 @@ import {
 
 import { QueryToFindQueryTypeOrmConverter } from '../../converters/typeorm/QueryToFindQueryTypeOrmConverter';
 import { QueryWithQueryBuilderToFindQueryTypeOrmConverter } from '../../converters/typeorm/QueryWithQueryBuilderToFindQueryTypeOrmConverter';
+import { isQueryBuilder } from '../../utils/typeorm/isQueryBuilder';
 
 export class FindTypeOrmService<
   TModel,
@@ -114,7 +115,7 @@ export class FindTypeOrmService<
 
     let outputDb: TOutputDb;
 
-    if (findQueryTypeOrmOrQueryBuilder instanceof QueryBuilder) {
+    if (isQueryBuilder<TModelDb>(findQueryTypeOrmOrQueryBuilder)) {
       outputDb = await findByQueryBuilder(
         findQueryTypeOrmOrQueryBuilder as SelectQueryBuilder<TModelDb>,
       );

--- a/packages/backend/libraries/backend-db/src/persistence/services/typeorm/InsertTypeOrmService.spec.ts
+++ b/packages/backend/libraries/backend-db/src/persistence/services/typeorm/InsertTypeOrmService.spec.ts
@@ -1,9 +1,12 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
+jest.mock('../../utils/typeorm/isQueryBuilder');
+
 import { Converter, ConverterAsync } from '@cornie-js/backend-common';
 import { FindManyOptions, InsertResult, Repository } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 
+import { isQueryBuilder } from '../../utils/typeorm/isQueryBuilder';
 import { InsertTypeOrmService } from './InsertTypeOrmService';
 
 interface ModelTest {
@@ -95,6 +98,7 @@ describe(InsertTypeOrmService.name, () => {
 
         typeOrmQueryFixture = {};
 
+        (isQueryBuilder as unknown as jest.Mock).mockReturnValueOnce(false);
         repositoryMock.find.mockResolvedValueOnce([modelFixture]);
         repositoryMock.insert.mockResolvedValueOnce(insertResultFixture);
         (
@@ -175,6 +179,7 @@ describe(InsertTypeOrmService.name, () => {
 
         typeOrmQueryFixture = {};
 
+        (isQueryBuilder as unknown as jest.Mock).mockReturnValueOnce(false);
         repositoryMock.find.mockResolvedValueOnce([modelFixture]);
         repositoryMock.insert.mockResolvedValueOnce(insertResultFixture);
         (
@@ -225,6 +230,7 @@ describe(InsertTypeOrmService.name, () => {
           identifiers: [{ id: 'sample-id' }],
         } as Partial<InsertResult> as InsertResult;
 
+        (isQueryBuilder as unknown as jest.Mock).mockReturnValueOnce(false);
         repositoryMock.find.mockResolvedValueOnce([modelFixture]);
         repositoryMock.insert.mockResolvedValueOnce(insertResultFixture);
         (
@@ -291,6 +297,7 @@ describe(InsertTypeOrmService.name, () => {
 
         typeOrmQueryFixture = [{}];
 
+        (isQueryBuilder as unknown as jest.Mock).mockReturnValueOnce(false);
         repositoryMock.find.mockResolvedValueOnce([modelFixture]);
         repositoryMock.insert.mockResolvedValueOnce(insertResultFixture);
         (
@@ -373,6 +380,7 @@ describe(InsertTypeOrmService.name, () => {
 
         typeOrmQueryFixture = {};
 
+        (isQueryBuilder as unknown as jest.Mock).mockReturnValueOnce(false);
         repositoryMock.find.mockResolvedValueOnce([modelFixture]);
         repositoryMock.insert.mockResolvedValueOnce(insertResultFixture);
         (

--- a/packages/backend/libraries/backend-db/src/persistence/services/typeorm/UpdateTypeOrmService.spec.ts
+++ b/packages/backend/libraries/backend-db/src/persistence/services/typeorm/UpdateTypeOrmService.spec.ts
@@ -1,5 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
+jest.mock('../../utils/typeorm/findManyOptionsToFindOptionsWhere');
+jest.mock('../../utils/typeorm/isQueryBuilder');
+
 import { ConverterAsync } from '@cornie-js/backend-common';
 import {
   FindManyOptions,
@@ -11,10 +14,9 @@ import {
 } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 
-jest.mock('../../utils/typeorm/findManyOptionsToFindOptionsWhere');
-
 import { QueryToFindQueryTypeOrmConverter } from '../../converters/typeorm/QueryToFindQueryTypeOrmConverter';
 import { findManyOptionsToFindOptionsWhere } from '../../utils/typeorm/findManyOptionsToFindOptionsWhere';
+import { isQueryBuilder } from '../../utils/typeorm/isQueryBuilder';
 import { UpdateTypeOrmService } from './UpdateTypeOrmService';
 
 interface ModelTest {
@@ -94,6 +96,7 @@ describe(UpdateTypeOrmService.name, () => {
           foo: 'sample-string-modified',
         };
 
+        (isQueryBuilder as unknown as jest.Mock).mockReturnValueOnce(false);
         (
           updateQueryToFindQueryTypeOrmConverterMock.convert as jest.Mock<
             (query: QueryTest) => Promise<FindManyOptions<ModelTest>>
@@ -163,6 +166,7 @@ describe(UpdateTypeOrmService.name, () => {
           foo: 'sample-string-modified',
         };
 
+        (isQueryBuilder as unknown as jest.Mock).mockReturnValueOnce(true);
         (
           updateQueryToFindQueryTypeOrmConverterMock.convert as jest.Mock<
             (

--- a/packages/backend/libraries/backend-db/src/persistence/services/typeorm/UpdateTypeOrmService.ts
+++ b/packages/backend/libraries/backend-db/src/persistence/services/typeorm/UpdateTypeOrmService.ts
@@ -11,6 +11,7 @@ import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity
 import { QueryToFindQueryTypeOrmConverter } from '../../converters/typeorm/QueryToFindQueryTypeOrmConverter';
 import { QueryWithQueryBuilderToFindQueryTypeOrmConverter } from '../../converters/typeorm/QueryWithQueryBuilderToFindQueryTypeOrmConverter';
 import { findManyOptionsToFindOptionsWhere } from '../../utils/typeorm/findManyOptionsToFindOptionsWhere';
+import { isQueryBuilder } from '../../utils/typeorm/isQueryBuilder';
 
 export class UpdateTypeOrmService<TModelDb extends ObjectLiteral, TQuery> {
   readonly #repository: Repository<TModelDb>;
@@ -60,7 +61,7 @@ export class UpdateTypeOrmService<TModelDb extends ObjectLiteral, TQuery> {
     const setQueryTypeOrm: QueryDeepPartialEntity<TModelDb> =
       await this.#updateQueryToSetQueryTypeOrmConverter.convert(query);
 
-    if (findQueryTypeOrmOrQueryBuilder instanceof QueryBuilder) {
+    if (isQueryBuilder<TModelDb>(findQueryTypeOrmOrQueryBuilder)) {
       await (findQueryTypeOrmOrQueryBuilder as UpdateQueryBuilder<TModelDb>)
         .set(setQueryTypeOrm)
         .execute();

--- a/packages/backend/libraries/backend-db/src/persistence/utils/typeorm/isQueryBuilder.spec.ts
+++ b/packages/backend/libraries/backend-db/src/persistence/utils/typeorm/isQueryBuilder.spec.ts
@@ -1,0 +1,124 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('typeorm', () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+  const originalTypeOrmModule: any = jest.requireActual('typeorm');
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const originalInstanceChecker: typeof InstanceChecker =
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    originalTypeOrmModule.InstanceChecker;
+
+  const instanceCheckerMock: typeof InstanceChecker = {
+    ...originalInstanceChecker,
+    isDeleteQueryBuilder: jest.fn() as unknown as (
+      obj: unknown,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) => obj is DeleteQueryBuilder<any>,
+    isInsertQueryBuilder: jest.fn() as unknown as (
+      obj: unknown,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) => obj is InsertQueryBuilder<any>,
+    isRelationQueryBuilder: jest.fn() as unknown as (
+      obj: unknown,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) => obj is RelationQueryBuilder<any>,
+    isSelectQueryBuilder: jest.fn() as unknown as (
+      obj: unknown,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) => obj is SelectQueryBuilder<any>,
+    isSoftDeleteQueryBuilder: jest.fn() as unknown as (
+      obj: unknown,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) => obj is SoftDeleteQueryBuilder<any>,
+    isUpdateQueryBuilder: jest.fn() as unknown as (
+      obj: unknown,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) => obj is UpdateQueryBuilder<any>,
+  } as typeof InstanceChecker;
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return {
+    ...originalTypeOrmModule,
+    InstanceChecker: instanceCheckerMock,
+  };
+});
+
+import {
+  DeleteQueryBuilder,
+  InsertQueryBuilder,
+  InstanceChecker,
+  RelationQueryBuilder,
+  SelectQueryBuilder,
+  UpdateQueryBuilder,
+} from 'typeorm';
+import { SoftDeleteQueryBuilder } from 'typeorm/query-builder/SoftDeleteQueryBuilder.js';
+
+import { isQueryBuilder } from './isQueryBuilder';
+
+const instanceCheckerMethods: (keyof typeof InstanceChecker)[] = [
+  'isDeleteQueryBuilder',
+  'isInsertQueryBuilder',
+  'isRelationQueryBuilder',
+  'isSelectQueryBuilder',
+  'isSoftDeleteQueryBuilder',
+  'isUpdateQueryBuilder',
+];
+
+describe(isQueryBuilder.name, () => {
+  let objectFixture: unknown;
+
+  beforeAll(() => {
+    objectFixture = Symbol();
+  });
+
+  describe.each<keyof typeof InstanceChecker>(instanceCheckerMethods)(
+    'when called, and InstanceChecker.%s returns true',
+    (method: keyof typeof InstanceChecker) => {
+      let result: unknown;
+
+      beforeAll(() => {
+        (
+          InstanceChecker[method] as unknown as jest.Mock<() => boolean>
+        ).mockReturnValueOnce(true);
+
+        result = isQueryBuilder(objectFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it(`should call InstanceChecker.${method}()`, () => {
+        expect(InstanceChecker[method]).toHaveBeenCalledTimes(1);
+        expect(InstanceChecker[method]).toHaveBeenCalledWith(objectFixture);
+      });
+
+      it('should return true', () => {
+        expect(result).toBe(true);
+      });
+    },
+  );
+
+  describe('when called, and InstanceChecker methods return false', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      for (const method of instanceCheckerMethods) {
+        (
+          InstanceChecker[method] as unknown as jest.Mock<() => boolean>
+        ).mockReturnValueOnce(false);
+      }
+
+      result = isQueryBuilder(objectFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should return fallse', () => {
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/packages/backend/libraries/backend-db/src/persistence/utils/typeorm/isQueryBuilder.ts
+++ b/packages/backend/libraries/backend-db/src/persistence/utils/typeorm/isQueryBuilder.ts
@@ -1,0 +1,14 @@
+import { InstanceChecker, ObjectLiteral, QueryBuilder } from 'typeorm';
+
+export function isQueryBuilder<TEntity extends ObjectLiteral>(
+  object: unknown,
+): object is QueryBuilder<TEntity> {
+  return (
+    InstanceChecker.isDeleteQueryBuilder(object) ||
+    InstanceChecker.isInsertQueryBuilder(object) ||
+    InstanceChecker.isRelationQueryBuilder(object) ||
+    InstanceChecker.isSelectQueryBuilder(object) ||
+    InstanceChecker.isSoftDeleteQueryBuilder(object) ||
+    InstanceChecker.isUpdateQueryBuilder(object)
+  );
+}


### PR DESCRIPTION
### Changed
- Fixed `typeorm` services to correctly detect query builders through `InstanceChecker`.