### PR TITLE
Update user query resolver types

### DIFF
--- a/packages/api/libraries/api-graphql-models/src/models/types.ts
+++ b/packages/api/libraries/api-graphql-models/src/models/types.ts
@@ -64,14 +64,6 @@ export type EmailPasswordAuthCreateInput = {
   password: Scalars['String']['input'];
 };
 
-export type FindUsersQuery = {
-  userById: Maybe<User>;
-};
-
-export type FindUsersQueryUserByIdArgs = {
-  id: Scalars['ID']['input'];
-};
-
 export type RootMutation = AuthMutation &
   UserMutation & {
     __typename?: 'RootMutation';
@@ -97,7 +89,7 @@ export type RootMutationUpdateUserMeArgs = {
   userUpdateInput: UserUpdateInput;
 };
 
-export type RootQuery = FindUsersQuery & {
+export type RootQuery = UserQuery & {
   __typename?: 'RootQuery';
   userById: Maybe<User>;
 };
@@ -130,6 +122,14 @@ export type UserMutationCreateUserArgs = {
 
 export type UserMutationUpdateUserMeArgs = {
   userUpdateInput: UserUpdateInput;
+};
+
+export type UserQuery = {
+  userById: Maybe<User>;
+};
+
+export type UserQueryUserByIdArgs = {
+  id: Scalars['ID']['input'];
 };
 
 export type UserUpdateInput = {
@@ -249,8 +249,8 @@ export type DirectiveResolverFn<
 export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> =
   ResolversObject<{
     AuthMutation: RootMutation;
-    FindUsersQuery: RootQuery;
     UserMutation: RootMutation;
+    UserQuery: RootQuery;
   }>;
 
 /** Mapping between all available schema types and the resolvers types */
@@ -262,9 +262,6 @@ export type ResolversTypes = ResolversObject<{
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
   CodeAuthCreateInput: CodeAuthCreateInput;
   EmailPasswordAuthCreateInput: EmailPasswordAuthCreateInput;
-  FindUsersQuery: ResolverTypeWrapper<
-    ResolversInterfaceTypes<ResolversTypes>['FindUsersQuery']
-  >;
   ID: ResolverTypeWrapper<Scalars['ID']['output']>;
   RootMutation: ResolverTypeWrapper<{}>;
   RootQuery: ResolverTypeWrapper<{}>;
@@ -273,6 +270,9 @@ export type ResolversTypes = ResolversObject<{
   UserCreateInput: UserCreateInput;
   UserMutation: ResolverTypeWrapper<
     ResolversInterfaceTypes<ResolversTypes>['UserMutation']
+  >;
+  UserQuery: ResolverTypeWrapper<
+    ResolversInterfaceTypes<ResolversTypes>['UserQuery']
   >;
   UserUpdateInput: UserUpdateInput;
 }>;
@@ -284,7 +284,6 @@ export type ResolversParentTypes = ResolversObject<{
   Boolean: Scalars['Boolean']['output'];
   CodeAuthCreateInput: CodeAuthCreateInput;
   EmailPasswordAuthCreateInput: EmailPasswordAuthCreateInput;
-  FindUsersQuery: ResolversInterfaceTypes<ResolversParentTypes>['FindUsersQuery'];
   ID: Scalars['ID']['output'];
   RootMutation: {};
   RootQuery: {};
@@ -292,6 +291,7 @@ export type ResolversParentTypes = ResolversObject<{
   User: User;
   UserCreateInput: UserCreateInput;
   UserMutation: ResolversInterfaceTypes<ResolversParentTypes>['UserMutation'];
+  UserQuery: ResolversInterfaceTypes<ResolversParentTypes>['UserQuery'];
   UserUpdateInput: UserUpdateInput;
 }>;
 
@@ -324,20 +324,6 @@ export type AuthMutationResolvers<
       AuthMutationCreateAuthByCredentialsArgs,
       'emailPasswordAuthCreateInput'
     >
-  >;
-}>;
-
-export type FindUsersQueryResolvers<
-  ContextType = any,
-  ParentType extends
-    ResolversParentTypes['FindUsersQuery'] = ResolversParentTypes['FindUsersQuery'],
-> = ResolversObject<{
-  __resolveType: TypeResolveFn<'RootQuery', ParentType, ContextType>;
-  userById: Resolver<
-    Maybe<ResolversTypes['User']>,
-    ParentType,
-    ContextType,
-    RequireFields<FindUsersQueryUserByIdArgs, 'id'>
   >;
 }>;
 
@@ -419,12 +405,26 @@ export type UserMutationResolvers<
   >;
 }>;
 
+export type UserQueryResolvers<
+  ContextType = any,
+  ParentType extends
+    ResolversParentTypes['UserQuery'] = ResolversParentTypes['UserQuery'],
+> = ResolversObject<{
+  __resolveType: TypeResolveFn<'RootQuery', ParentType, ContextType>;
+  userById: Resolver<
+    Maybe<ResolversTypes['User']>,
+    ParentType,
+    ContextType,
+    RequireFields<UserQueryUserByIdArgs, 'id'>
+  >;
+}>;
+
 export type Resolvers<ContextType = any> = ResolversObject<{
   Auth: AuthResolvers<ContextType>;
   AuthMutation: AuthMutationResolvers<ContextType>;
-  FindUsersQuery: FindUsersQueryResolvers<ContextType>;
   RootMutation: RootMutationResolvers<ContextType>;
   RootQuery: RootQueryResolvers<ContextType>;
   User: UserResolvers<ContextType>;
   UserMutation: UserMutationResolvers<ContextType>;
+  UserQuery: UserQueryResolvers<ContextType>;
 }>;

--- a/packages/api/libraries/api-graphql-schemas/schemas/root.graphql
+++ b/packages/api/libraries/api-graphql-schemas/schemas/root.graphql
@@ -3,7 +3,7 @@
 #import AuthMutation from './auth/AuthMutation.graphql'
 #import UserMutation from './users/UserMutation.graphql'
 #import EmailPasswordAuthCreateInput from './auth/EmailPasswordAuthCreateInput.graphql'
-#import FindUsersQuery from './users/FindUsersQuery.graphql'
+#import UserQuery from './users/UserQuery.graphql'
 #import User from './users/User.graphql'
 #import UserCreateInput from './users/UserCreateInput.graphql'
 #import UserUpdateInput from './users/UserUpdateInput.graphql'
@@ -15,7 +15,7 @@ type RootMutation implements AuthMutation & UserMutation {
   updateUserMe(userUpdateInput: UserUpdateInput!): User!
 }
 
-type RootQuery implements FindUsersQuery {
+type RootQuery implements UserQuery {
   userById(id: ID!): User
 }
 

--- a/packages/api/libraries/api-graphql-schemas/schemas/users/UserQuery.graphql
+++ b/packages/api/libraries/api-graphql-schemas/schemas/users/UserQuery.graphql
@@ -1,5 +1,5 @@
 #import User from './User.graphql'
 
-interface FindUsersQuery {
+interface UserQuery {
   userById(id: ID!): User
 }

--- a/packages/api/libraries/api-http-client/src/httpClient/generated/HttpClient.ts
+++ b/packages/api/libraries/api-http-client/src/httpClient/generated/HttpClient.ts
@@ -20,7 +20,7 @@ export class HttpClient {
   ): Promise<
     | Response<Record<string, string>, apiModels.AuthV1, 200>
     | Response<Record<string, string>, apiModels.ErrorV1, 400>
-    | Response<Record<string, string>, apiModels.ErrorV1, 422>
+    | Response<Record<string, string>, apiModels.ErrorV1, 401>
   > {
     return this.#axiosHttpClient.callEndpoint(
       'POST',

--- a/packages/api/libraries/api-openapi-schema/schemas/src/one-game.yaml
+++ b/packages/api/libraries/api-openapi-schema/schemas/src/one-game.yaml
@@ -35,8 +35,8 @@ paths:
             application/json:
               schema:
                 $ref: 'https://onegame.schemas/api/v1/errors/error.json'
-        '422':
-          description: Unprocessable operation
+        '401':
+          description: Unauthorized
           content:
             application/json:
               schema:

--- a/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootQueryResolver.spec.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootQueryResolver.spec.ts
@@ -13,15 +13,12 @@ describe(RootQueryResolver.name, () => {
       graphqlModels.Maybe<graphqlModels.ResolversTypes['User']>,
       unknown,
       Request,
-      graphqlModels.RequireFields<
-        graphqlModels.FindUsersQueryUserByIdArgs,
-        'id'
-      >
+      graphqlModels.RequireFields<graphqlModels.UserQueryUserByIdArgs, 'id'>
     >
   >;
 
-  let findUsersQueryResolverMock: jest.Mocked<
-    graphqlModels.FindUsersQueryResolvers<Request>
+  let userQueryResolverMock: jest.Mocked<
+    graphqlModels.UserQueryResolvers<Request>
   >;
 
   let rootQueryResolver: RootQueryResolver;
@@ -29,13 +26,13 @@ describe(RootQueryResolver.name, () => {
   beforeAll(() => {
     userByIdMock = jest.fn();
 
-    findUsersQueryResolverMock = {
+    userQueryResolverMock = {
       userById: userByIdMock,
     } as Partial<
-      jest.Mocked<graphqlModels.FindUsersQueryResolvers<Request>>
-    > as jest.Mocked<graphqlModels.FindUsersQueryResolvers<Request>>;
+      jest.Mocked<graphqlModels.UserQueryResolvers<Request>>
+    > as jest.Mocked<graphqlModels.UserQueryResolvers<Request>>;
 
-    rootQueryResolver = new RootQueryResolver(findUsersQueryResolverMock);
+    rootQueryResolver = new RootQueryResolver(userQueryResolverMock);
   });
 
   describe('.userById', () => {
@@ -43,7 +40,7 @@ describe(RootQueryResolver.name, () => {
 
     describe('when called', () => {
       let parentFixture: graphqlModels.RootQuery;
-      let argsFixture: graphqlModels.FindUsersQueryUserByIdArgs;
+      let argsFixture: graphqlModels.UserQueryUserByIdArgs;
       let requestFixture: Request;
       let infoFixture: GraphQLResolveInfo;
 
@@ -71,7 +68,7 @@ describe(RootQueryResolver.name, () => {
         jest.clearAllMocks();
       });
 
-      it('should call findUsersQueryResolver.userById()', () => {
+      it('should call userQueryResolver.userById()', () => {
         expect(userByIdMock).toHaveBeenCalledTimes(1);
         expect(userByIdMock).toHaveBeenCalledWith(
           parentFixture,

--- a/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootQueryResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootQueryResolver.ts
@@ -3,30 +3,30 @@ import { Request } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 import { GraphQLResolveInfo } from 'graphql';
 
-import { FindUsersQueryResolver } from '../../../users/application/resolvers/FindUsersQueryResolver';
+import { UserQueryResolver } from '../../../users/application/resolvers/UserQueryResolver';
 
 @Injectable()
 export class RootQueryResolver
   implements graphqlModels.RootQueryResolvers<Request, graphqlModels.RootQuery>
 {
-  readonly #findUsersQueryResolver: graphqlModels.FindUsersQueryResolvers<Request>;
+  readonly #userQueryResolver: graphqlModels.UserQueryResolvers<Request>;
 
   constructor(
-    @Inject(FindUsersQueryResolver)
-    findUsersQueryResolver: graphqlModels.FindUsersQueryResolvers<Request>,
+    @Inject(UserQueryResolver)
+    userQueryResolver: graphqlModels.UserQueryResolvers<Request>,
   ) {
-    this.#findUsersQueryResolver = findUsersQueryResolver;
+    this.#userQueryResolver = userQueryResolver;
   }
 
   public async userById(
     parent: graphqlModels.RootQuery,
-    args: graphqlModels.FindUsersQueryUserByIdArgs,
+    args: graphqlModels.UserQueryUserByIdArgs,
     request: Request,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.User | null> {
     return this.#getResolverFunction(
-      this.#findUsersQueryResolver,
-      this.#findUsersQueryResolver.userById,
+      this.#userQueryResolver,
+      this.#userQueryResolver.userById,
     )(parent, args, request, info);
   }
 

--- a/packages/backend/apps/gateway/backend-gateway-application/src/auth/application/resolvers/AuthMutationResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/auth/application/resolvers/AuthMutationResolver.ts
@@ -29,7 +29,7 @@ export class AuthMutationResolver
       case 200:
         return httpResponse.body;
       case 400:
-      case 422:
+      case 401:
         throw new AppError(
           AppErrorKind.unprocessableOperation,
           httpResponse.body.description,
@@ -52,7 +52,7 @@ export class AuthMutationResolver
       case 200:
         return httpResponse.body;
       case 400:
-      case 422:
+      case 401:
         throw new AppError(
           AppErrorKind.unprocessableOperation,
           httpResponse.body.description,

--- a/packages/backend/apps/gateway/backend-gateway-application/src/users/adapter/nest/modules/UsersModule.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/users/adapter/nest/modules/UsersModule.ts
@@ -1,12 +1,12 @@
 import { Module } from '@nestjs/common';
 
 import { HttpApiModule } from '../../../../foundation/api/adapter/nest/modules/HttpApiModule';
-import { FindUsersQueryResolver } from '../../../application/resolvers/FindUsersQueryResolver';
 import { UserMutationResolver } from '../../../application/resolvers/UserMutationResolver';
+import { UserQueryResolver } from '../../../application/resolvers/UserQueryResolver';
 
 @Module({
-  exports: [FindUsersQueryResolver, UserMutationResolver],
+  exports: [UserQueryResolver, UserMutationResolver],
   imports: [HttpApiModule],
-  providers: [FindUsersQueryResolver, UserMutationResolver],
+  providers: [UserQueryResolver, UserMutationResolver],
 })
 export class UsersModule {}

--- a/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserQueryResolver.spec.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserQueryResolver.spec.ts
@@ -7,25 +7,25 @@ import { AppError, AppErrorKind } from '@cornie-js/backend-common';
 import { Request } from '@cornie-js/backend-http';
 import { HttpStatus } from '@nestjs/common';
 
-import { FindUsersQueryResolver } from './FindUsersQueryResolver';
+import { UserQueryResolver } from './UserQueryResolver';
 
-describe(FindUsersQueryResolver.name, () => {
+describe(UserQueryResolver.name, () => {
   let httpClientMock: jest.Mocked<HttpClient>;
 
-  let findUsersQueryResolver: FindUsersQueryResolver;
+  let userQueryResolver: UserQueryResolver;
 
   beforeAll(() => {
     httpClientMock = {
       getUser: jest.fn(),
     } as Partial<jest.Mocked<HttpClient>> as jest.Mocked<HttpClient>;
 
-    findUsersQueryResolver = new FindUsersQueryResolver(httpClientMock);
+    userQueryResolver = new UserQueryResolver(httpClientMock);
   });
 
   describe('.userById', () => {
     describe('when called, and httpClient.getUser() returns a Response with status code 200', () => {
       let firstArgFixture: unknown;
-      let argsFixture: graphqlModels.FindUsersQueryUserByIdArgs;
+      let argsFixture: graphqlModels.UserQueryUserByIdArgs;
       let requestFixture: Request;
 
       let responseFixture: Response<
@@ -59,7 +59,7 @@ describe(FindUsersQueryResolver.name, () => {
 
         httpClientMock.getUser.mockResolvedValueOnce(responseFixture);
 
-        result = await findUsersQueryResolver.userById(
+        result = await userQueryResolver.userById(
           firstArgFixture,
           argsFixture,
           requestFixture,
@@ -87,7 +87,7 @@ describe(FindUsersQueryResolver.name, () => {
 
     describe('when called, and httpClient.getUser() returns a Response with status code 401', () => {
       let firstArgFixture: unknown;
-      let argsFixture: graphqlModels.FindUsersQueryUserByIdArgs;
+      let argsFixture: graphqlModels.UserQueryUserByIdArgs;
       let requestFixture: Request;
 
       let responseFixture: Response<
@@ -120,7 +120,7 @@ describe(FindUsersQueryResolver.name, () => {
         httpClientMock.getUser.mockResolvedValueOnce(responseFixture);
 
         try {
-          await findUsersQueryResolver.userById(
+          await userQueryResolver.userById(
             firstArgFixture,
             argsFixture,
             requestFixture,
@@ -159,7 +159,7 @@ describe(FindUsersQueryResolver.name, () => {
 
     describe('when called, and httpClient.getUser() returns a Response with status code 404', () => {
       let firstArgFixture: unknown;
-      let argsFixture: graphqlModels.FindUsersQueryUserByIdArgs;
+      let argsFixture: graphqlModels.UserQueryUserByIdArgs;
       let requestFixture: Request;
 
       let responseFixture: Response<
@@ -191,7 +191,7 @@ describe(FindUsersQueryResolver.name, () => {
 
         httpClientMock.getUser.mockResolvedValueOnce(responseFixture);
 
-        result = await findUsersQueryResolver.userById(
+        result = await userQueryResolver.userById(
           firstArgFixture,
           argsFixture,
           requestFixture,

--- a/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserQueryResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserQueryResolver.ts
@@ -7,8 +7,8 @@ import { Request } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
 @Injectable()
-export class FindUsersQueryResolver
-  implements graphqlModels.FindUsersQueryResolvers<Request>
+export class UserQueryResolver
+  implements graphqlModels.UserQueryResolvers<Request>
 {
   readonly #httpClient: HttpClient;
 
@@ -18,7 +18,7 @@ export class FindUsersQueryResolver
 
   public async userById(
     _: unknown,
-    args: graphqlModels.FindUsersQueryUserByIdArgs,
+    args: graphqlModels.UserQueryUserByIdArgs,
     request: Request,
   ): Promise<graphqlModels.User | null> {
     const httpResponse: Awaited<ReturnType<HttpClient['getUser']>> =

--- a/packages/backend/libraries/backend-http/src/http/application/modules/DelayedSseConsumer.ts
+++ b/packages/backend/libraries/backend-http/src/http/application/modules/DelayedSseConsumer.ts
@@ -6,7 +6,7 @@ import { SseConsumer } from './SseConsumer';
 @Injectable()
 export class DelayedSseConsumer implements SseConsumer {
   #delayEnabled: boolean;
-  #innerConsumer: SseConsumer;
+  readonly #innerConsumer: SseConsumer;
   #pendingOnComplete: boolean;
   #eventsBuffer: MessageEvent[] | undefined;
 


### PR DESCRIPTION
### Changed
- Renamed `FindUsersQuery` to `UserQuery`.
- Updated `POST /v1/auth` with right HTTP response codes.