### PR TITLE
Update AuthMiddleware with abstraction over composition

### DIFF
--- a/packages/backend/apps/game/backend-game-application/src/auth/application/middlewares/AuthMiddleware.ts
+++ b/packages/backend/apps/game/backend-game-application/src/auth/application/middlewares/AuthMiddleware.ts
@@ -1,3 +1,4 @@
+import { UserV1 } from '@cornie-js/api-models/lib/models/types';
 import { EnvironmentService } from '@cornie-js/backend-app-game-env';
 import { JwtService } from '@cornie-js/backend-app-jwt';
 import * as backendHttp from '@cornie-js/backend-http';
@@ -8,6 +9,8 @@ import { UserManagementInputPort } from '../../../users/application/ports/input/
 
 @Injectable()
 export class AuthMiddleware extends backendHttp.AuthMiddleware<UserJwtPayload> {
+  readonly #userManagementInputPort: UserManagementInputPort;
+
   constructor(
     @Inject(EnvironmentService)
     environmentService: EnvironmentService,
@@ -19,11 +22,16 @@ export class AuthMiddleware extends backendHttp.AuthMiddleware<UserJwtPayload> {
     super(
       environmentService.getEnvironment().apiBackendServiceSecret,
       jwtService,
-      userManagementInputPort,
     );
+
+    this.#userManagementInputPort = userManagementInputPort;
   }
 
-  protected _getUserId(jwtPayload: UserJwtPayload): string {
+  protected override async _findUser(id: string): Promise<UserV1 | undefined> {
+    return this.#userManagementInputPort.findOne(id);
+  }
+
+  protected override _getUserId(jwtPayload: UserJwtPayload): string {
     return jwtPayload.sub;
   }
 }

--- a/packages/backend/apps/user/backend-user-application/src/auth/application/middlewares/AuthMiddleware.ts
+++ b/packages/backend/apps/user/backend-user-application/src/auth/application/middlewares/AuthMiddleware.ts
@@ -1,3 +1,4 @@
+import { UserV1 } from '@cornie-js/api-models/lib/models/types';
 import { JwtService } from '@cornie-js/backend-app-jwt';
 import { EnvironmentService } from '@cornie-js/backend-app-user-env';
 import * as backendHttp from '@cornie-js/backend-http';
@@ -8,6 +9,8 @@ import { UserManagementInputPort } from '../../../users/application/ports/input/
 
 @Injectable()
 export class AuthMiddleware extends backendHttp.AuthMiddleware<UserJwtPayload> {
+  readonly #userManagementInputPort: UserManagementInputPort;
+
   constructor(
     @Inject(EnvironmentService)
     environmentService: EnvironmentService,
@@ -19,11 +22,16 @@ export class AuthMiddleware extends backendHttp.AuthMiddleware<UserJwtPayload> {
     super(
       environmentService.getEnvironment().apiBackendServiceSecret,
       jwtService,
-      userManagementInputPort,
     );
+
+    this.#userManagementInputPort = userManagementInputPort;
   }
 
-  protected _getUserId(jwtPayload: UserJwtPayload): string {
+  protected override async _findUser(id: string): Promise<UserV1 | undefined> {
+    return this.#userManagementInputPort.findOne(id);
+  }
+
+  protected override _getUserId(jwtPayload: UserJwtPayload): string {
     return jwtPayload.sub;
   }
 }

--- a/packages/backend/libraries/backend-http/src/index.ts
+++ b/packages/backend/libraries/backend-http/src/index.ts
@@ -34,7 +34,6 @@ import { SseConsumer } from './http/application/modules/SseConsumer';
 import { SsePublisher } from './http/application/modules/SsePublisher';
 import { SseTeardownExecutor } from './http/application/modules/SseTeardownExecutor';
 import { AuthMiddleware } from './user/application/middleware/AuthMiddleware';
-import { UserManagementInputPort } from './user/application/ports/input/UserManagementInputPort';
 
 export type {
   Auth,
@@ -51,7 +50,6 @@ export type {
   SseConsumer,
   SseTeardownExecutor,
   UserAuth,
-  UserManagementInputPort,
 };
 
 export {

--- a/packages/backend/libraries/backend-http/src/user/application/middleware/AuthMiddleware.ts
+++ b/packages/backend/libraries/backend-http/src/user/application/middleware/AuthMiddleware.ts
@@ -11,7 +11,6 @@ import { RequestWithBody } from '../../../http/application/models/RequestWithBod
 import { Response } from '../../../http/application/models/Response';
 import { ResponseWithBody } from '../../../http/application/models/ResponseWithBody';
 import { Middleware } from '../../../http/application/modules/Middleware';
-import { UserManagementInputPort } from '../ports/input/UserManagementInputPort';
 
 // Auth headers are not case sensitive. Consider https://github.com/fastify/help/issues/71
 const AUTH_HEADER_NAME: string = 'authorization';
@@ -23,16 +22,10 @@ export abstract class AuthMiddleware<
 {
   readonly #backendServicesSecret: string;
   readonly #jwtService: JwtService<TPayload>;
-  readonly #userManagementInputPort: UserManagementInputPort;
 
-  constructor(
-    backendServicesSecret: string,
-    jwtService: JwtService<TPayload>,
-    userManagementInputPort: UserManagementInputPort,
-  ) {
+  constructor(backendServicesSecret: string, jwtService: JwtService<TPayload>) {
     this.#backendServicesSecret = backendServicesSecret;
     this.#jwtService = jwtService;
-    this.#userManagementInputPort = userManagementInputPort;
   }
 
   public async handle(
@@ -98,7 +91,7 @@ export abstract class AuthMiddleware<
     const userId: string = this._getUserId(jwtPayload);
 
     const userV1OrUndefined: apiModels.UserV1 | undefined =
-      await this.#userManagementInputPort.findOne(userId);
+      await this._findUser(userId);
 
     if (userV1OrUndefined === undefined) {
       throw new AppError(
@@ -116,6 +109,10 @@ export abstract class AuthMiddleware<
       user: userV1OrUndefined,
     };
   }
+
+  protected abstract _findUser(
+    id: string,
+  ): Promise<apiModels.UserV1 | undefined>;
 
   protected abstract _getUserId(jwtPayload: TPayload): string;
 }

--- a/packages/backend/libraries/backend-http/src/user/application/ports/input/UserManagementInputPort.ts
+++ b/packages/backend/libraries/backend-http/src/user/application/ports/input/UserManagementInputPort.ts
@@ -1,5 +1,0 @@
-import { models as apiModels } from '@cornie-js/api-models';
-
-export interface UserManagementInputPort {
-  findOne(id: string): Promise<apiModels.UserV1 | undefined>;
-}


### PR DESCRIPTION
### Changed
- Updated `AuthMiddleware` with an abstract `_findUser` method instead of relying on a `userManagementInputPort`.