### PR TITLE
Add get user me graphql query

### DIFF
--- a/packages/api/libraries/api-graphql-models/src/models/types.ts
+++ b/packages/api/libraries/api-graphql-models/src/models/types.ts
@@ -245,6 +245,7 @@ export type RootMutationUpdateUserMeArgs = {
 export type RootQuery = UserQuery & {
   __typename?: 'RootQuery';
   userById: Maybe<User>;
+  userMe: User;
 };
 
 export type RootQueryUserByIdArgs = {
@@ -287,6 +288,7 @@ export type UserMutationUpdateUserMeArgs = {
 
 export type UserQuery = {
   userById: Maybe<User>;
+  userMe: User;
 };
 
 export type UserQueryUserByIdArgs = {
@@ -881,6 +883,7 @@ export type RootQueryResolvers<
     ContextType,
     RequireFields<RootQueryUserByIdArgs, 'id'>
   >;
+  userMe: Resolver<ResolversTypes['User'], ParentType, ContextType>;
 }>;
 
 export type SkipCardResolvers<
@@ -936,6 +939,7 @@ export type UserQueryResolvers<
     ContextType,
     RequireFields<UserQueryUserByIdArgs, 'id'>
   >;
+  userMe: Resolver<ResolversTypes['User'], ParentType, ContextType>;
 }>;
 
 export type WildCardResolvers<

--- a/packages/api/libraries/api-graphql-schemas/schemas/root.graphql
+++ b/packages/api/libraries/api-graphql-schemas/schemas/root.graphql
@@ -21,6 +21,7 @@ type RootMutation implements AuthMutation & GameMutation & UserMutation {
 
 type RootQuery implements UserQuery {
   userById(id: ID!): User
+  userMe: User!
 }
 
 schema {

--- a/packages/api/libraries/api-graphql-schemas/schemas/users/UserQuery.graphql
+++ b/packages/api/libraries/api-graphql-schemas/schemas/users/UserQuery.graphql
@@ -2,4 +2,5 @@
 
 interface UserQuery {
   userById(id: ID!): User
+  userMe: User!
 }

--- a/packages/api/libraries/api-http-client/src/httpClient/generated/HttpClient.ts
+++ b/packages/api/libraries/api-http-client/src/httpClient/generated/HttpClient.ts
@@ -263,8 +263,7 @@ export class HttpClient {
   }): Promise<
     | Response<Record<string, string>, apiModels.UserV1, 200>
     | Response<Record<string, string>, apiModels.ErrorV1, 401>
-    | Response<Record<string, string>, apiModels.ErrorV1, 404>
-    | Response<Record<string, string>, apiModels.ErrorV1, 422>
+    | Response<Record<string, string>, apiModels.ErrorV1, 403>
   > {
     return this.#axiosHttpClient.callEndpoint(
       'GET',

--- a/packages/api/libraries/api-openapi-schema/schemas/src/one-game.yaml
+++ b/packages/api/libraries/api-openapi-schema/schemas/src/one-game.yaml
@@ -427,14 +427,8 @@ paths:
             application/json:
               schema:
                 $ref: 'https://onegame.schemas/api/v1/errors/error.json'
-        '404':
-          description: User not found
-          content:
-            application/json:
-              schema:
-                $ref: 'https://onegame.schemas/api/v1/errors/error.json'
-        '422':
-          description: Unprocessable request
+        '403':
+          description: Invalid credentials
           content:
             application/json:
               schema:

--- a/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootQueryResolver.spec.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootQueryResolver.spec.ts
@@ -17,6 +17,15 @@ describe(RootQueryResolver.name, () => {
     >
   >;
 
+  let userMeMock: jest.Mock<
+    graphqlModels.ResolverFn<
+      graphqlModels.Maybe<graphqlModels.ResolversTypes['User']>,
+      unknown,
+      Request,
+      Record<string, unknown>
+    >
+  >;
+
   let userQueryResolverMock: jest.Mocked<
     graphqlModels.UserQueryResolvers<Request>
   >;
@@ -25,9 +34,11 @@ describe(RootQueryResolver.name, () => {
 
   beforeAll(() => {
     userByIdMock = jest.fn();
+    userMeMock = jest.fn();
 
     userQueryResolverMock = {
       userById: userByIdMock,
+      userMe: userMeMock,
     } as Partial<
       jest.Mocked<graphqlModels.UserQueryResolvers<Request>>
     > as jest.Mocked<graphqlModels.UserQueryResolvers<Request>>;
@@ -71,6 +82,53 @@ describe(RootQueryResolver.name, () => {
       it('should call userQueryResolver.userById()', () => {
         expect(userByIdMock).toHaveBeenCalledTimes(1);
         expect(userByIdMock).toHaveBeenCalledWith(
+          parentFixture,
+          argsFixture,
+          requestFixture,
+          infoFixture,
+        );
+      });
+
+      it('should return UserV1', () => {
+        expect(result).toBe(userV1Fixture);
+      });
+    });
+  });
+
+  describe('.userMe', () => {
+    let userV1Fixture: apiModels.UserV1;
+
+    describe('when called', () => {
+      let parentFixture: graphqlModels.RootQuery;
+      let argsFixture: Record<string, unknown>;
+      let requestFixture: Request;
+      let infoFixture: GraphQLResolveInfo;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        parentFixture = Symbol() as unknown as graphqlModels.RootQuery;
+        argsFixture = {};
+        requestFixture = Symbol() as unknown as Request;
+        infoFixture = Symbol() as unknown as GraphQLResolveInfo;
+
+        userMeMock.mockReturnValueOnce(Promise.resolve(userV1Fixture));
+
+        result = await rootQueryResolver.userMe(
+          parentFixture,
+          argsFixture,
+          requestFixture,
+          infoFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call userQueryResolver.userMe()', () => {
+        expect(userMeMock).toHaveBeenCalledTimes(1);
+        expect(userMeMock).toHaveBeenCalledWith(
           parentFixture,
           argsFixture,
           requestFixture,

--- a/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootQueryResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootQueryResolver.ts
@@ -30,6 +30,18 @@ export class RootQueryResolver
     )(parent, args, request, info);
   }
 
+  public async userMe(
+    parent: graphqlModels.RootQuery,
+    args: Record<string, unknown>,
+    request: Request,
+    info: GraphQLResolveInfo,
+  ): Promise<graphqlModels.User> {
+    return this.#getResolverFunction(
+      this.#userQueryResolver,
+      this.#userQueryResolver.userMe,
+    )(parent, args, request, info);
+  }
+
   #getResolverFunction<TResult, TArgs>(
     self: unknown,
     resolver: graphqlModels.Resolver<

--- a/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserQueryResolver.spec.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserQueryResolver.spec.ts
@@ -17,6 +17,7 @@ describe(UserQueryResolver.name, () => {
   beforeAll(() => {
     httpClientMock = {
       getUser: jest.fn(),
+      getUserMe: jest.fn(),
     } as Partial<jest.Mocked<HttpClient>> as jest.Mocked<HttpClient>;
 
     userQueryResolver = new UserQueryResolver(httpClientMock);
@@ -214,6 +215,199 @@ describe(UserQueryResolver.name, () => {
 
       it('should return null', () => {
         expect(result).toBeNull();
+      });
+    });
+  });
+
+  describe('.userMe', () => {
+    describe('when called, and httpClient.getUserMe() returns a Response with status code 200', () => {
+      let firstArgFixture: unknown;
+      let argsFixture: Record<string, string>;
+      let requestFixture: Request;
+
+      let responseFixture: Response<
+        Record<string, string>,
+        apiModels.UserV1,
+        HttpStatus.OK
+      >;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        firstArgFixture = Symbol();
+        argsFixture = {};
+        requestFixture = {
+          headers: {},
+          query: {},
+          urlParameters: {},
+        };
+
+        responseFixture = {
+          body: {
+            active: false,
+            id: 'id-fixture',
+            name: 'name',
+          },
+          headers: {},
+          statusCode: HttpStatus.OK,
+        };
+
+        httpClientMock.getUserMe.mockResolvedValueOnce(responseFixture);
+
+        result = await userQueryResolver.userMe(
+          firstArgFixture,
+          argsFixture,
+          requestFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call httpClient.getUserMe()', () => {
+        expect(httpClientMock.getUserMe).toHaveBeenCalledTimes(1);
+        expect(httpClientMock.getUserMe).toHaveBeenCalledWith(
+          requestFixture.headers,
+        );
+      });
+
+      it('should return response body', () => {
+        expect(result).toBe(responseFixture.body);
+      });
+    });
+
+    describe('when called, and httpClient.getUserMe() returns a Response with status code 401', () => {
+      let firstArgFixture: unknown;
+      let argsFixture: Record<string, string>;
+      let requestFixture: Request;
+
+      let responseFixture: Response<
+        Record<string, string>,
+        apiModels.ErrorV1,
+        HttpStatus.UNAUTHORIZED
+      >;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        firstArgFixture = Symbol();
+        argsFixture = {};
+        requestFixture = {
+          headers: {},
+          query: {},
+          urlParameters: {},
+        };
+
+        responseFixture = {
+          body: {
+            description: 'Error description fixture',
+          },
+          headers: {},
+          statusCode: HttpStatus.UNAUTHORIZED,
+        };
+
+        httpClientMock.getUserMe.mockResolvedValueOnce(responseFixture);
+
+        try {
+          await userQueryResolver.userMe(
+            firstArgFixture,
+            argsFixture,
+            requestFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call httpClient.getUserMe()', () => {
+        expect(httpClientMock.getUserMe).toHaveBeenCalledTimes(1);
+        expect(httpClientMock.getUserMe).toHaveBeenCalledWith(
+          requestFixture.headers,
+        );
+      });
+
+      it('should throw an AppError', () => {
+        const expectedErrorProperties: Partial<AppError> = {
+          kind: AppErrorKind.missingCredentials,
+          message: responseFixture.body.description,
+        };
+
+        expect(result).toBeInstanceOf(AppError);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProperties),
+        );
+      });
+    });
+
+    describe('when called, and httpClient.getUserMe() returns a Response with status code 403', () => {
+      let firstArgFixture: unknown;
+      let argsFixture: Record<string, string>;
+      let requestFixture: Request;
+
+      let responseFixture: Response<
+        Record<string, string>,
+        apiModels.ErrorV1,
+        HttpStatus.FORBIDDEN
+      >;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        firstArgFixture = Symbol();
+        argsFixture = {};
+        requestFixture = {
+          headers: {},
+          query: {},
+          urlParameters: {},
+        };
+
+        responseFixture = {
+          body: {
+            description: 'Error description fixture',
+          },
+          headers: {},
+          statusCode: HttpStatus.FORBIDDEN,
+        };
+
+        httpClientMock.getUserMe.mockResolvedValueOnce(responseFixture);
+
+        try {
+          await userQueryResolver.userMe(
+            firstArgFixture,
+            argsFixture,
+            requestFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call httpClient.getUserMe()', () => {
+        expect(httpClientMock.getUserMe).toHaveBeenCalledTimes(1);
+        expect(httpClientMock.getUserMe).toHaveBeenCalledWith(
+          requestFixture.headers,
+        );
+      });
+
+      it('should throw an AppError', () => {
+        const expectedErrorProperties: Partial<AppError> = {
+          kind: AppErrorKind.invalidCredentials,
+          message: responseFixture.body.description,
+        };
+
+        expect(result).toBeInstanceOf(AppError);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProperties),
+        );
       });
     });
   });

--- a/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserQueryResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserQueryResolver.ts
@@ -39,6 +39,30 @@ export class UserQueryResolver
     }
   }
 
+  public async userMe(
+    _: unknown,
+    _args: unknown,
+    request: Request,
+  ): Promise<graphqlModels.User> {
+    const httpResponse: Awaited<ReturnType<HttpClient['getUserMe']>> =
+      await this.#httpClient.getUserMe(request.headers);
+
+    switch (httpResponse.statusCode) {
+      case 200:
+        return httpResponse.body;
+      case 401:
+        throw new AppError(
+          AppErrorKind.missingCredentials,
+          httpResponse.body.description,
+        );
+      case 403:
+        throw new AppError(
+          AppErrorKind.invalidCredentials,
+          httpResponse.body.description,
+        );
+    }
+  }
+
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public __resolveType(): never {
     throw new Error('Method not implemented');

--- a/packages/backend/apps/user/backend-user-application/src/users/application/controllers/GetUserV1MeHttpRequestController.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/controllers/GetUserV1MeHttpRequestController.ts
@@ -18,13 +18,13 @@ import { GetUserV1MeRequestParamHandler } from '../handlers/GetUserV1MeRequestPa
 export class GetUserV1MeHttpRequestController extends HttpRequestController<
   Request,
   [apiModels.UserV1],
-  apiModels.UserV1 | undefined
+  apiModels.UserV1
 > {
   constructor(
     @Inject(GetUserV1MeRequestParamHandler)
     requestParamHandler: Handler<[Request], [apiModels.UserV1]>,
     @Inject(SingleEntityGetResponseBuilder)
-    responseBuilder: Builder<Response, [apiModels.UserV1 | undefined]>,
+    responseBuilder: Builder<Response, [apiModels.UserV1]>,
     @Inject(ErrorV1ResponseFromErrorBuilder)
     errorV1ResponseFromErrorBuilder: Builder<
       Response | ResponseWithBody<unknown>,
@@ -43,7 +43,7 @@ export class GetUserV1MeHttpRequestController extends HttpRequestController<
 
   protected async _handleUseCase(
     userV1: apiModels.UserV1,
-  ): Promise<apiModels.UserV1 | undefined> {
+  ): Promise<apiModels.UserV1> {
     return userV1;
   }
 }

--- a/packages/backend/services/backend-service-gateway/src/app/adapter/apollo/calculations/buildApolloApplicationResolver.ts
+++ b/packages/backend/services/backend-service-gateway/src/app/adapter/apollo/calculations/buildApolloApplicationResolver.ts
@@ -43,6 +43,11 @@ export function buildApolloApplicationResolver(
         graphQlErrorFromErrorBuilder,
         applicationResolver.RootQuery.userById,
       ),
+      userMe: buildApolloResolver(
+        applicationResolver.RootQuery,
+        graphQlErrorFromErrorBuilder,
+        applicationResolver.RootQuery.userMe,
+      ),
     },
   };
 }


### PR DESCRIPTION
### Added
- Added `userMe` query.

### Changed
- Updated `QueryResolver` with `userMe`.
- Updated `RootQueryResolver` with `userMe`.
- Updated `GetUserV1MeHttpRequestController` with better types.
- Updated `v1/users/me` docs with right response codes.