### PR TITLE
Update graphql service with create game mutation

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "migrations:run": "turbo run migrations:run",
     "prepare": "husky install",
     "serve": "trap '' INT TERM; turbo run serve --concurrency=9000",
+    "serve:api:graphql": "pnpm run serve:api:rest --filter=backend-service-gateway",
     "serve:api:rest": "pnpm run serve --filter=backend-maildev --filter=backend-dev-redis-pub-sub --filter=backend-dev-user-db --filter=backend-dev-game-db --filter=backend-service-user --filter=backend-service-game --filter=backend-dev-proxy",
     "serve:api:rest:docs": "pnpm run serve --filter=backend-dev-swagger-ui",
     "start:e2e": "turbo run start:e2e",

--- a/packages/api/libraries/api-graphql-models/src/models/types.ts
+++ b/packages/api/libraries/api-graphql-models/src/models/types.ts
@@ -212,10 +212,12 @@ export type ReverseCard = {
 export type ReverseCardKind = 'reverse';
 
 export type RootMutation = AuthMutation &
+  GameMutation &
   UserMutation & {
     __typename?: 'RootMutation';
     createAuthByCode: Auth;
     createAuthByCredentials: Auth;
+    createGame: Game;
     createUser: User;
     updateUserMe: User;
   };
@@ -226,6 +228,10 @@ export type RootMutationCreateAuthByCodeArgs = {
 
 export type RootMutationCreateAuthByCredentialsArgs = {
   emailPasswordAuthCreateInput: EmailPasswordAuthCreateInput;
+};
+
+export type RootMutationCreateGameArgs = {
+  gameCreateInput: GameCreateInput;
 };
 
 export type RootMutationCreateUserArgs = {
@@ -430,9 +436,15 @@ export type ResolversUnionTypes<RefType extends Record<string, unknown>> =
 /** Mapping of interface types */
 export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> =
   ResolversObject<{
-    AuthMutation: RootMutation;
-    GameMutation: never;
-    UserMutation: RootMutation;
+    AuthMutation: Omit<RootMutation, 'createGame'> & {
+      createGame: RefType['Game'];
+    };
+    GameMutation: Omit<RootMutation, 'createGame'> & {
+      createGame: RefType['Game'];
+    };
+    UserMutation: Omit<RootMutation, 'createGame'> & {
+      createGame: RefType['Game'];
+    };
     UserQuery: RootQuery;
   }>;
 
@@ -731,7 +743,7 @@ export type GameMutationResolvers<
   ParentType extends
     ResolversParentTypes['GameMutation'] = ResolversParentTypes['GameMutation'],
 > = ResolversObject<{
-  __resolveType: TypeResolveFn<null, ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'RootMutation', ParentType, ContextType>;
   createGame: Resolver<
     ResolversTypes['Game'],
     ParentType,
@@ -837,6 +849,12 @@ export type RootMutationResolvers<
       RootMutationCreateAuthByCredentialsArgs,
       'emailPasswordAuthCreateInput'
     >
+  >;
+  createGame: Resolver<
+    ResolversTypes['Game'],
+    ParentType,
+    ContextType,
+    RequireFields<RootMutationCreateGameArgs, 'gameCreateInput'>
   >;
   createUser: Resolver<
     ResolversTypes['User'],

--- a/packages/api/libraries/api-graphql-schemas/schemas/root.graphql
+++ b/packages/api/libraries/api-graphql-schemas/schemas/root.graphql
@@ -1,6 +1,9 @@
 #import Auth from './auth/Auth.graphql'
 #import CodeAuthCreateInput from './auth/CodeAuthCreateInput.graphql'
 #import AuthMutation from './auth/AuthMutation.graphql'
+#import Game from './games/Game.graphql'
+#import GameCreateInput from './games/GameCreateInput.graphql'
+#import GameMutation from './games/GameMutation.graphql'
 #import UserMutation from './users/UserMutation.graphql'
 #import EmailPasswordAuthCreateInput from './auth/EmailPasswordAuthCreateInput.graphql'
 #import UserQuery from './users/UserQuery.graphql'
@@ -8,9 +11,10 @@
 #import UserCreateInput from './users/UserCreateInput.graphql'
 #import UserUpdateInput from './users/UserUpdateInput.graphql'
 
-type RootMutation implements AuthMutation & UserMutation {
+type RootMutation implements AuthMutation & GameMutation & UserMutation {
   createAuthByCode(codeAuthCreateInput: CodeAuthCreateInput!): Auth!
   createAuthByCredentials(emailPasswordAuthCreateInput: EmailPasswordAuthCreateInput!): Auth!
+  createGame(gameCreateInput: GameCreateInput!): Game!
   createUser(userCreateInput: UserCreateInput!): User!
   updateUserMe(userUpdateInput: UserUpdateInput!): User!
 }

--- a/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/ApplicationResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/ApplicationResolver.ts
@@ -2,22 +2,28 @@ import { models as graphqlModels } from '@cornie-js/api-graphql-models';
 import { Request } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
+import { GameResolver } from '../../../games/application/resolvers/GameResolver';
 import { RootMutationResolver } from './RootMutationResolver';
 import { RootQueryResolver } from './RootQueryResolver';
 
 @Injectable()
 export class ApplicationResolver implements Partial<graphqlModels.Resolvers> {
   // eslint-disable-next-line @typescript-eslint/naming-convention
+  public readonly Game: graphqlModels.GameResolvers<Request>;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   public readonly RootMutation: graphqlModels.RootMutationResolvers<Request>;
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public readonly RootQuery: graphqlModels.RootQueryResolvers<Request>;
 
   constructor(
+    @Inject(GameResolver)
+    gameResolver: graphqlModels.GameResolvers<Request>,
     @Inject(RootMutationResolver)
     rootMutationResolver: graphqlModels.RootMutationResolvers<Request>,
     @Inject(RootQueryResolver)
     rootQueryResolver: graphqlModels.RootQueryResolvers<Request>,
   ) {
+    this.Game = gameResolver;
     this.RootMutation = rootMutationResolver;
     this.RootQuery = rootQueryResolver;
   }

--- a/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootMutationResolver.spec.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootMutationResolver.spec.ts
@@ -1,7 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 import { models as graphqlModels } from '@cornie-js/api-graphql-models';
-import { models as apiModels } from '@cornie-js/api-models';
 import { Request } from '@cornie-js/backend-http';
 import { GraphQLResolveInfo } from 'graphql';
 
@@ -30,6 +29,17 @@ describe(RootMutationResolver.name, () => {
       >
     >
   >;
+  let createGameMock: jest.Mock<
+    graphqlModels.ResolverFn<
+      graphqlModels.ResolversTypes['Game'],
+      unknown,
+      Request,
+      graphqlModels.RequireFields<
+        graphqlModels.GameMutationCreateGameArgs,
+        'gameCreateInput'
+      >
+    >
+  >;
   let createUserMock: jest.Mock<
     graphqlModels.ResolverFn<
       graphqlModels.ResolversTypes['User'],
@@ -45,6 +55,9 @@ describe(RootMutationResolver.name, () => {
   let authMutationMock: jest.Mocked<
     graphqlModels.AuthMutationResolvers<Request>
   >;
+  let gameMutationMock: jest.Mocked<
+    graphqlModels.GameMutationResolvers<Request>
+  >;
   let userMutationMock: jest.Mocked<
     graphqlModels.UserMutationResolvers<Request>
   >;
@@ -54,6 +67,7 @@ describe(RootMutationResolver.name, () => {
   beforeAll(() => {
     createAuthByCodeMock = jest.fn();
     createAuthByCredentialsMock = jest.fn();
+    createGameMock = jest.fn();
     createUserMock = jest.fn();
 
     authMutationMock = {
@@ -63,6 +77,12 @@ describe(RootMutationResolver.name, () => {
       jest.Mocked<graphqlModels.AuthMutationResolvers<Request>>
     > as jest.Mocked<graphqlModels.AuthMutationResolvers<Request>>;
 
+    gameMutationMock = {
+      createGame: createGameMock,
+    } as Partial<
+      jest.Mocked<graphqlModels.GameMutationResolvers<Request>>
+    > as jest.Mocked<graphqlModels.GameMutationResolvers<Request>>;
+
     userMutationMock = {
       createUser: createUserMock,
     } as Partial<
@@ -71,15 +91,16 @@ describe(RootMutationResolver.name, () => {
 
     rootMutationResolver = new RootMutationResolver(
       authMutationMock,
+      gameMutationMock,
       userMutationMock,
     );
   });
 
   describe('.createAuthByCode', () => {
-    let authV1Fixture: apiModels.AuthV1;
+    let graphQlAuthFixture: graphqlModels.Auth;
 
     beforeAll(() => {
-      authV1Fixture = {
+      graphQlAuthFixture = {
         jwt: 'jwt fixture',
       };
     });
@@ -103,7 +124,7 @@ describe(RootMutationResolver.name, () => {
         infoFixture = Symbol() as unknown as GraphQLResolveInfo;
 
         createAuthByCodeMock.mockReturnValueOnce(
-          Promise.resolve(authV1Fixture),
+          Promise.resolve(graphQlAuthFixture),
         );
 
         result = await rootMutationResolver.createAuthByCode(
@@ -128,17 +149,17 @@ describe(RootMutationResolver.name, () => {
         );
       });
 
-      it('should return AuthV1', () => {
-        expect(result).toBe(authV1Fixture);
+      it('should return GraphQL Auth', () => {
+        expect(result).toBe(graphQlAuthFixture);
       });
     });
   });
 
   describe('.createAuthByCredentials', () => {
-    let authV1Fixture: apiModels.AuthV1;
+    let graphQlAuthFixture: graphqlModels.Auth;
 
     beforeAll(() => {
-      authV1Fixture = {
+      graphQlAuthFixture = {
         jwt: 'jwt fixture',
       };
     });
@@ -163,7 +184,7 @@ describe(RootMutationResolver.name, () => {
         infoFixture = Symbol() as unknown as GraphQLResolveInfo;
 
         createAuthByCredentialsMock.mockReturnValueOnce(
-          Promise.resolve(authV1Fixture),
+          Promise.resolve(graphQlAuthFixture),
         );
 
         result = await rootMutationResolver.createAuthByCredentials(
@@ -188,17 +209,69 @@ describe(RootMutationResolver.name, () => {
         );
       });
 
-      it('should return AuthV1', () => {
-        expect(result).toBe(authV1Fixture);
+      it('should return GraphQL Auth', () => {
+        expect(result).toBe(graphQlAuthFixture);
+      });
+    });
+  });
+
+  describe('.createGame', () => {
+    let graphQlGameFixture: graphqlModels.Game;
+
+    beforeAll(() => {
+      graphQlGameFixture = Symbol() as unknown as graphqlModels.Game;
+    });
+
+    describe('when called', () => {
+      let parentFixture: graphqlModels.RootMutation;
+      let argsFixture: graphqlModels.GameMutationCreateGameArgs;
+      let requestFixture: Request;
+      let infoFixture: GraphQLResolveInfo;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        parentFixture = Symbol() as unknown as graphqlModels.RootMutation;
+        argsFixture =
+          Symbol() as unknown as graphqlModels.GameMutationCreateGameArgs;
+        requestFixture = Symbol() as unknown as Request;
+        infoFixture = Symbol() as unknown as GraphQLResolveInfo;
+
+        createGameMock.mockReturnValueOnce(Promise.resolve(graphQlGameFixture));
+
+        result = await rootMutationResolver.createGame(
+          parentFixture,
+          argsFixture,
+          requestFixture,
+          infoFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call gameMutation.createGame()', () => {
+        expect(createGameMock).toHaveBeenCalledTimes(1);
+        expect(createGameMock).toHaveBeenCalledWith(
+          parentFixture,
+          argsFixture,
+          requestFixture,
+          infoFixture,
+        );
+      });
+
+      it('should return GraphQL game', () => {
+        expect(result).toBe(graphQlGameFixture);
       });
     });
   });
 
   describe('.createUser', () => {
-    let userV1Fixture: apiModels.UserV1;
+    let graphQlUserFixture: graphqlModels.User;
 
     beforeAll(() => {
-      userV1Fixture = {
+      graphQlUserFixture = {
         active: false,
         id: 'id',
         name: 'name',
@@ -225,7 +298,7 @@ describe(RootMutationResolver.name, () => {
         requestFixture = Symbol() as unknown as Request;
         infoFixture = Symbol() as unknown as GraphQLResolveInfo;
 
-        createUserMock.mockReturnValueOnce(Promise.resolve(userV1Fixture));
+        createUserMock.mockReturnValueOnce(Promise.resolve(graphQlUserFixture));
 
         result = await rootMutationResolver.createUser(
           parentFixture,
@@ -249,8 +322,8 @@ describe(RootMutationResolver.name, () => {
         );
       });
 
-      it('should return UserV1', () => {
-        expect(result).toBe(userV1Fixture);
+      it('should return GraphQL User', () => {
+        expect(result).toBe(graphQlUserFixture);
       });
     });
   });

--- a/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootMutationResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootMutationResolver.ts
@@ -4,6 +4,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { GraphQLResolveInfo } from 'graphql';
 
 import { AuthMutationResolver } from '../../../auth/application/resolvers/AuthMutationResolver';
+import { GameMutationResolver } from '../../../games/application/resolvers/GameMutationResolver';
 import { UserMutationResolver } from '../../../users/application/resolvers/UserMutationResolver';
 
 @Injectable()
@@ -12,15 +13,19 @@ export class RootMutationResolver
     graphqlModels.RootMutationResolvers<Request, graphqlModels.RootMutation>
 {
   readonly #authMutation: graphqlModels.AuthMutationResolvers<Request>;
+  readonly #gameMutationResolver: graphqlModels.GameMutationResolvers<Request>;
   readonly #userMutation: graphqlModels.UserMutationResolvers<Request>;
 
   constructor(
     @Inject(AuthMutationResolver)
     authMutationResolver: graphqlModels.AuthMutationResolvers<Request>,
+    @Inject(GameMutationResolver)
+    gameMutationResolver: graphqlModels.GameMutationResolvers<Request>,
     @Inject(UserMutationResolver)
     userMutationResolver: graphqlModels.UserMutationResolvers<Request>,
   ) {
     this.#authMutation = authMutationResolver;
+    this.#gameMutationResolver = gameMutationResolver;
     this.#userMutation = userMutationResolver;
   }
 
@@ -45,6 +50,18 @@ export class RootMutationResolver
     return this.#getResolverFunction(
       this.#authMutation,
       this.#authMutation.createAuthByCredentials,
+    )(parent, args, request, info);
+  }
+
+  public async createGame(
+    parent: graphqlModels.RootMutation,
+    args: graphqlModels.GameMutationCreateGameArgs,
+    request: Request,
+    info: GraphQLResolveInfo,
+  ): Promise<graphqlModels.Game> {
+    return this.#getResolverFunction(
+      this.#gameMutationResolver,
+      this.#gameMutationResolver.createGame,
     )(parent, args, request, info);
   }
 

--- a/packages/backend/apps/gateway/backend-gateway-application/src/games/adapter/nest/modules/GamesModule.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/games/adapter/nest/modules/GamesModule.ts
@@ -3,10 +3,11 @@ import { Module } from '@nestjs/common';
 import { HttpApiModule } from '../../../../foundation/api/adapter/nest/modules/HttpApiModule';
 import { GameGraphQlFromGameV1Builder } from '../../../application/builders/GameGraphQlFromGameV1Builder';
 import { GameMutationResolver } from '../../../application/resolvers/GameMutationResolver';
+import { GameResolver } from '../../../application/resolvers/GameResolver';
 
 @Module({
-  exports: [GameMutationResolver],
+  exports: [GameMutationResolver, GameResolver],
   imports: [HttpApiModule],
-  providers: [GameGraphQlFromGameV1Builder, GameMutationResolver],
+  providers: [GameGraphQlFromGameV1Builder, GameMutationResolver, GameResolver],
 })
 export class GamesModule {}

--- a/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameResolver.spec.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameResolver.spec.ts
@@ -1,0 +1,95 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { models as graphqlModels } from '@cornie-js/api-graphql-models';
+
+import { GameResolver } from './GameResolver';
+
+type GameResolvedType = ReturnType<GameResolver['__resolveType']>;
+
+describe(GameResolver.name, () => {
+  let gameResolver: GameResolver;
+
+  beforeAll(() => {
+    gameResolver = new GameResolver();
+  });
+
+  describe('.__resolveType', () => {
+    describe('having an ActiveGame', () => {
+      let activeGameFixture: graphqlModels.ActiveGame;
+
+      beforeAll(() => {
+        activeGameFixture = {
+          state: {
+            status: 'active',
+          } as graphqlModels.ActiveGameState,
+        } as graphqlModels.ActiveGame;
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = gameResolver.__resolveType(activeGameFixture);
+        });
+
+        it('should return the right resolved type', () => {
+          const expected: GameResolvedType = 'ActiveGame';
+
+          expect(result).toBe(expected);
+        });
+      });
+    });
+
+    describe('having a FinishedGame', () => {
+      let activeGameFixture: graphqlModels.FinishedGame;
+
+      beforeAll(() => {
+        activeGameFixture = {
+          state: {
+            status: 'finished',
+          } as graphqlModels.FinishedGameState,
+        } as graphqlModels.FinishedGame;
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = gameResolver.__resolveType(activeGameFixture);
+        });
+
+        it('should return the right resolved type', () => {
+          const expected: GameResolvedType = 'FinishedGame';
+
+          expect(result).toBe(expected);
+        });
+      });
+    });
+
+    describe('having a NonStartedGame', () => {
+      let activeGameFixture: graphqlModels.NonStartedGame;
+
+      beforeAll(() => {
+        activeGameFixture = {
+          state: {
+            status: 'nonStarted',
+          } as graphqlModels.NonStartedGameState,
+        } as graphqlModels.NonStartedGame;
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = gameResolver.__resolveType(activeGameFixture);
+        });
+
+        it('should return the right resolved type', () => {
+          const expected: GameResolvedType = 'NonStartedGame';
+
+          expect(result).toBe(expected);
+        });
+      });
+    });
+  });
+});

--- a/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameResolver.ts
@@ -1,0 +1,23 @@
+import { models as graphqlModels } from '@cornie-js/api-graphql-models';
+import { Request } from '@cornie-js/backend-http';
+import { Injectable } from '@nestjs/common';
+
+type GameResolvedType = ReturnType<GameResolver['__resolveType']>;
+
+const GAME_STATUS_TO_GAME_RESOLVED_TYPE: {
+  [TKey in graphqlModels.Game['state']['status']]: GameResolvedType;
+} = {
+  active: 'ActiveGame',
+  finished: 'FinishedGame',
+  nonStarted: 'NonStartedGame',
+};
+
+@Injectable()
+export class GameResolver implements graphqlModels.GameResolvers<Request> {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  public __resolveType(
+    game: graphqlModels.Game,
+  ): 'ActiveGame' | 'FinishedGame' | 'NonStartedGame' {
+    return GAME_STATUS_TO_GAME_RESOLVED_TYPE[game.state.status];
+  }
+}

--- a/packages/backend/services/backend-service-gateway/src/app/adapter/apollo/calculations/buildApolloApplicationResolver.ts
+++ b/packages/backend/services/backend-service-gateway/src/app/adapter/apollo/calculations/buildApolloApplicationResolver.ts
@@ -9,6 +9,7 @@ export function buildApolloApplicationResolver(
   graphQlErrorFromErrorBuilder: Builder<GraphQLError, [unknown]>,
 ): ApplicationResolver {
   return {
+    Game: applicationResolver.Game,
     RootMutation: {
       createAuthByCode: buildApolloResolver(
         applicationResolver.RootMutation,
@@ -19,6 +20,11 @@ export function buildApolloApplicationResolver(
         applicationResolver.RootMutation,
         graphQlErrorFromErrorBuilder,
         applicationResolver.RootMutation.createAuthByCredentials,
+      ),
+      createGame: buildApolloResolver(
+        applicationResolver.RootMutation,
+        graphQlErrorFromErrorBuilder,
+        applicationResolver.RootMutation.createGame,
       ),
       createUser: buildApolloResolver(
         applicationResolver.RootMutation,


### PR DESCRIPTION
### Added
- Added `GameResolver`.
- Added `serve:api:graphql` script.

### Changed
- Updated `ApplicationResolver` to use `GameResolver`.
- Updated `RootMutation` to implement `GameMutation`.