### PR TITLE
Docker node renovatebot constraints

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,22 @@
       "automerge": true,
       "matchUpdateTypes": ["patch", "minor"],
       "excludePackageNames": ["turbo", "typescript"]
+    },
+    {
+      "matchPackagePatterns": ["node"],
+      "groupName": "auto merge docker node on patch or minor",
+      "automerge": true,
+      "matchDatasources": ["docker"],
+      "allowedVersions": "^20.0.0",
+      "labels": ["docker-update"]
+    },
+    {
+      "enabled": false,
+      "matchPackagePatterns": ["node"],
+      "groupName": "forbid docker node on unstable versions",
+      "matchDatasources": ["docker"],
+      "allowedVersions": "^21.0.0",
+      "labels": ["docker-update"]
     }
   ]
 }

--- a/packages/backend/tools/backend-maildev/docker/maildev.Dockerfile
+++ b/packages/backend/tools/backend-maildev/docker/maildev.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.18.2-alpine
+FROM node:20.9.0-alpine
 
 RUN npm i -g maildev@2.0.5
 


### PR DESCRIPTION
### Changed
- Updated renovate config with docker node policy.
- Updated maildev docker image to be on top node 20.