### PR TITLE
Add update game graphql mutations

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   },
   "scripts": {
     "build": "turbo run build",
+    "build:api:rest": "turbo run build --filter=backend-service-user --filter=backend-service-game",
+    "build:api:graphql": "pnpm run build:api:rest --filter=backend-service-gateway",
     "close:e2e": "turbo run close:e2e",
     "commit": "commit",
     "format": "turbo run format",

--- a/packages/api/libraries/api-graphql-models/src/models/types.ts
+++ b/packages/api/libraries/api-graphql-models/src/models/types.ts
@@ -167,10 +167,32 @@ export type GameDirection = 'antiClockwise' | 'clockwise';
 
 export type GameMutation = {
   createGame: Game;
+  passGameTurn: Maybe<Game>;
+  playGameCards: Maybe<Game>;
 };
 
 export type GameMutationCreateGameArgs = {
   gameCreateInput: GameCreateInput;
+};
+
+export type GameMutationPassGameTurnArgs = {
+  gameId: Scalars['ID']['input'];
+  gamePassTurnInput: GamePassTurnInput;
+};
+
+export type GameMutationPlayGameCardsArgs = {
+  gameId: Scalars['ID']['input'];
+  gamePlayCardsInput: GamePlayCardsInput;
+};
+
+export type GamePassTurnInput = {
+  slotIndex: Scalars['Int']['input'];
+};
+
+export type GamePlayCardsInput = {
+  cardIndexes: Array<Scalars['Int']['input']>;
+  colorChoice: InputMaybe<CardColor>;
+  slotIndex: Scalars['Int']['input'];
 };
 
 export type GameQuery = {
@@ -238,6 +260,8 @@ export type RootMutation = AuthMutation &
     createAuthByCredentials: Auth;
     createGame: Game;
     createUser: User;
+    passGameTurn: Maybe<Game>;
+    playGameCards: Maybe<Game>;
     updateUserMe: User;
   };
 
@@ -255,6 +279,16 @@ export type RootMutationCreateGameArgs = {
 
 export type RootMutationCreateUserArgs = {
   userCreateInput: UserCreateInput;
+};
+
+export type RootMutationPassGameTurnArgs = {
+  gameId: Scalars['ID']['input'];
+  gamePassTurnInput: GamePassTurnInput;
+};
+
+export type RootMutationPlayGameCardsArgs = {
+  gameId: Scalars['ID']['input'];
+  gamePlayCardsInput: GamePlayCardsInput;
 };
 
 export type RootMutationUpdateUserMeArgs = {
@@ -468,18 +502,33 @@ export type ResolversUnionTypes<RefType extends Record<string, unknown>> =
 /** Mapping of interface types */
 export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> =
   ResolversObject<{
-    AuthMutation: Omit<RootMutation, 'createGame'> & {
+    AuthMutation: Omit<
+      RootMutation,
+      'createGame' | 'passGameTurn' | 'playGameCards'
+    > & {
       createGame: RefType['Game'];
+      passGameTurn: Maybe<RefType['Game']>;
+      playGameCards: Maybe<RefType['Game']>;
     };
-    GameMutation: Omit<RootMutation, 'createGame'> & {
+    GameMutation: Omit<
+      RootMutation,
+      'createGame' | 'passGameTurn' | 'playGameCards'
+    > & {
       createGame: RefType['Game'];
+      passGameTurn: Maybe<RefType['Game']>;
+      playGameCards: Maybe<RefType['Game']>;
     };
     GameQuery: Omit<RootQuery, 'gameById' | 'myGames'> & {
       gameById: Maybe<RefType['Game']>;
       myGames: Array<RefType['Game']>;
     };
-    UserMutation: Omit<RootMutation, 'createGame'> & {
+    UserMutation: Omit<
+      RootMutation,
+      'createGame' | 'passGameTurn' | 'playGameCards'
+    > & {
       createGame: RefType['Game'];
+      passGameTurn: Maybe<RefType['Game']>;
+      playGameCards: Maybe<RefType['Game']>;
     };
     UserQuery: Omit<RootQuery, 'gameById' | 'myGames'> & {
       gameById: Maybe<RefType['Game']>;
@@ -523,6 +572,8 @@ export type ResolversTypes = ResolversObject<{
   GameMutation: ResolverTypeWrapper<
     ResolversInterfaceTypes<ResolversTypes>['GameMutation']
   >;
+  GamePassTurnInput: GamePassTurnInput;
+  GamePlayCardsInput: GamePlayCardsInput;
   GameQuery: ResolverTypeWrapper<
     ResolversInterfaceTypes<ResolversTypes>['GameQuery']
   >;
@@ -582,6 +633,8 @@ export type ResolversParentTypes = ResolversObject<{
   GameCreateInput: GameCreateInput;
   GameCreateInputOptions: GameCreateInputOptions;
   GameMutation: ResolversInterfaceTypes<ResolversParentTypes>['GameMutation'];
+  GamePassTurnInput: GamePassTurnInput;
+  GamePlayCardsInput: GamePlayCardsInput;
   GameQuery: ResolversInterfaceTypes<ResolversParentTypes>['GameQuery'];
   GameSpec: GameSpec;
   ID: Scalars['ID']['output'];
@@ -795,6 +848,21 @@ export type GameMutationResolvers<
     ContextType,
     RequireFields<GameMutationCreateGameArgs, 'gameCreateInput'>
   >;
+  passGameTurn: Resolver<
+    Maybe<ResolversTypes['Game']>,
+    ParentType,
+    ContextType,
+    RequireFields<GameMutationPassGameTurnArgs, 'gameId' | 'gamePassTurnInput'>
+  >;
+  playGameCards: Resolver<
+    Maybe<ResolversTypes['Game']>,
+    ParentType,
+    ContextType,
+    RequireFields<
+      GameMutationPlayGameCardsArgs,
+      'gameId' | 'gamePlayCardsInput'
+    >
+  >;
 }>;
 
 export type GameQueryResolvers<
@@ -926,6 +994,21 @@ export type RootMutationResolvers<
     ParentType,
     ContextType,
     RequireFields<RootMutationCreateUserArgs, 'userCreateInput'>
+  >;
+  passGameTurn: Resolver<
+    Maybe<ResolversTypes['Game']>,
+    ParentType,
+    ContextType,
+    RequireFields<RootMutationPassGameTurnArgs, 'gameId' | 'gamePassTurnInput'>
+  >;
+  playGameCards: Resolver<
+    Maybe<ResolversTypes['Game']>,
+    ParentType,
+    ContextType,
+    RequireFields<
+      RootMutationPlayGameCardsArgs,
+      'gameId' | 'gamePlayCardsInput'
+    >
   >;
   updateUserMe: Resolver<
     ResolversTypes['User'],

--- a/packages/api/libraries/api-graphql-schemas/schemas/games/GameMutation.graphql
+++ b/packages/api/libraries/api-graphql-schemas/schemas/games/GameMutation.graphql
@@ -1,6 +1,10 @@
 #import Game from './Game.graphql'
 #import GameCreateInput from './GameCreateInput.graphql'
+#import GamePassTurnInput from './GamePassTurnInput.graphql'
+#import GamePlayCardsInput from './GamePlayCardsInput.graphql'
 
 interface GameMutation {
   createGame(gameCreateInput: GameCreateInput!): Game!
+  passGameTurn(gameId: ID!, gamePassTurnInput: GamePassTurnInput!): Game
+  playGameCards(gameId: ID!, gamePlayCardsInput: GamePlayCardsInput!): Game
 }

--- a/packages/api/libraries/api-graphql-schemas/schemas/games/GamePassTurnInput.graphql
+++ b/packages/api/libraries/api-graphql-schemas/schemas/games/GamePassTurnInput.graphql
@@ -1,0 +1,3 @@
+input GamePassTurnInput {
+  slotIndex: Int!
+}

--- a/packages/api/libraries/api-graphql-schemas/schemas/games/GamePlayCardsInput.graphql
+++ b/packages/api/libraries/api-graphql-schemas/schemas/games/GamePlayCardsInput.graphql
@@ -1,0 +1,7 @@
+#import CardColor from '../cards/CardColor.graphql'
+
+input GamePlayCardsInput {
+  cardIndexes: [Int!]!
+  colorChoice: CardColor
+  slotIndex: Int!
+}

--- a/packages/api/libraries/api-graphql-schemas/schemas/root.graphql
+++ b/packages/api/libraries/api-graphql-schemas/schemas/root.graphql
@@ -5,6 +5,8 @@
 #import Game from './games/Game.graphql'
 #import GameCreateInput from './games/GameCreateInput.graphql'
 #import GameMutation from './games/GameMutation.graphql'
+#import GamePassTurnInput from './games/GamePassTurnInput.graphql'
+#import GamePlayCardsInput from './games/GamePlayCardsInput.graphql'
 #import GameQuery from './games/GameQuery.graphql'
 #import UserMutation from './users/UserMutation.graphql'
 #import EmailPasswordAuthCreateInput from './auth/EmailPasswordAuthCreateInput.graphql'
@@ -18,6 +20,8 @@ type RootMutation implements AuthMutation & GameMutation & UserMutation {
   createAuthByCredentials(emailPasswordAuthCreateInput: EmailPasswordAuthCreateInput!): Auth!
   createGame(gameCreateInput: GameCreateInput!): Game!
   createUser(userCreateInput: UserCreateInput!): User!
+  passGameTurn(gameId: ID!, gamePassTurnInput: GamePassTurnInput!): Game
+  playGameCards(gameId: ID!, gamePlayCardsInput: GamePlayCardsInput!): Game
   updateUserMe(userUpdateInput: UserUpdateInput!): User!
 }
 

--- a/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootMutationResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootMutationResolver.ts
@@ -4,6 +4,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { GraphQLResolveInfo } from 'graphql';
 
 import { AuthMutationResolver } from '../../../auth/application/resolvers/AuthMutationResolver';
+import { CanonicalResolver } from '../../../foundation/graphql/application/models/CanonicalResolver';
 import { GameMutationResolver } from '../../../games/application/resolvers/GameMutationResolver';
 import { UserMutationResolver } from '../../../users/application/resolvers/UserMutationResolver';
 
@@ -12,21 +13,33 @@ export class RootMutationResolver
   implements
     graphqlModels.RootMutationResolvers<Request, graphqlModels.RootMutation>
 {
-  readonly #authMutation: graphqlModels.AuthMutationResolvers<Request>;
-  readonly #gameMutationResolver: graphqlModels.GameMutationResolvers<Request>;
-  readonly #userMutation: graphqlModels.UserMutationResolvers<Request>;
+  readonly #authMutationResolver: CanonicalResolver<
+    graphqlModels.AuthMutationResolvers<Request>
+  >;
+  readonly #gameMutationResolver: CanonicalResolver<
+    graphqlModels.GameMutationResolvers<Request>
+  >;
+  readonly #userMutationResolver: CanonicalResolver<
+    graphqlModels.UserMutationResolvers<Request>
+  >;
 
   constructor(
     @Inject(AuthMutationResolver)
-    authMutationResolver: graphqlModels.AuthMutationResolvers<Request>,
+    authMutationResolver: CanonicalResolver<
+      graphqlModels.AuthMutationResolvers<Request>
+    >,
     @Inject(GameMutationResolver)
-    gameMutationResolver: graphqlModels.GameMutationResolvers<Request>,
+    gameMutationResolver: CanonicalResolver<
+      graphqlModels.GameMutationResolvers<Request>
+    >,
     @Inject(UserMutationResolver)
-    userMutationResolver: graphqlModels.UserMutationResolvers<Request>,
+    userMutationResolver: CanonicalResolver<
+      graphqlModels.UserMutationResolvers<Request>
+    >,
   ) {
-    this.#authMutation = authMutationResolver;
+    this.#authMutationResolver = authMutationResolver;
     this.#gameMutationResolver = gameMutationResolver;
-    this.#userMutation = userMutationResolver;
+    this.#userMutationResolver = userMutationResolver;
   }
 
   public async createAuthByCode(
@@ -35,10 +48,12 @@ export class RootMutationResolver
     request: Request,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.Auth> {
-    return this.#getResolverFunction(
-      this.#authMutation,
-      this.#authMutation.createAuthByCode,
-    )(parent, args, request, info);
+    return this.#authMutationResolver.createAuthByCode(
+      parent,
+      args,
+      request,
+      info,
+    );
   }
 
   public async createAuthByCredentials(
@@ -47,10 +62,12 @@ export class RootMutationResolver
     request: Request,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.Auth> {
-    return this.#getResolverFunction(
-      this.#authMutation,
-      this.#authMutation.createAuthByCredentials,
-    )(parent, args, request, info);
+    return this.#authMutationResolver.createAuthByCredentials(
+      parent,
+      args,
+      request,
+      info,
+    );
   }
 
   public async createGame(
@@ -59,10 +76,7 @@ export class RootMutationResolver
     request: Request,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.Game> {
-    return this.#getResolverFunction(
-      this.#gameMutationResolver,
-      this.#gameMutationResolver.createGame,
-    )(parent, args, request, info);
+    return this.#gameMutationResolver.createGame(parent, args, request, info);
   }
 
   public async createUser(
@@ -71,10 +85,30 @@ export class RootMutationResolver
     request: Request,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.User> {
-    return this.#getResolverFunction(
-      this.#userMutation,
-      this.#userMutation.createUser,
-    )(parent, args, request, info);
+    return this.#userMutationResolver.createUser(parent, args, request, info);
+  }
+
+  public async passGameTurn(
+    parent: graphqlModels.RootMutation,
+    args: graphqlModels.GameMutationPassGameTurnArgs,
+    request: Request,
+    info: GraphQLResolveInfo,
+  ): Promise<graphqlModels.Game | null> {
+    return this.#gameMutationResolver.passGameTurn(parent, args, request, info);
+  }
+
+  public async playGameCards(
+    parent: graphqlModels.RootMutation,
+    args: graphqlModels.GameMutationPlayGameCardsArgs,
+    request: Request,
+    info: GraphQLResolveInfo,
+  ): Promise<graphqlModels.Game | null> {
+    return this.#gameMutationResolver.playGameCards(
+      parent,
+      args,
+      request,
+      info,
+    );
   }
 
   public async updateUserMe(
@@ -83,30 +117,6 @@ export class RootMutationResolver
     request: Request,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.User> {
-    return this.#getResolverFunction(
-      this.#userMutation,
-      this.#userMutation.updateUserMe,
-    )(parent, args, request, info);
-  }
-
-  #getResolverFunction<TResult, TArgs>(
-    self: unknown,
-    resolver: graphqlModels.Resolver<
-      TResult,
-      graphqlModels.RootMutation,
-      Request,
-      TArgs
-    >,
-  ): graphqlModels.ResolverFn<
-    TResult,
-    graphqlModels.RootMutation,
-    Request,
-    TArgs
-  > {
-    if (typeof resolver === 'function') {
-      return resolver.bind(self);
-    } else {
-      return resolver.resolve.bind(self);
-    }
+    return this.#userMutationResolver.updateUserMe(parent, args, request, info);
   }
 }

--- a/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootQueryResolver.spec.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootQueryResolver.spec.ts
@@ -4,293 +4,145 @@ import { models as graphqlModels } from '@cornie-js/api-graphql-models';
 import { Request } from '@cornie-js/backend-http';
 import { GraphQLResolveInfo } from 'graphql';
 
+import { CanonicalResolver } from '../../../foundation/graphql/application/models/CanonicalResolver';
 import { RootQueryResolver } from './RootQueryResolver';
 
+function buildTestTuples(): [
+  string,
+  graphqlModels.ResolverFn<
+    unknown,
+    graphqlModels.RootQuery,
+    Request,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any
+  >,
+  jest.Mock,
+][] {
+  const gameQueryResolverMock: jest.Mocked<
+    CanonicalResolver<graphqlModels.GameQueryResolvers<Request>>
+  > = {
+    gameById: jest.fn(),
+    myGames: jest.fn(),
+  } as Partial<
+    jest.Mocked<CanonicalResolver<graphqlModels.GameQueryResolvers<Request>>>
+  > as jest.Mocked<
+    CanonicalResolver<graphqlModels.GameQueryResolvers<Request>>
+  >;
+
+  const userQueryResolverMock: jest.Mocked<
+    CanonicalResolver<graphqlModels.UserQueryResolvers<Request>>
+  > = {
+    userById: jest.fn(),
+    userMe: jest.fn(),
+  } as Partial<
+    jest.Mocked<CanonicalResolver<graphqlModels.UserQueryResolvers<Request>>>
+  > as jest.Mocked<
+    CanonicalResolver<graphqlModels.UserQueryResolvers<Request>>
+  >;
+
+  const rootQueryResolver: RootQueryResolver = new RootQueryResolver(
+    gameQueryResolverMock,
+    userQueryResolverMock,
+  );
+
+  return [
+    [
+      'gameById',
+      rootQueryResolver.gameById.bind(rootQueryResolver),
+      gameQueryResolverMock.gameById as jest.Mock,
+    ],
+    [
+      'myGames',
+      rootQueryResolver.myGames.bind(rootQueryResolver),
+      gameQueryResolverMock.myGames as jest.Mock,
+    ],
+    [
+      'userById',
+      rootQueryResolver.userById.bind(rootQueryResolver),
+      userQueryResolverMock.userById as jest.Mock,
+    ],
+    [
+      'userMe',
+      rootQueryResolver.userMe.bind(rootQueryResolver),
+      userQueryResolverMock.userMe as jest.Mock,
+    ],
+  ];
+}
+
 describe(RootQueryResolver.name, () => {
-  let gameByIdMock: jest.Mock<
-    graphqlModels.ResolverFn<
-      graphqlModels.Maybe<graphqlModels.ResolversTypes['Game']>,
-      unknown,
-      Request,
-      graphqlModels.RequireFields<graphqlModels.GameQueryGameByIdArgs, 'id'>
-    >
-  >;
+  describe.each<
+    [
+      string,
+      graphqlModels.ResolverFn<
+        unknown,
+        graphqlModels.RootQuery,
+        Request,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        any
+      >,
+      jest.Mock,
+    ]
+  >(buildTestTuples())(
+    '.%s',
+    (
+      _: string,
+      resolver: graphqlModels.ResolverFn<
+        unknown,
+        graphqlModels.RootQuery,
+        Request,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        any
+      >,
+      resolverMock: jest.Mock,
+    ) => {
+      describe('when called', () => {
+        let parentFixture: graphqlModels.RootQuery;
+        let argsFixture: unknown;
+        let requestFixture: Request;
+        let infoFixture: GraphQLResolveInfo;
 
-  let myGamesMock: jest.Mock<
-    graphqlModels.ResolverFn<
-      Array<graphqlModels.ResolversTypes['Game']>,
-      unknown,
-      Request,
-      Partial<graphqlModels.RootQueryMyGamesArgs>
-    >
-  >;
+        let resolverResultFixture: unknown;
 
-  let gameQueryResolverMock: jest.Mocked<
-    graphqlModels.GameQueryResolvers<Request>
-  >;
+        let result: unknown;
 
-  let userByIdMock: jest.Mock<
-    graphqlModels.ResolverFn<
-      graphqlModels.Maybe<graphqlModels.ResolversTypes['User']>,
-      unknown,
-      Request,
-      graphqlModels.RequireFields<graphqlModels.UserQueryUserByIdArgs, 'id'>
-    >
-  >;
+        beforeAll(async () => {
+          parentFixture = Symbol() as unknown as graphqlModels.RootQuery;
+          argsFixture = Symbol();
+          requestFixture = Symbol() as unknown as Request;
+          infoFixture = Symbol() as unknown as GraphQLResolveInfo;
 
-  let userMeMock: jest.Mock<
-    graphqlModels.ResolverFn<
-      graphqlModels.Maybe<graphqlModels.ResolversTypes['User']>,
-      unknown,
-      Request,
-      Record<string, unknown>
-    >
-  >;
+          resolverResultFixture = Symbol();
 
-  let userQueryResolverMock: jest.Mocked<
-    graphqlModels.UserQueryResolvers<Request>
-  >;
+          resolverMock.mockReturnValueOnce(
+            Promise.resolve(resolverResultFixture),
+          );
 
-  let rootQueryResolver: RootQueryResolver;
+          result = await resolver(
+            parentFixture,
+            argsFixture,
+            requestFixture,
+            infoFixture,
+          );
+        });
 
-  beforeAll(() => {
-    myGamesMock = jest.fn();
-    gameByIdMock = jest.fn();
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
 
-    gameQueryResolverMock = {
-      gameById: gameByIdMock,
-      myGames: myGamesMock,
-    } as Partial<
-      jest.Mocked<graphqlModels.GameQueryResolvers<Request>>
-    > as jest.Mocked<graphqlModels.GameQueryResolvers<Request>>;
+        it('should call resolverMock()', () => {
+          expect(resolverMock).toHaveBeenCalledTimes(1);
+          expect(resolverMock).toHaveBeenCalledWith(
+            parentFixture,
+            argsFixture,
+            requestFixture,
+            infoFixture,
+          );
+        });
 
-    userByIdMock = jest.fn();
-    userMeMock = jest.fn();
-
-    userQueryResolverMock = {
-      userById: userByIdMock,
-      userMe: userMeMock,
-    } as Partial<
-      jest.Mocked<graphqlModels.UserQueryResolvers<Request>>
-    > as jest.Mocked<graphqlModels.UserQueryResolvers<Request>>;
-
-    rootQueryResolver = new RootQueryResolver(
-      gameQueryResolverMock,
-      userQueryResolverMock,
-    );
-  });
-
-  describe('.gameById', () => {
-    let gameFixture: graphqlModels.Game;
-
-    beforeAll(() => {
-      gameFixture = Symbol() as unknown as graphqlModels.Game;
-    });
-
-    describe('when called', () => {
-      let parentFixture: graphqlModels.RootQuery;
-      let argsFixture: graphqlModels.GameQueryGameByIdArgs;
-      let requestFixture: Request;
-      let infoFixture: GraphQLResolveInfo;
-
-      let result: unknown;
-
-      beforeAll(async () => {
-        parentFixture = Symbol() as unknown as graphqlModels.RootQuery;
-        argsFixture = {
-          id: 'id fixture',
-        };
-        requestFixture = Symbol() as unknown as Request;
-        infoFixture = Symbol() as unknown as GraphQLResolveInfo;
-
-        gameByIdMock.mockReturnValueOnce(Promise.resolve(gameFixture));
-
-        result = await rootQueryResolver.gameById(
-          parentFixture,
-          argsFixture,
-          requestFixture,
-          infoFixture,
-        );
+        it('should return result', () => {
+          expect(result).toBe(resolverResultFixture);
+        });
       });
-
-      afterAll(() => {
-        jest.clearAllMocks();
-      });
-
-      it('should call gameQueryResolver.gameById()', () => {
-        expect(gameByIdMock).toHaveBeenCalledTimes(1);
-        expect(gameByIdMock).toHaveBeenCalledWith(
-          parentFixture,
-          argsFixture,
-          requestFixture,
-          infoFixture,
-        );
-      });
-
-      it('should return Game', () => {
-        expect(result).toBe(gameFixture);
-      });
-    });
-  });
-
-  describe('.myGames', () => {
-    let gameFixture: graphqlModels.Game;
-
-    beforeAll(() => {
-      gameFixture = Symbol() as unknown as graphqlModels.Game;
-    });
-
-    describe('when called', () => {
-      let parentFixture: graphqlModels.RootQuery;
-      let argsFixture: Partial<graphqlModels.RootQueryMyGamesArgs>;
-      let requestFixture: Request;
-      let infoFixture: GraphQLResolveInfo;
-
-      let result: unknown;
-
-      beforeAll(async () => {
-        parentFixture = Symbol() as unknown as graphqlModels.RootQuery;
-        argsFixture = {
-          findMyGamesInput: {
-            page: 1,
-            pageSize: null,
-            status: 'active',
-          },
-        };
-        requestFixture = Symbol() as unknown as Request;
-        infoFixture = Symbol() as unknown as GraphQLResolveInfo;
-
-        myGamesMock.mockReturnValueOnce(Promise.resolve([gameFixture]));
-
-        result = await rootQueryResolver.myGames(
-          parentFixture,
-          argsFixture,
-          requestFixture,
-          infoFixture,
-        );
-      });
-
-      afterAll(() => {
-        jest.clearAllMocks();
-      });
-
-      it('should call gameQueryResolver.myGames()', () => {
-        expect(myGamesMock).toHaveBeenCalledTimes(1);
-        expect(myGamesMock).toHaveBeenCalledWith(
-          parentFixture,
-          argsFixture,
-          requestFixture,
-          infoFixture,
-        );
-      });
-
-      it('should return Game', () => {
-        expect(result).toStrictEqual([gameFixture]);
-      });
-    });
-  });
-
-  describe('.userById', () => {
-    let userFixture: graphqlModels.User;
-
-    beforeAll(() => {
-      userFixture = Symbol() as unknown as graphqlModels.User;
-    });
-
-    describe('when called', () => {
-      let parentFixture: graphqlModels.RootQuery;
-      let argsFixture: graphqlModels.UserQueryUserByIdArgs;
-      let requestFixture: Request;
-      let infoFixture: GraphQLResolveInfo;
-
-      let result: unknown;
-
-      beforeAll(async () => {
-        parentFixture = Symbol() as unknown as graphqlModels.RootQuery;
-        argsFixture = {
-          id: 'id fixture',
-        };
-        requestFixture = Symbol() as unknown as Request;
-        infoFixture = Symbol() as unknown as GraphQLResolveInfo;
-
-        userByIdMock.mockReturnValueOnce(Promise.resolve(userFixture));
-
-        result = await rootQueryResolver.userById(
-          parentFixture,
-          argsFixture,
-          requestFixture,
-          infoFixture,
-        );
-      });
-
-      afterAll(() => {
-        jest.clearAllMocks();
-      });
-
-      it('should call userQueryResolver.userById()', () => {
-        expect(userByIdMock).toHaveBeenCalledTimes(1);
-        expect(userByIdMock).toHaveBeenCalledWith(
-          parentFixture,
-          argsFixture,
-          requestFixture,
-          infoFixture,
-        );
-      });
-
-      it('should return UserV1', () => {
-        expect(result).toBe(userFixture);
-      });
-    });
-  });
-
-  describe('.userMe', () => {
-    let userFixture: graphqlModels.User;
-
-    beforeAll(() => {
-      userFixture = Symbol() as unknown as graphqlModels.User;
-    });
-
-    describe('when called', () => {
-      let parentFixture: graphqlModels.RootQuery;
-      let argsFixture: Record<string, unknown>;
-      let requestFixture: Request;
-      let infoFixture: GraphQLResolveInfo;
-
-      let result: unknown;
-
-      beforeAll(async () => {
-        parentFixture = Symbol() as unknown as graphqlModels.RootQuery;
-        argsFixture = {};
-        requestFixture = Symbol() as unknown as Request;
-        infoFixture = Symbol() as unknown as GraphQLResolveInfo;
-
-        userMeMock.mockReturnValueOnce(Promise.resolve(userFixture));
-
-        result = await rootQueryResolver.userMe(
-          parentFixture,
-          argsFixture,
-          requestFixture,
-          infoFixture,
-        );
-      });
-
-      afterAll(() => {
-        jest.clearAllMocks();
-      });
-
-      it('should call userQueryResolver.userMe()', () => {
-        expect(userMeMock).toHaveBeenCalledTimes(1);
-        expect(userMeMock).toHaveBeenCalledWith(
-          parentFixture,
-          argsFixture,
-          requestFixture,
-          infoFixture,
-        );
-      });
-
-      it('should return UserV1', () => {
-        expect(result).toBe(userFixture);
-      });
-    });
-  });
+    },
+  );
 });

--- a/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootQueryResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootQueryResolver.ts
@@ -3,6 +3,7 @@ import { Request } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 import { GraphQLResolveInfo } from 'graphql';
 
+import { CanonicalResolver } from '../../../foundation/graphql/application/models/CanonicalResolver';
 import { GameQueryResolver } from '../../../games/application/resolvers/GameQueryResolver';
 import { UserQueryResolver } from '../../../users/application/resolvers/UserQueryResolver';
 
@@ -14,14 +15,22 @@ type ResolverFnReturnType<TResult, TArgs> = ReturnType<
 export class RootQueryResolver
   implements graphqlModels.RootQueryResolvers<Request, graphqlModels.RootQuery>
 {
-  readonly #gameQueryResolver: graphqlModels.GameQueryResolvers<Request>;
-  readonly #userQueryResolver: graphqlModels.UserQueryResolvers<Request>;
+  readonly #gameQueryResolver: CanonicalResolver<
+    graphqlModels.GameQueryResolvers<Request>
+  >;
+  readonly #userQueryResolver: CanonicalResolver<
+    graphqlModels.UserQueryResolvers<Request>
+  >;
 
   constructor(
     @Inject(GameQueryResolver)
-    gameQueryResolver: graphqlModels.GameQueryResolvers<Request>,
+    gameQueryResolver: CanonicalResolver<
+      graphqlModels.GameQueryResolvers<Request>
+    >,
     @Inject(UserQueryResolver)
-    userQueryResolver: graphqlModels.UserQueryResolvers<Request>,
+    userQueryResolver: CanonicalResolver<
+      graphqlModels.UserQueryResolvers<Request>
+    >,
   ) {
     this.#gameQueryResolver = gameQueryResolver;
     this.#userQueryResolver = userQueryResolver;
@@ -33,10 +42,7 @@ export class RootQueryResolver
     request: Request,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.Game | null> {
-    return this.#getResolverFunction(
-      this.#gameQueryResolver,
-      this.#gameQueryResolver.gameById,
-    )(parent, args, request, info);
+    return this.#gameQueryResolver.gameById(parent, args, request, info);
   }
 
   public myGames(
@@ -48,10 +54,7 @@ export class RootQueryResolver
     Array<graphqlModels.ResolversTypes['Game']>,
     Partial<graphqlModels.RootQueryMyGamesArgs>
   > {
-    return this.#getResolverFunction(
-      this.#gameQueryResolver,
-      this.#gameQueryResolver.myGames,
-    )(parent, args, request, info);
+    return this.#gameQueryResolver.myGames(parent, args, request, info);
   }
 
   public async userById(
@@ -60,10 +63,7 @@ export class RootQueryResolver
     request: Request,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.User | null> {
-    return this.#getResolverFunction(
-      this.#userQueryResolver,
-      this.#userQueryResolver.userById,
-    )(parent, args, request, info);
+    return this.#userQueryResolver.userById(parent, args, request, info);
   }
 
   public async userMe(
@@ -72,30 +72,6 @@ export class RootQueryResolver
     request: Request,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.User> {
-    return this.#getResolverFunction(
-      this.#userQueryResolver,
-      this.#userQueryResolver.userMe,
-    )(parent, args, request, info);
-  }
-
-  #getResolverFunction<TResult, TArgs>(
-    self: unknown,
-    resolver: graphqlModels.Resolver<
-      TResult,
-      graphqlModels.RootQuery,
-      Request,
-      TArgs
-    >,
-  ): graphqlModels.ResolverFn<
-    TResult,
-    graphqlModels.RootQuery,
-    Request,
-    TArgs
-  > {
-    if (typeof resolver === 'function') {
-      return resolver.bind(self);
-    } else {
-      return resolver.resolve.bind(self);
-    }
+    return this.#userQueryResolver.userMe(parent, args, request, info);
   }
 }

--- a/packages/backend/apps/gateway/backend-gateway-application/src/auth/application/resolvers/AuthMutationResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/auth/application/resolvers/AuthMutationResolver.ts
@@ -5,9 +5,11 @@ import { AppError, AppErrorKind } from '@cornie-js/backend-common';
 import { Request } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
+import { CanonicalResolver } from '../../../foundation/graphql/application/models/CanonicalResolver';
+
 @Injectable()
 export class AuthMutationResolver
-  implements graphqlModels.AuthMutationResolvers<Request>
+  implements CanonicalResolver<graphqlModels.AuthMutationResolvers<Request>>
 {
   readonly #httpClient: HttpClient;
 

--- a/packages/backend/apps/gateway/backend-gateway-application/src/foundation/graphql/application/models/CanonicalResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/foundation/graphql/application/models/CanonicalResolver.ts
@@ -1,0 +1,12 @@
+import { models as graphqlModels } from '@cornie-js/api-graphql-models';
+
+export type CanonicalResolver<T extends object> = {
+  [K in keyof T]: T[K] extends graphqlModels.Resolver<
+    infer TResult,
+    infer TParent,
+    infer TContext,
+    infer TArgs
+  >
+    ? graphqlModels.ResolverFn<TResult, TParent, TContext, TArgs>
+    : T[K];
+} & T;

--- a/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameMutationResolver.spec.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameMutationResolver.spec.ts
@@ -24,6 +24,7 @@ describe(GameMutationResolver.name, () => {
 
     httpClientMock = {
       createGame: jest.fn(),
+      updateGame: jest.fn(),
     } as Partial<jest.Mocked<HttpClient>> as jest.Mocked<HttpClient>;
 
     gameMutationResolver = new GameMutationResolver(
@@ -187,6 +188,481 @@ describe(GameMutationResolver.name, () => {
       it('should throw an AppError', () => {
         const expectedErrorProperties: Partial<AppError> = {
           kind: AppErrorKind.contractViolation,
+          message: errorV1.description,
+        };
+
+        expect(result).toBeInstanceOf(AppError);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProperties),
+        );
+      });
+    });
+  });
+
+  describe('.passGameTurn', () => {
+    let gameIdFixture: string;
+    let slotIndexFixture: number;
+
+    beforeAll(() => {
+      slotIndexFixture = 2;
+      gameIdFixture = 'game-id-fixture';
+    });
+
+    describe('when called, and httpClient.updateGame() returns an OK response', () => {
+      let gameV1Fixture: apiModels.NonStartedGameV1;
+      let gameGraphQlFixture: graphqlModels.Game;
+
+      let requestFixture: Request;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        gameV1Fixture = Symbol() as unknown as apiModels.NonStartedGameV1;
+        gameGraphQlFixture = Symbol() as unknown as graphqlModels.Game;
+
+        requestFixture = {
+          headers: {
+            foo: 'bar',
+          },
+          query: {},
+          urlParameters: {},
+        };
+
+        httpClientMock.updateGame.mockResolvedValueOnce({
+          body: gameV1Fixture,
+          headers: {},
+          statusCode: HttpStatus.OK,
+        });
+
+        gameGraphQlFromGameV1BuilderMock.build.mockReturnValueOnce(
+          gameGraphQlFixture,
+        );
+
+        result = await gameMutationResolver.passGameTurn(
+          undefined,
+          {
+            gameId: gameIdFixture,
+            gamePassTurnInput: {
+              slotIndex: slotIndexFixture,
+            },
+          },
+          requestFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call httpClient.updateGame()', () => {
+        const expectedBody: apiModels.GameIdPassTurnQueryV1 = {
+          kind: 'passTurn',
+          slotIndex: slotIndexFixture,
+        };
+
+        expect(httpClientMock.updateGame).toHaveBeenCalledTimes(1);
+        expect(httpClientMock.updateGame).toHaveBeenCalledWith(
+          requestFixture.headers,
+          {
+            gameId: gameIdFixture,
+          },
+          expectedBody,
+        );
+      });
+
+      it('should call gameGraphQlFromGameV1Builder.build()', () => {
+        expect(gameGraphQlFromGameV1BuilderMock.build).toHaveBeenCalledTimes(1);
+        expect(gameGraphQlFromGameV1BuilderMock.build).toHaveBeenCalledWith(
+          gameV1Fixture,
+        );
+      });
+
+      it('should return GraphQl Game', () => {
+        expect(result).toBe(gameGraphQlFixture);
+      });
+    });
+
+    describe('when called, and httpClient.updateGame() returns an UNAUTHORIZED response', () => {
+      let errorV1: apiModels.ErrorV1;
+      let requestFixture: Request;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        errorV1 = {
+          description: 'error description fixture',
+        };
+
+        requestFixture = {
+          headers: {
+            foo: 'bar',
+          },
+          query: {},
+          urlParameters: {},
+        };
+
+        httpClientMock.updateGame.mockResolvedValueOnce({
+          body: errorV1,
+          headers: {},
+          statusCode: HttpStatus.UNAUTHORIZED,
+        });
+
+        try {
+          await gameMutationResolver.passGameTurn(
+            undefined,
+            {
+              gameId: gameIdFixture,
+              gamePassTurnInput: {
+                slotIndex: slotIndexFixture,
+              },
+            },
+            requestFixture,
+          );
+        } catch (error) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call httpClient.updateGame()', () => {
+        const expectedBody: apiModels.GameIdPassTurnQueryV1 = {
+          kind: 'passTurn',
+          slotIndex: slotIndexFixture,
+        };
+
+        expect(httpClientMock.updateGame).toHaveBeenCalledTimes(1);
+        expect(httpClientMock.updateGame).toHaveBeenCalledWith(
+          requestFixture.headers,
+          {
+            gameId: gameIdFixture,
+          },
+          expectedBody,
+        );
+      });
+
+      it('should throw an AppError', () => {
+        const expectedErrorProperties: Partial<AppError> = {
+          kind: AppErrorKind.missingCredentials,
+          message: errorV1.description,
+        };
+
+        expect(result).toBeInstanceOf(AppError);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProperties),
+        );
+      });
+    });
+
+    describe('when called, and httpClient.updateGame() returns an FORBIDDEN response', () => {
+      let errorV1: apiModels.ErrorV1;
+      let requestFixture: Request;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        errorV1 = {
+          description: 'error description fixture',
+        };
+
+        requestFixture = {
+          headers: {
+            foo: 'bar',
+          },
+          query: {},
+          urlParameters: {},
+        };
+
+        httpClientMock.updateGame.mockResolvedValueOnce({
+          body: errorV1,
+          headers: {},
+          statusCode: HttpStatus.FORBIDDEN,
+        });
+
+        try {
+          await gameMutationResolver.passGameTurn(
+            undefined,
+            {
+              gameId: gameIdFixture,
+              gamePassTurnInput: {
+                slotIndex: slotIndexFixture,
+              },
+            },
+            requestFixture,
+          );
+        } catch (error) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call httpClient.updateGame()', () => {
+        const expectedBody: apiModels.GameIdPassTurnQueryV1 = {
+          kind: 'passTurn',
+          slotIndex: slotIndexFixture,
+        };
+
+        expect(httpClientMock.updateGame).toHaveBeenCalledTimes(1);
+        expect(httpClientMock.updateGame).toHaveBeenCalledWith(
+          requestFixture.headers,
+          {
+            gameId: gameIdFixture,
+          },
+          expectedBody,
+        );
+      });
+
+      it('should throw an AppError', () => {
+        const expectedErrorProperties: Partial<AppError> = {
+          kind: AppErrorKind.invalidCredentials,
+          message: errorV1.description,
+        };
+
+        expect(result).toBeInstanceOf(AppError);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProperties),
+        );
+      });
+    });
+  });
+
+  describe('.playGameCards', () => {
+    let cardIndexesFixture: number[];
+    let gameIdFixture: string;
+    let slotIndexFixture: number;
+
+    beforeAll(() => {
+      cardIndexesFixture = [0, 1];
+      slotIndexFixture = 2;
+      gameIdFixture = 'game-id-fixture';
+    });
+
+    describe('when called, and httpClient.updateGame() returns an OK response', () => {
+      let gameV1Fixture: apiModels.NonStartedGameV1;
+      let gameGraphQlFixture: graphqlModels.Game;
+
+      let requestFixture: Request;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        gameV1Fixture = Symbol() as unknown as apiModels.NonStartedGameV1;
+        gameGraphQlFixture = Symbol() as unknown as graphqlModels.Game;
+
+        requestFixture = {
+          headers: {
+            foo: 'bar',
+          },
+          query: {},
+          urlParameters: {},
+        };
+
+        httpClientMock.updateGame.mockResolvedValueOnce({
+          body: gameV1Fixture,
+          headers: {},
+          statusCode: HttpStatus.OK,
+        });
+
+        gameGraphQlFromGameV1BuilderMock.build.mockReturnValueOnce(
+          gameGraphQlFixture,
+        );
+
+        result = await gameMutationResolver.playGameCards(
+          undefined,
+          {
+            gameId: gameIdFixture,
+            gamePlayCardsInput: {
+              cardIndexes: cardIndexesFixture,
+              colorChoice: null,
+              slotIndex: slotIndexFixture,
+            },
+          },
+          requestFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call httpClient.updateGame()', () => {
+        const expectedBody: apiModels.GameIdPlayCardsQueryV1 = {
+          cardIndexes: cardIndexesFixture,
+          kind: 'playCards',
+          slotIndex: slotIndexFixture,
+        };
+
+        expect(httpClientMock.updateGame).toHaveBeenCalledTimes(1);
+        expect(httpClientMock.updateGame).toHaveBeenCalledWith(
+          requestFixture.headers,
+          {
+            gameId: gameIdFixture,
+          },
+          expectedBody,
+        );
+      });
+
+      it('should call gameGraphQlFromGameV1Builder.build()', () => {
+        expect(gameGraphQlFromGameV1BuilderMock.build).toHaveBeenCalledTimes(1);
+        expect(gameGraphQlFromGameV1BuilderMock.build).toHaveBeenCalledWith(
+          gameV1Fixture,
+        );
+      });
+
+      it('should return GraphQl Game', () => {
+        expect(result).toBe(gameGraphQlFixture);
+      });
+    });
+
+    describe('when called, and httpClient.updateGame() returns an UNAUTHORIZED response', () => {
+      let errorV1: apiModels.ErrorV1;
+      let requestFixture: Request;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        errorV1 = {
+          description: 'error description fixture',
+        };
+
+        requestFixture = {
+          headers: {
+            foo: 'bar',
+          },
+          query: {},
+          urlParameters: {},
+        };
+
+        httpClientMock.updateGame.mockResolvedValueOnce({
+          body: errorV1,
+          headers: {},
+          statusCode: HttpStatus.UNAUTHORIZED,
+        });
+
+        try {
+          await gameMutationResolver.playGameCards(
+            undefined,
+            {
+              gameId: gameIdFixture,
+              gamePlayCardsInput: {
+                cardIndexes: cardIndexesFixture,
+                colorChoice: null,
+                slotIndex: slotIndexFixture,
+              },
+            },
+            requestFixture,
+          );
+        } catch (error) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call httpClient.updateGame()', () => {
+        const expectedBody: apiModels.GameIdPlayCardsQueryV1 = {
+          cardIndexes: cardIndexesFixture,
+          kind: 'playCards',
+          slotIndex: slotIndexFixture,
+        };
+
+        expect(httpClientMock.updateGame).toHaveBeenCalledTimes(1);
+        expect(httpClientMock.updateGame).toHaveBeenCalledWith(
+          requestFixture.headers,
+          {
+            gameId: gameIdFixture,
+          },
+          expectedBody,
+        );
+      });
+
+      it('should throw an AppError', () => {
+        const expectedErrorProperties: Partial<AppError> = {
+          kind: AppErrorKind.missingCredentials,
+          message: errorV1.description,
+        };
+
+        expect(result).toBeInstanceOf(AppError);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProperties),
+        );
+      });
+    });
+
+    describe('when called, and httpClient.updateGame() returns an FORBIDDEN response', () => {
+      let errorV1: apiModels.ErrorV1;
+      let requestFixture: Request;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        errorV1 = {
+          description: 'error description fixture',
+        };
+
+        requestFixture = {
+          headers: {
+            foo: 'bar',
+          },
+          query: {},
+          urlParameters: {},
+        };
+
+        httpClientMock.updateGame.mockResolvedValueOnce({
+          body: errorV1,
+          headers: {},
+          statusCode: HttpStatus.FORBIDDEN,
+        });
+
+        try {
+          await gameMutationResolver.playGameCards(
+            undefined,
+            {
+              gameId: gameIdFixture,
+              gamePlayCardsInput: {
+                cardIndexes: cardIndexesFixture,
+                colorChoice: null,
+                slotIndex: slotIndexFixture,
+              },
+            },
+            requestFixture,
+          );
+        } catch (error) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call httpClient.updateGame()', () => {
+        const expectedBody: apiModels.GameIdPlayCardsQueryV1 = {
+          cardIndexes: cardIndexesFixture,
+          kind: 'playCards',
+          slotIndex: slotIndexFixture,
+        };
+
+        expect(httpClientMock.updateGame).toHaveBeenCalledTimes(1);
+        expect(httpClientMock.updateGame).toHaveBeenCalledWith(
+          requestFixture.headers,
+          {
+            gameId: gameIdFixture,
+          },
+          expectedBody,
+        );
+      });
+
+      it('should throw an AppError', () => {
+        const expectedErrorProperties: Partial<AppError> = {
+          kind: AppErrorKind.invalidCredentials,
           message: errorV1.description,
         };
 

--- a/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameMutationResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameMutationResolver.ts
@@ -6,11 +6,12 @@ import { AppError, AppErrorKind, Builder } from '@cornie-js/backend-common';
 import { Request } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
+import { CanonicalResolver } from '../../../foundation/graphql/application/models/CanonicalResolver';
 import { GameGraphQlFromGameV1Builder } from '../builders/GameGraphQlFromGameV1Builder';
 
 @Injectable()
 export class GameMutationResolver
-  implements graphqlModels.GameMutationResolvers<Request>
+  implements CanonicalResolver<graphqlModels.GameMutationResolvers<Request>>
 {
   readonly #gameGraphQlFromGameV1Builder: Builder<
     graphqlModels.Game,
@@ -70,8 +71,77 @@ export class GameMutationResolver
     }
   }
 
+  public async passGameTurn(
+    _: unknown,
+    args: graphqlModels.GameMutationPassGameTurnArgs,
+    request: Request,
+  ): Promise<graphqlModels.Game | null> {
+    const gamePassTurnQueryV1: apiModels.GameIdPassTurnQueryV1 = {
+      kind: 'passTurn',
+      slotIndex: args.gamePassTurnInput.slotIndex,
+    };
+
+    return this.#handleUpdateGameV1(
+      request.headers,
+      args.gameId,
+      gamePassTurnQueryV1,
+    );
+  }
+
+  public async playGameCards(
+    _: unknown,
+    args: graphqlModels.GameMutationPlayGameCardsArgs,
+    request: Request,
+  ): Promise<graphqlModels.Game | null> {
+    const gamePlayCardsQueryV1: apiModels.GameIdPlayCardsQueryV1 = {
+      cardIndexes: args.gamePlayCardsInput.cardIndexes,
+      kind: 'playCards',
+      slotIndex: args.gamePlayCardsInput.slotIndex,
+    };
+
+    if (args.gamePlayCardsInput.colorChoice !== null) {
+      gamePlayCardsQueryV1.colorChoice = args.gamePlayCardsInput.colorChoice;
+    }
+
+    return this.#handleUpdateGameV1(
+      request.headers,
+      args.gameId,
+      gamePlayCardsQueryV1,
+    );
+  }
+
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public __resolveType(): never {
     throw new Error('Method not implemented');
+  }
+
+  async #handleUpdateGameV1(
+    headers: Record<string, string>,
+    gameId: string,
+    gameUpdateQueryV1: apiModels.GameIdUpdateQueryV1,
+  ): Promise<graphqlModels.Game | null> {
+    const httpResponse: Awaited<ReturnType<HttpClient['updateGame']>> =
+      await this.#httpClient.updateGame(
+        headers,
+        { gameId: gameId },
+        gameUpdateQueryV1,
+      );
+
+    switch (httpResponse.statusCode) {
+      case 200:
+        return this.#gameGraphQlFromGameV1Builder.build(httpResponse.body);
+      case 401:
+        throw new AppError(
+          AppErrorKind.missingCredentials,
+          httpResponse.body.description,
+        );
+      case 403:
+        throw new AppError(
+          AppErrorKind.invalidCredentials,
+          httpResponse.body.description,
+        );
+      case 404:
+        return null;
+    }
   }
 }

--- a/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameQueryResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameQueryResolver.ts
@@ -7,6 +7,7 @@ import { AppError, AppErrorKind, Builder } from '@cornie-js/backend-common';
 import { Request } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
+import { CanonicalResolver } from '../../../foundation/graphql/application/models/CanonicalResolver';
 import { GameGraphQlFromGameV1Builder } from '../builders/GameGraphQlFromGameV1Builder';
 
 interface GetGamesMineQueryArgs extends Record<string, string | string[]> {
@@ -17,7 +18,7 @@ interface GetGamesMineQueryArgs extends Record<string, string | string[]> {
 
 @Injectable()
 export class GameQueryResolver
-  implements graphqlModels.GameQueryResolvers<Request>
+  implements CanonicalResolver<graphqlModels.GameQueryResolvers<Request>>
 {
   readonly #gameGraphQlFromGameV1Builder: Builder<
     graphqlModels.Game,

--- a/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserMutationResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserMutationResolver.ts
@@ -6,9 +6,11 @@ import { AppError, AppErrorKind } from '@cornie-js/backend-common';
 import { Request } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
+import { CanonicalResolver } from '../../../foundation/graphql/application/models/CanonicalResolver';
+
 @Injectable()
 export class UserMutationResolver
-  implements graphqlModels.UserMutationResolvers<Request>
+  implements CanonicalResolver<graphqlModels.UserMutationResolvers<Request>>
 {
   readonly #httpClient: HttpClient;
 

--- a/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserQueryResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserQueryResolver.ts
@@ -6,9 +6,11 @@ import { AppError, AppErrorKind } from '@cornie-js/backend-common';
 import { Request } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
+import { CanonicalResolver } from '../../../foundation/graphql/application/models/CanonicalResolver';
+
 @Injectable()
 export class UserQueryResolver
-  implements graphqlModels.UserQueryResolvers<Request>
+  implements CanonicalResolver<graphqlModels.UserQueryResolvers<Request>>
 {
   readonly #httpClient: HttpClient;
 

--- a/packages/backend/services/backend-service-gateway/src/app/adapter/apollo/calculations/buildApolloApplicationResolver.ts
+++ b/packages/backend/services/backend-service-gateway/src/app/adapter/apollo/calculations/buildApolloApplicationResolver.ts
@@ -31,6 +31,16 @@ export function buildApolloApplicationResolver(
         graphQlErrorFromErrorBuilder,
         applicationResolver.RootMutation.createUser,
       ),
+      passGameTurn: buildApolloResolver(
+        applicationResolver.RootMutation,
+        graphQlErrorFromErrorBuilder,
+        applicationResolver.RootMutation.passGameTurn,
+      ),
+      playGameCards: buildApolloResolver(
+        applicationResolver.RootMutation,
+        graphQlErrorFromErrorBuilder,
+        applicationResolver.RootMutation.playGameCards,
+      ),
       updateUserMe: buildApolloResolver(
         applicationResolver.RootMutation,
         graphQlErrorFromErrorBuilder,

--- a/packages/frontend/web-ui/package.json
+++ b/packages/frontend/web-ui/package.json
@@ -36,7 +36,7 @@
     "@testing-library/react": "^14.0.0",
     "@types/react": "^18.2.5",
     "@types/react-dom": "^18.2.4",
-    "@vitejs/plugin-react": "^4.0.0",
+    "@vitejs/plugin-react": "^4.2.0",
     "babel-jest": "29.7.0",
     "babel-preset-vite": "^1.1.0",
     "jest": "29.7.0",


### PR DESCRIPTION
### Added
- Added `passGameTurn` mutation.
- Added `playGameCards` mutation.
- Added `CanonicalResolver` type.

### Changed
- Updated `RootQuery` to rely on `CanonicalResolver`.
- Updated `RootMutation` to rely on `CanonicalResolver`.