### PR TITLE
Add GameSpecDb

### DIFF
--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/app/adapter/typeorm/migrations/1700842833047-AddGameSpec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/app/adapter/typeorm/migrations/1700842833047-AddGameSpec.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddGameSpec1700842833047 implements MigrationInterface {
+  public readonly name: string = 'AddGameSpec1700842833047';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "GameSpec" ("spec" json NOT NULL, "chain_draw_2_draw_2_cards" smallint NOT NULL, "chain_draw_2_draw_4_cards" smallint NOT NULL, "chain_draw_4_draw_2_cards" smallint NOT NULL, "chain_draw_4_draw_4_cards" smallint NOT NULL, "game_slots_amount" smallint NOT NULL, "id" character varying(36) NOT NULL, "play_card_is_mandatory" smallint NOT NULL, "play_multiple_same_cards" smallint NOT NULL, "play_wild_draw_4_if_no_other_alternative" smallint NOT NULL, "game_id" character varying(36) NOT NULL, CONSTRAINT "REL_031d897a639b67efeb5ae0024a" UNIQUE ("game_id"), CONSTRAINT "PK_ccccc1c569c0ecb3d7d32b890e7" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "GameSpec" ADD CONSTRAINT "FK_031d897a639b67efeb5ae0024a1" FOREIGN KEY ("game_id") REFERENCES "Game"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "GameSpec" DROP CONSTRAINT "FK_031d897a639b67efeb5ae0024a1"`,
+    );
+    await queryRunner.query(`DROP TABLE "GameSpec"`);
+  }
+}

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/foundation/db/adapter/nest/models/entities.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/foundation/db/adapter/nest/models/entities.ts
@@ -1,6 +1,12 @@
 import { GameDb } from '../../../../../games/adapter/typeorm/models/GameDb';
 import { GameOptionsDb } from '../../../../../games/adapter/typeorm/models/GameOptionsDb';
 import { GameSlotDb } from '../../../../../games/adapter/typeorm/models/GameSlotDb';
+import { GameSpecDb } from '../../../../../games/adapter/typeorm/models/GameSpecDb';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export const typeOrmEntities: Function[] = [GameDb, GameOptionsDb, GameSlotDb];
+export const typeOrmEntities: Function[] = [
+  GameDb,
+  GameOptionsDb,
+  GameSlotDb,
+  GameSpecDb,
+];

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/nest/modules/GameDbModule.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/nest/modules/GameDbModule.ts
@@ -12,6 +12,8 @@ import { DbModule } from '../../../../foundation/db/adapter/nest/modules/DbModul
 import { GameOptionsPersistenceTypeOrmAdapter } from '../../typeorm/adapters/GameOptionsPersistenceTypeOrmAdapter';
 import { GamePersistenceTypeOrmAdapter } from '../../typeorm/adapters/GamePersistenceTypeOrmAdapter';
 import { GameSlotPersistenceTypeOrmAdapter } from '../../typeorm/adapters/GameSlotPersistenceTypeOrmAdapter';
+import { GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder } from '../../typeorm/builders/GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder';
+import { GameSpecFromGameSpecDbBuilder } from '../../typeorm/builders/GameSpecFromGameSpecDbBuilder';
 import { GameCardSpecArrayToGameCardSpecArrayDbConverter } from '../../typeorm/converters/GameCardSpecArrayToGameCardSpecArrayDbConverter';
 import { GameCreateQueryToGameCreateQueryTypeOrmConverter } from '../../typeorm/converters/GameCreateQueryToGameCreateQueryTypeOrmConverter';
 import { GameDbToGameConverter } from '../../typeorm/converters/GameDbToGameConverter';
@@ -35,6 +37,7 @@ import { GameSlotDb } from '../../typeorm/models/GameSlotDb';
 import { GameSpecDb } from '../../typeorm/models/GameSpecDb';
 import { CreateGameOptionsTypeOrmService } from '../../typeorm/services/CreateGameOptionsTypeOrmService';
 import { CreateGameSlotTypeOrmService } from '../../typeorm/services/CreateGameSlotTypeOrmService';
+import { CreateGameSpecTypeOrmService } from '../../typeorm/services/CreateGameSpecTypeOrmService';
 import { CreateGameTypeOrmService } from '../../typeorm/services/CreateGameTypeOrmService';
 import { FindGameOptionsTypeOrmService } from '../../typeorm/services/FindGameOptionsTypeOrmService';
 import { FindGameTypeOrmService } from '../../typeorm/services/FindGameTypeOrmService';
@@ -65,6 +68,7 @@ export class GameDbModule {
       providers: [
         CreateGameOptionsTypeOrmService,
         CreateGameSlotTypeOrmService,
+        CreateGameSpecTypeOrmService,
         CreateGameTypeOrmService,
         FindGameTypeOrmService,
         FindGameOptionsTypeOrmService,
@@ -88,6 +92,8 @@ export class GameDbModule {
         GameSlotFindQueryToGameSlotFindQueryTypeOrmConverter,
         GameSlotUpdateQueryToGameSlotFindQueryTypeOrmConverter,
         GameSlotUpdateQueryToGameSlotSetQueryTypeOrmConverter,
+        GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder,
+        GameSpecFromGameSpecDbBuilder,
         GameStatusToGameStatusDbConverter,
         GameUpdateQueryToGameFindQueryTypeOrmConverter,
         GameUpdateQueryToGameSetQueryTypeOrmConverter,

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/nest/modules/GameDbModule.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/nest/modules/GameDbModule.ts
@@ -2,6 +2,7 @@ import {
   gameOptionsPersistenceOutputPortSymbol,
   gamePersistenceOutputPortSymbol,
   gameSlotPersistenceOutputPortSymbol,
+  gameSpecPersistenceOutputPortSymbol,
 } from '@cornie-js/backend-game-application/games';
 import { DynamicModule, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -12,6 +13,7 @@ import { DbModule } from '../../../../foundation/db/adapter/nest/modules/DbModul
 import { GameOptionsPersistenceTypeOrmAdapter } from '../../typeorm/adapters/GameOptionsPersistenceTypeOrmAdapter';
 import { GamePersistenceTypeOrmAdapter } from '../../typeorm/adapters/GamePersistenceTypeOrmAdapter';
 import { GameSlotPersistenceTypeOrmAdapter } from '../../typeorm/adapters/GameSlotPersistenceTypeOrmAdapter';
+import { GameSpecPersistenceTypeOrmAdapter } from '../../typeorm/adapters/GameSpecPersistenceTypeOrmAdapter';
 import { GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder } from '../../typeorm/builders/GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder';
 import { GameSpecFromGameSpecDbBuilder } from '../../typeorm/builders/GameSpecFromGameSpecDbBuilder';
 import { GameCardSpecArrayToGameCardSpecArrayDbConverter } from '../../typeorm/converters/GameCardSpecArrayToGameCardSpecArrayDbConverter';
@@ -52,6 +54,7 @@ export class GameDbModule {
         gameOptionsPersistenceOutputPortSymbol,
         gamePersistenceOutputPortSymbol,
         gameSlotPersistenceOutputPortSymbol,
+        gameSpecPersistenceOutputPortSymbol,
       ],
       global: false,
       imports: [
@@ -94,6 +97,10 @@ export class GameDbModule {
         GameSlotUpdateQueryToGameSlotSetQueryTypeOrmConverter,
         GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder,
         GameSpecFromGameSpecDbBuilder,
+        {
+          provide: gameSpecPersistenceOutputPortSymbol,
+          useClass: GameSpecPersistenceTypeOrmAdapter,
+        },
         GameStatusToGameStatusDbConverter,
         GameUpdateQueryToGameFindQueryTypeOrmConverter,
         GameUpdateQueryToGameSetQueryTypeOrmConverter,

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/nest/modules/GameDbModule.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/nest/modules/GameDbModule.ts
@@ -32,6 +32,7 @@ import { GameUpdateQueryToGameSetQueryTypeOrmConverter } from '../../typeorm/con
 import { GameDb } from '../../typeorm/models/GameDb';
 import { GameOptionsDb } from '../../typeorm/models/GameOptionsDb';
 import { GameSlotDb } from '../../typeorm/models/GameSlotDb';
+import { GameSpecDb } from '../../typeorm/models/GameSpecDb';
 import { CreateGameOptionsTypeOrmService } from '../../typeorm/services/CreateGameOptionsTypeOrmService';
 import { CreateGameSlotTypeOrmService } from '../../typeorm/services/CreateGameSlotTypeOrmService';
 import { CreateGameTypeOrmService } from '../../typeorm/services/CreateGameTypeOrmService';
@@ -53,7 +54,12 @@ export class GameDbModule {
       imports: [
         CardDbModule,
         DbModule.forRootAsync(dbModuleOptions),
-        TypeOrmModule.forFeature([GameDb, GameOptionsDb, GameSlotDb]),
+        TypeOrmModule.forFeature([
+          GameDb,
+          GameOptionsDb,
+          GameSlotDb,
+          GameSpecDb,
+        ]),
       ],
       module: GameDbModule,
       providers: [

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/adapters/GameSpecPersistenceTypeOrmAdapter.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/adapters/GameSpecPersistenceTypeOrmAdapter.spec.ts
@@ -1,0 +1,74 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import {
+  GameSpec,
+  GameSpecCreateQuery,
+} from '@cornie-js/backend-game-domain/games';
+import {
+  GameSpecCreateQueryFixtures,
+  GameSpecFixtures,
+} from '@cornie-js/backend-game-domain/games/fixtures';
+
+import { CreateGameSpecTypeOrmService } from '../services/CreateGameSpecTypeOrmService';
+import { GameSpecPersistenceTypeOrmAdapter } from './GameSpecPersistenceTypeOrmAdapter';
+
+describe(GameSpecPersistenceTypeOrmAdapter.name, () => {
+  let createGameSpecTypeOrmServiceMock: jest.Mocked<CreateGameSpecTypeOrmService>;
+
+  let gameSpecPersistenceTypeOrmAdapter: GameSpecPersistenceTypeOrmAdapter;
+
+  beforeAll(() => {
+    createGameSpecTypeOrmServiceMock = {
+      insertOne: jest.fn(),
+    } as Partial<
+      jest.Mocked<CreateGameSpecTypeOrmService>
+    > as jest.Mocked<CreateGameSpecTypeOrmService>;
+
+    gameSpecPersistenceTypeOrmAdapter = new GameSpecPersistenceTypeOrmAdapter(
+      createGameSpecTypeOrmServiceMock,
+    );
+  });
+
+  describe('.create', () => {
+    let gameSpecCreateQueryFixture: GameSpecCreateQuery;
+
+    beforeAll(() => {
+      gameSpecCreateQueryFixture = GameSpecCreateQueryFixtures.any;
+    });
+
+    describe('when called', () => {
+      let gameSpecFixture: GameSpec;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        gameSpecFixture = GameSpecFixtures.any;
+
+        createGameSpecTypeOrmServiceMock.insertOne.mockResolvedValueOnce(
+          gameSpecFixture,
+        );
+
+        result = await gameSpecPersistenceTypeOrmAdapter.create(
+          gameSpecCreateQueryFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call createGameSpecTypeOrmService.insertOne()', () => {
+        expect(
+          createGameSpecTypeOrmServiceMock.insertOne,
+        ).toHaveBeenCalledTimes(1);
+        expect(createGameSpecTypeOrmServiceMock.insertOne).toHaveBeenCalledWith(
+          gameSpecCreateQueryFixture,
+        );
+      });
+
+      it('should return GameSpec', () => {
+        expect(result).toBe(gameSpecFixture);
+      });
+    });
+  });
+});

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/adapters/GameSpecPersistenceTypeOrmAdapter.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/adapters/GameSpecPersistenceTypeOrmAdapter.ts
@@ -1,0 +1,28 @@
+import { GameSpecPersistenceOutputPort } from '@cornie-js/backend-game-application/games';
+import {
+  GameSpecCreateQuery,
+  GameSpec,
+} from '@cornie-js/backend-game-domain/games';
+import { Inject, Injectable } from '@nestjs/common';
+
+import { CreateGameSpecTypeOrmService } from '../services/CreateGameSpecTypeOrmService';
+
+@Injectable()
+export class GameSpecPersistenceTypeOrmAdapter
+  implements GameSpecPersistenceOutputPort
+{
+  readonly #createGameSpecTypeOrmService: CreateGameSpecTypeOrmService;
+
+  constructor(
+    @Inject(CreateGameSpecTypeOrmService)
+    createGameSpecTypeOrmService: CreateGameSpecTypeOrmService,
+  ) {
+    this.#createGameSpecTypeOrmService = createGameSpecTypeOrmService;
+  }
+
+  public async create(
+    gameSpecCreateQuery: GameSpecCreateQuery,
+  ): Promise<GameSpec> {
+    return this.#createGameSpecTypeOrmService.insertOne(gameSpecCreateQuery);
+  }
+}

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder.spec.ts
@@ -1,0 +1,100 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { Converter } from '@cornie-js/backend-common';
+import {
+  GameCardSpec,
+  GameSpecCreateQuery,
+} from '@cornie-js/backend-game-domain/games';
+import { GameSpecCreateQueryFixtures } from '@cornie-js/backend-game-domain/games/fixtures';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity.js';
+
+import { GameSpecDb } from '../models/GameSpecDb';
+import { GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder } from './GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder';
+
+describe(
+  GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder.name,
+  () => {
+    let gameCardSpecArrayToGameCardSpecArrayDbConverterMock: jest.Mocked<
+      Converter<GameCardSpec[], string>
+    >;
+
+    let gameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder: GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder;
+
+    beforeAll(() => {
+      gameCardSpecArrayToGameCardSpecArrayDbConverterMock = {
+        convert: jest.fn(),
+      };
+
+      gameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder =
+        new GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder(
+          gameCardSpecArrayToGameCardSpecArrayDbConverterMock,
+        );
+    });
+
+    describe('.build', () => {
+      let gameSpecCreateQueryFixture: GameSpecCreateQuery;
+
+      beforeAll(() => {
+        gameSpecCreateQueryFixture = GameSpecCreateQueryFixtures.any;
+      });
+
+      describe('when called', () => {
+        let cardSpecsStringifiedFixture: string;
+
+        let result: unknown;
+
+        beforeAll(() => {
+          cardSpecsStringifiedFixture = 'cards-fixture';
+
+          gameCardSpecArrayToGameCardSpecArrayDbConverterMock.convert.mockReturnValueOnce(
+            cardSpecsStringifiedFixture,
+          );
+
+          result =
+            gameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder.build(
+              gameSpecCreateQueryFixture,
+            );
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call gameCardSpecArrayToGameCardSpecArrayDbConverter.convert()', () => {
+          expect(
+            gameCardSpecArrayToGameCardSpecArrayDbConverterMock.convert,
+          ).toHaveBeenCalledTimes(1);
+          expect(
+            gameCardSpecArrayToGameCardSpecArrayDbConverterMock.convert,
+          ).toHaveBeenCalledWith(gameSpecCreateQueryFixture.cards);
+        });
+
+        it('should return DeepPartial<GameSpecDb>', () => {
+          const expected: QueryDeepPartialEntity<GameSpecDb> = {
+            cardsSpec: cardSpecsStringifiedFixture,
+            chainDraw2Draw2Cards:
+              gameSpecCreateQueryFixture.options.chainDraw2Draw2Cards,
+            chainDraw2Draw4Cards:
+              gameSpecCreateQueryFixture.options.chainDraw2Draw4Cards,
+            chainDraw4Draw2Cards:
+              gameSpecCreateQueryFixture.options.chainDraw4Draw2Cards,
+            chainDraw4Draw4Cards:
+              gameSpecCreateQueryFixture.options.chainDraw4Draw4Cards,
+            game: { id: gameSpecCreateQueryFixture.options.gameId },
+            gameSlotsAmount: gameSpecCreateQueryFixture.gameSlotsAmount,
+            id: gameSpecCreateQueryFixture.id,
+            playCardIsMandatory:
+              gameSpecCreateQueryFixture.options.playCardIsMandatory,
+            playMultipleSameCards:
+              gameSpecCreateQueryFixture.options.playMultipleSameCards,
+            playWildDraw4IfNoOtherAlternative:
+              gameSpecCreateQueryFixture.options
+                .playWildDraw4IfNoOtherAlternative,
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+  },
+);

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder.ts
@@ -1,0 +1,57 @@
+import { Builder, Converter } from '@cornie-js/backend-common';
+import {
+  GameCardSpec,
+  GameSpecCreateQuery,
+} from '@cornie-js/backend-game-domain/games';
+import { Inject, Injectable } from '@nestjs/common';
+import { DeepPartial } from 'typeorm';
+
+import { GameCardSpecArrayToGameCardSpecArrayDbConverter } from '../converters/GameCardSpecArrayToGameCardSpecArrayDbConverter';
+import { GameSpecDb } from '../models/GameSpecDb';
+
+@Injectable()
+export class GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder
+  implements Builder<DeepPartial<GameSpecDb>, [GameSpecCreateQuery]>
+{
+  readonly #gameCardSpecArrayToGameCardSpecArrayDbConverter: Converter<
+    GameCardSpec[],
+    string
+  >;
+
+  constructor(
+    @Inject(GameCardSpecArrayToGameCardSpecArrayDbConverter)
+    gameCardSpecArrayToGameCardSpecArrayDbConverter: Converter<
+      GameCardSpec[],
+      string
+    >,
+  ) {
+    this.#gameCardSpecArrayToGameCardSpecArrayDbConverter =
+      gameCardSpecArrayToGameCardSpecArrayDbConverter;
+  }
+
+  public build(
+    gameSpecCreateQuery: GameSpecCreateQuery,
+  ): DeepPartial<GameSpecDb> {
+    const gameCardsStringified: string =
+      this.#gameCardSpecArrayToGameCardSpecArrayDbConverter.convert(
+        gameSpecCreateQuery.cards,
+      );
+
+    return {
+      cardsSpec: gameCardsStringified,
+      chainDraw2Draw2Cards: gameSpecCreateQuery.options.chainDraw2Draw2Cards,
+      chainDraw2Draw4Cards: gameSpecCreateQuery.options.chainDraw2Draw4Cards,
+      chainDraw4Draw2Cards: gameSpecCreateQuery.options.chainDraw4Draw2Cards,
+      chainDraw4Draw4Cards: gameSpecCreateQuery.options.chainDraw4Draw4Cards,
+      game: {
+        id: gameSpecCreateQuery.gameId,
+      },
+      gameSlotsAmount: gameSpecCreateQuery.gameSlotsAmount,
+      id: gameSpecCreateQuery.id,
+      playCardIsMandatory: gameSpecCreateQuery.options.playCardIsMandatory,
+      playMultipleSameCards: gameSpecCreateQuery.options.playMultipleSameCards,
+      playWildDraw4IfNoOtherAlternative:
+        gameSpecCreateQuery.options.playWildDraw4IfNoOtherAlternative,
+    };
+  }
+}

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSpecFromGameSpecDbBuilder.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSpecFromGameSpecDbBuilder.spec.ts
@@ -1,0 +1,82 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { Builder } from '@cornie-js/backend-common';
+import { Card } from '@cornie-js/backend-game-domain/cards';
+import { CardFixtures } from '@cornie-js/backend-game-domain/cards/fixtures';
+import { GameSpec } from '@cornie-js/backend-game-domain/games';
+
+import { CardDb } from '../../../../cards/adapter/typeorm/models/CardDb';
+import { GameSpecDbFixtures } from '../fixtures/GameSpecDbFixtures';
+import { GameCardSpecDb } from '../models/GameCardSpecDb';
+import { GameSpecDb } from '../models/GameSpecDb';
+import { GameSpecFromGameSpecDbBuilder } from './GameSpecFromGameSpecDbBuilder';
+
+describe(GameSpecFromGameSpecDbBuilder.name, () => {
+  let cardBuilderMock: jest.Mocked<Builder<Card, [CardDb]>>;
+
+  let gameSpecFromGameSpecDbBuilder: GameSpecFromGameSpecDbBuilder;
+
+  beforeAll(() => {
+    cardBuilderMock = {
+      build: jest.fn(),
+    };
+
+    gameSpecFromGameSpecDbBuilder = new GameSpecFromGameSpecDbBuilder(
+      cardBuilderMock,
+    );
+  });
+
+  describe('having a valid GameSpecDb with a card', () => {
+    let gameCardSpecDbFixture: GameCardSpecDb;
+    let gameSpecDbFixture: GameSpecDb;
+
+    beforeAll(() => {
+      gameSpecDbFixture = GameSpecDbFixtures.withCardSpecWithOne;
+
+      [gameCardSpecDbFixture] = JSON.parse(gameSpecDbFixture.cardsSpec) as [
+        GameCardSpecDb,
+      ];
+    });
+
+    describe('when called', () => {
+      let cardFixture: Card;
+
+      beforeAll(() => {
+        cardFixture = CardFixtures.any;
+      });
+
+      let result: unknown;
+
+      beforeAll(() => {
+        cardBuilderMock.build.mockReturnValueOnce(cardFixture);
+
+        result = gameSpecFromGameSpecDbBuilder.build(gameSpecDbFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call cardBuilder.build()', () => {
+        expect(cardBuilderMock.build).toHaveBeenCalledTimes(1);
+        expect(cardBuilderMock.build).toHaveBeenCalledWith(
+          gameCardSpecDbFixture.card,
+        );
+      });
+
+      it('should return a GameSpec', () => {
+        const expected: GameSpec = {
+          cards: [
+            {
+              amount: gameCardSpecDbFixture.amount,
+              card: cardFixture,
+            },
+          ],
+          gameSlotsAmount: gameSpecDbFixture.gameSlotsAmount,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+});

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSpecFromGameSpecDbBuilder.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSpecFromGameSpecDbBuilder.ts
@@ -1,0 +1,60 @@
+import { AppError, AppErrorKind, Builder } from '@cornie-js/backend-common';
+import { Card } from '@cornie-js/backend-game-domain/cards';
+import { GameCardSpec, GameSpec } from '@cornie-js/backend-game-domain/games';
+import { Inject, Injectable } from '@nestjs/common';
+
+import { CardBuilder } from '../../../../cards/adapter/typeorm/builders/CardBuilder';
+import { CardDb } from '../../../../cards/adapter/typeorm/models/CardDb';
+import { GameCardSpecDb } from '../models/GameCardSpecDb';
+import { GameSpecDb } from '../models/GameSpecDb';
+
+@Injectable()
+export class GameSpecFromGameSpecDbBuilder
+  implements Builder<GameSpec, [GameSpecDb]>
+{
+  readonly #cardBuilder: Builder<Card, [CardDb]>;
+
+  constructor(@Inject(CardBuilder) cardBuilder: Builder<Card, [CardDb]>) {
+    this.#cardBuilder = cardBuilder;
+  }
+
+  public build(gameSpecDb: GameSpecDb): GameSpec {
+    return {
+      cards: this.#convertCardSpecs(gameSpecDb.cardsSpec),
+      gameSlotsAmount: gameSpecDb.gameSlotsAmount,
+    };
+  }
+
+  #convertCardSpecs(specs: string): GameCardSpec[] {
+    const gameCardDbSpecs: unknown = JSON.parse(specs);
+
+    if (!this.#isGameCardSpecDbArray(gameCardDbSpecs)) {
+      throw new AppError(AppErrorKind.unknown, 'Unexpected card spec db entry');
+    }
+
+    return gameCardDbSpecs.map((gameCardSpecDb: GameCardSpecDb) => ({
+      amount: gameCardSpecDb.amount,
+      card: this.#cardBuilder.build(gameCardSpecDb.card),
+    }));
+  }
+
+  #isGameCardSpecDbArray(
+    parsedSpecs: unknown,
+  ): parsedSpecs is GameCardSpecDb[] {
+    return (
+      Array.isArray(parsedSpecs) &&
+      parsedSpecs.every((parsedSpec: unknown): parsedSpec is GameCardSpecDb =>
+        this.#isGameCardSpecDb(parsedSpec),
+      )
+    );
+  }
+
+  #isGameCardSpecDb(parsedSpec: unknown): parsedSpec is GameCardSpecDb {
+    return (
+      typeof parsedSpec === 'object' &&
+      parsedSpec !== null &&
+      typeof (parsedSpec as GameCardSpecDb).amount === 'number' &&
+      typeof (parsedSpec as GameCardSpecDb).card === 'number'
+    );
+  }
+}

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/fixtures/GameSpecDbFixtures.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/fixtures/GameSpecDbFixtures.ts
@@ -1,0 +1,31 @@
+import { Writable } from '@cornie-js/backend-common';
+
+import { GameSpecDb } from '../models/GameSpecDb';
+
+export class GameSpecDbFixtures {
+  public static get any(): GameSpecDb {
+    const fixture: Writable<GameSpecDb> = new GameSpecDb();
+
+    fixture.cardsSpec = '[{ "amount": 1, "card": 39 }]';
+    fixture.chainDraw2Draw2Cards = false;
+    fixture.chainDraw2Draw4Cards = false;
+    fixture.chainDraw4Draw2Cards = false;
+    fixture.chainDraw4Draw4Cards = false;
+    fixture.gameId = 'e6b54159-a4ef-41fc-994a-20709526bdaa';
+    fixture.gameSlotsAmount = 2;
+    fixture.id = 'e3b54159-a4ef-41fc-094a-20709526bdaf';
+    fixture.playCardIsMandatory = false;
+    fixture.playMultipleSameCards = false;
+    fixture.playWildDraw4IfNoOtherAlternative = true;
+
+    return fixture;
+  }
+
+  public static get withCardSpecWithOne(): GameSpecDb {
+    const fixture: Writable<GameSpecDb> = GameSpecDbFixtures.any;
+
+    fixture.cardsSpec = '[{ "amount": 1, "card": 39 }]';
+
+    return fixture;
+  }
+}

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/models/GameSpecDb.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/models/GameSpecDb.ts
@@ -1,0 +1,99 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryColumn,
+  RelationId,
+} from 'typeorm';
+
+import { NumberToBooleanTransformer } from '../../../../foundation/db/adapter/typeorm/transformers/NumberToBooleanTransformer';
+import { GameDb } from './GameDb';
+
+@Entity({
+  name: 'GameSpec',
+})
+export class GameSpecDb {
+  @Column({
+    name: 'spec',
+    type: 'json',
+  })
+  public readonly cardsSpec!: string;
+
+  @Column({
+    name: 'chain_draw_2_draw_2_cards',
+    transformer: new NumberToBooleanTransformer(),
+    type: 'smallint',
+    width: 1,
+  })
+  public readonly chainDraw2Draw2Cards!: boolean;
+
+  @Column({
+    name: 'chain_draw_2_draw_4_cards',
+    transformer: new NumberToBooleanTransformer(),
+    type: 'smallint',
+    width: 1,
+  })
+  public readonly chainDraw2Draw4Cards!: boolean;
+
+  @Column({
+    name: 'chain_draw_4_draw_2_cards',
+    transformer: new NumberToBooleanTransformer(),
+    type: 'smallint',
+    width: 1,
+  })
+  public readonly chainDraw4Draw2Cards!: boolean;
+
+  @Column({
+    name: 'chain_draw_4_draw_4_cards',
+    transformer: new NumberToBooleanTransformer(),
+    type: 'smallint',
+    width: 1,
+  })
+  public readonly chainDraw4Draw4Cards!: boolean;
+
+  @OneToOne(() => GameDb, { nullable: false })
+  @JoinColumn({ name: 'game_id' })
+  public readonly game!: GameDb;
+
+  @RelationId((gameOptions: GameSpecDb) => gameOptions.game)
+  public readonly gameId!: string;
+
+  @Column({
+    name: 'game_slots_amount',
+    nullable: false,
+    type: 'smallint',
+  })
+  public readonly gameSlotsAmount!: number;
+
+  @PrimaryColumn({
+    length: 36,
+    name: 'id',
+    type: 'varchar',
+  })
+  public readonly id!: string;
+
+  @Column({
+    name: 'play_card_is_mandatory',
+    transformer: new NumberToBooleanTransformer(),
+    type: 'smallint',
+    width: 1,
+  })
+  public readonly playCardIsMandatory!: boolean;
+
+  @Column({
+    name: 'play_multiple_same_cards',
+    transformer: new NumberToBooleanTransformer(),
+    type: 'smallint',
+    width: 1,
+  })
+  public readonly playMultipleSameCards!: boolean;
+
+  @Column({
+    name: 'play_wild_draw_4_if_no_other_alternative',
+    transformer: new NumberToBooleanTransformer(),
+    type: 'smallint',
+    width: 1,
+  })
+  public readonly playWildDraw4IfNoOtherAlternative!: boolean;
+}

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/services/CreateGameSpecTypeOrmService.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/services/CreateGameSpecTypeOrmService.ts
@@ -1,0 +1,38 @@
+import { Builder } from '@cornie-js/backend-common';
+import { InsertTypeOrmPostgresServiceV2 } from '@cornie-js/backend-db';
+import {
+  GameSpec,
+  GameSpecCreateQuery,
+} from '@cornie-js/backend-game-domain/games';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DeepPartial, Repository } from 'typeorm';
+
+import { GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder } from '../builders/GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder';
+import { GameSpecFromGameSpecDbBuilder } from '../builders/GameSpecFromGameSpecDbBuilder';
+import { GameSpecDb } from '../models/GameSpecDb';
+
+@Injectable()
+export class CreateGameSpecTypeOrmService extends InsertTypeOrmPostgresServiceV2<
+  GameSpec,
+  GameSpecDb,
+  GameSpecCreateQuery
+> {
+  constructor(
+    @InjectRepository(GameSpecDb)
+    repository: Repository<GameSpecDb>,
+    @Inject(GameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder)
+    gameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder: Builder<
+      DeepPartial<GameSpecDb>,
+      [GameSpecCreateQuery]
+    >,
+    @Inject(GameSpecFromGameSpecDbBuilder)
+    gameSpecFromGameSpecDbBuilder: Builder<GameSpec, [GameSpecDb]>,
+  ) {
+    super(
+      repository,
+      gameSpecFromGameSpecDbBuilder,
+      gameSpecCreateQueryTypeormFromGameGameSpecCreateQueryBuilder,
+    );
+  }
+}

--- a/packages/backend/apps/game/backend-game-application/src/games/application/builders/GameCreateQueryFromGameCreateQueryV1Builder.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/builders/GameCreateQueryFromGameCreateQueryV1Builder.spec.ts
@@ -109,7 +109,9 @@ describe(GameCreateQueryFromGameCreateQueryV1Builder.name, () => {
           name: gameCreateQueryV1Fixture.name,
           spec: {
             cards: [gameCardSpecFixture],
+            gameId: gameCreateQueryContextFixture.uuid,
             gameSlotsAmount: gameCreateQueryV1Fixture.gameSlotsAmount,
+            id: gameCreateQueryContextFixture.gameSpecId,
             options: gameOptionsCreateQueryFixture,
           },
         };

--- a/packages/backend/apps/game/backend-game-application/src/games/application/builders/GameCreateQueryFromGameCreateQueryV1Builder.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/builders/GameCreateQueryFromGameCreateQueryV1Builder.ts
@@ -59,7 +59,9 @@ export class GameCreateQueryFromGameCreateQueryV1Builder
       name: gameCreateQueryV1.name,
       spec: {
         cards: this.#gameService.getInitialCardsSpec(),
+        gameId: context.uuid,
         gameSlotsAmount: gameCreateQueryV1.gameSlotsAmount,
+        id: context.gameSpecId,
         options: gameOptionsCreateQuery,
       },
     };

--- a/packages/backend/apps/game/backend-game-application/src/games/application/fixtures/GameCreateQueryContextFixtures.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/fixtures/GameCreateQueryContextFixtures.ts
@@ -4,6 +4,7 @@ export class GameCreateQueryContextFixtures {
   public static get any(): GameCreateQueryContext {
     return {
       gameOptionsId: '738e3afd-b015-4385-ad87-378475db4847',
+      gameSpecId: 'e3b54159-a4ef-41fc-094a-20709526bdaf',
       uuid: 'e6b54159-a4ef-41fc-994a-20709526bdaa',
     };
   }

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameCreatedEventHandler.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameCreatedEventHandler.spec.ts
@@ -5,10 +5,12 @@ import { GameOptionsFixtures } from '@cornie-js/backend-game-domain/games/fixtur
 import { GameCreatedEventFixtures } from '../fixtures/GameCreatedEventFixtures';
 import { GameCreatedEvent } from '../models/GameCreatedEvent';
 import { GameOptionsPersistenceOutputPort } from '../ports/output/GameOptionsPersistenceOutputPort';
+import { GameSpecPersistenceOutputPort } from '../ports/output/GameSpecPersistenceOutputPort';
 import { GameCreatedEventHandler } from './GameCreatedEventHandler';
 
 describe(GameCreatedEventHandler.name, () => {
   let gameOptionsPersistenceOutputPortMock: jest.Mocked<GameOptionsPersistenceOutputPort>;
+  let gameSpecPersistenceOutputPortMock: jest.Mocked<GameSpecPersistenceOutputPort>;
 
   let gameCreatedEventHandler: GameCreatedEventHandler;
 
@@ -18,9 +20,13 @@ describe(GameCreatedEventHandler.name, () => {
     } as Partial<
       jest.Mocked<GameOptionsPersistenceOutputPort>
     > as jest.Mocked<GameOptionsPersistenceOutputPort>;
+    gameSpecPersistenceOutputPortMock = {
+      create: jest.fn(),
+    };
 
     gameCreatedEventHandler = new GameCreatedEventHandler(
       gameOptionsPersistenceOutputPortMock,
+      gameSpecPersistenceOutputPortMock,
     );
   });
 
@@ -50,6 +56,15 @@ describe(GameCreatedEventHandler.name, () => {
           gameOptionsPersistenceOutputPortMock.create,
         ).toHaveBeenCalledWith(
           gameCreatedEventFixture.gameCreateQuery.spec.options,
+        );
+      });
+
+      it('should call gameSpecPersistenceOutputPort.create()', () => {
+        expect(gameSpecPersistenceOutputPortMock.create).toHaveBeenCalledTimes(
+          1,
+        );
+        expect(gameSpecPersistenceOutputPortMock.create).toHaveBeenCalledWith(
+          gameCreatedEventFixture.gameCreateQuery.spec,
         );
       });
 

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameCreatedEventHandler.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameCreatedEventHandler.ts
@@ -6,23 +6,36 @@ import {
   GameOptionsPersistenceOutputPort,
   gameOptionsPersistenceOutputPortSymbol,
 } from '../ports/output/GameOptionsPersistenceOutputPort';
+import {
+  GameSpecPersistenceOutputPort,
+  gameSpecPersistenceOutputPortSymbol,
+} from '../ports/output/GameSpecPersistenceOutputPort';
 
 @Injectable()
 export class GameCreatedEventHandler
   implements Handler<[GameCreatedEvent], void>
 {
   readonly #gameOptionsPersistenceOutputPort: GameOptionsPersistenceOutputPort;
+  readonly #gameSpecPersistenceOutputPort: GameSpecPersistenceOutputPort;
 
   constructor(
     @Inject(gameOptionsPersistenceOutputPortSymbol)
     gameOptionsPersistenceOutputPort: GameOptionsPersistenceOutputPort,
+    @Inject(gameSpecPersistenceOutputPortSymbol)
+    gameSpecPersistenceOutputPort: GameSpecPersistenceOutputPort,
   ) {
     this.#gameOptionsPersistenceOutputPort = gameOptionsPersistenceOutputPort;
+    this.#gameSpecPersistenceOutputPort = gameSpecPersistenceOutputPort;
   }
 
   public async handle(gameCreatedEvent: GameCreatedEvent): Promise<void> {
-    await this.#gameOptionsPersistenceOutputPort.create(
-      gameCreatedEvent.gameCreateQuery.spec.options,
-    );
+    await Promise.all([
+      this.#gameOptionsPersistenceOutputPort.create(
+        gameCreatedEvent.gameCreateQuery.spec.options,
+      ),
+      this.#gameSpecPersistenceOutputPort.create(
+        gameCreatedEvent.gameCreateQuery.spec,
+      ),
+    ]);
   }
 }

--- a/packages/backend/apps/game/backend-game-application/src/games/application/index.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/index.ts
@@ -31,6 +31,10 @@ import {
   GameSlotPersistenceOutputPort,
   gameSlotPersistenceOutputPortSymbol,
 } from './ports/output/GameSlotPersistenceOutputPort';
+import {
+  GameSpecPersistenceOutputPort,
+  gameSpecPersistenceOutputPortSymbol,
+} from './ports/output/GameSpecPersistenceOutputPort';
 
 export type {
   BaseGameMessageEvent,
@@ -40,6 +44,7 @@ export type {
   GameOptionsPersistenceOutputPort,
   GamePersistenceOutputPort,
   GameSlotPersistenceOutputPort,
+  GameSpecPersistenceOutputPort,
   GameUpdatedMessageEvent,
 };
 
@@ -49,6 +54,7 @@ export {
   GameMiddleware,
   gameOptionsPersistenceOutputPortSymbol,
   gamePersistenceOutputPortSymbol,
+  gameSpecPersistenceOutputPortSymbol,
   gameSlotPersistenceOutputPortSymbol,
   GetGameGameIdEventsV1SseController,
   GetGameGameIdSlotSlotIdCardsV1RequestController,

--- a/packages/backend/apps/game/backend-game-application/src/games/application/models/GameCreateQueryContext.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/models/GameCreateQueryContext.ts
@@ -2,4 +2,5 @@ import { UuidContext } from '../../../foundation/common/application/models/UuidC
 
 export interface GameCreateQueryContext extends UuidContext {
   gameOptionsId: string;
+  gameSpecId: string;
 }

--- a/packages/backend/apps/game/backend-game-application/src/games/application/ports/input/GameManagementInputPort.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/ports/input/GameManagementInputPort.spec.ts
@@ -138,13 +138,14 @@ describe(GameManagementInputPort.name, () => {
       });
 
       it('should call uuidProviderOutputPort.generateV4()', () => {
-        expect(uuidProviderOutputPortMock.generateV4).toHaveBeenCalledTimes(2);
+        expect(uuidProviderOutputPortMock.generateV4).toHaveBeenCalledTimes(3);
         expect(uuidProviderOutputPortMock.generateV4).toHaveBeenCalledWith();
       });
 
       it('should call gameCreateQueryFromGameCreateQueryV1Builder.build()', () => {
         const expectedUuidContext: GameCreateQueryContext = {
           gameOptionsId: uuidFixture,
+          gameSpecId: uuidFixture,
           uuid: uuidFixture,
         };
 
@@ -223,13 +224,14 @@ describe(GameManagementInputPort.name, () => {
       });
 
       it('should call uuidProviderOutputPort.generateV4()', () => {
-        expect(uuidProviderOutputPortMock.generateV4).toHaveBeenCalledTimes(2);
+        expect(uuidProviderOutputPortMock.generateV4).toHaveBeenCalledTimes(3);
         expect(uuidProviderOutputPortMock.generateV4).toHaveBeenCalledWith();
       });
 
       it('should call gameCreateQueryFromGameCreateQueryV1Builder.build()', () => {
         const expectedUuidContext: GameCreateQueryContext = {
           gameOptionsId: uuidFixture,
+          gameSpecId: uuidFixture,
           uuid: uuidFixture,
         };
 

--- a/packages/backend/apps/game/backend-game-application/src/games/application/ports/input/GameManagementInputPort.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/ports/input/GameManagementInputPort.ts
@@ -169,6 +169,7 @@ export class GameManagementInputPort {
   #createGameCreationQueryContext(): GameCreateQueryContext {
     return {
       gameOptionsId: this.#uuidProviderOutputPort.generateV4(),
+      gameSpecId: this.#uuidProviderOutputPort.generateV4(),
       uuid: this.#uuidProviderOutputPort.generateV4(),
     };
   }

--- a/packages/backend/apps/game/backend-game-application/src/games/application/ports/output/GameSpecPersistenceOutputPort.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/ports/output/GameSpecPersistenceOutputPort.ts
@@ -1,0 +1,12 @@
+import {
+  GameSpec,
+  GameSpecCreateQuery,
+} from '@cornie-js/backend-game-domain/games';
+
+export interface GameSpecPersistenceOutputPort {
+  create(gameSpecCreateQuery: GameSpecCreateQuery): Promise<GameSpec>;
+}
+
+export const gameSpecPersistenceOutputPortSymbol: symbol = Symbol.for(
+  'GameSpecPersistenceOutputPort',
+);

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameCreateQueryFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameCreateQueryFixtures.ts
@@ -1,17 +1,13 @@
-import { GameOptionsCreateQueryFixtures } from '.';
 import { CardFixtures } from '../../../cards/domain/fixtures/CardFixtures';
 import { GameCreateQuery } from '../query/GameCreateQuery';
+import { GameSpecCreateQueryFixtures } from './GameSpecCreateQueryFixtures';
 
 export class GameCreateQueryFixtures {
   public static get any(): GameCreateQuery {
     const fixture: GameCreateQuery = {
       id: 'e6b54159-a4ef-41fc-994a-20709526bdaa',
       name: undefined,
-      spec: {
-        cards: [],
-        gameSlotsAmount: 2,
-        options: GameOptionsCreateQueryFixtures.any,
-      },
+      spec: GameSpecCreateQueryFixtures.any,
     };
 
     return fixture;

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameSpecCreateQueryFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameSpecCreateQueryFixtures.ts
@@ -1,0 +1,15 @@
+import { GameSpecCreateQuery } from '../query/GameSpecCreateQuery';
+import { GameCardSpecFixtures } from './GameCardSpecFixtures';
+import { GameOptionsFixtures } from './GameOptionsFixtures';
+
+export class GameSpecCreateQueryFixtures {
+  public static get any(): GameSpecCreateQuery {
+    return {
+      cards: [GameCardSpecFixtures.any],
+      gameId: 'e6b54159-a4ef-41fc-994a-20709526bdaa',
+      gameSlotsAmount: 2,
+      id: 'e3b54159-a4ef-41fc-094a-20709526bdaf',
+      options: GameOptionsFixtures.any,
+    };
+  }
+}

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/index.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/index.ts
@@ -11,6 +11,7 @@ import { GameOptionsFixtures } from './GameOptionsFixtures';
 import { GameSlotCreateQueryFixtures } from './GameSlotCreateQueryFixtures';
 import { GameSlotFindQueryFixtures } from './GameSlotFindQueryFixtures';
 import { GameSlotUpdateQueryFixtures } from './GameSlotUpdateQueryFixtures';
+import { GameSpecCreateQueryFixtures } from './GameSpecCreateQueryFixtures';
 import { GameSpecFixtures } from './GameSpecFixtures';
 import { GameUpdateQueryFixtures } from './GameUpdateQueryFixtures';
 import { NonStartedGameFixtures } from './NonStartedGameFixtures';
@@ -30,6 +31,7 @@ export {
   GameSlotCreateQueryFixtures,
   GameSlotFindQueryFixtures,
   GameSlotUpdateQueryFixtures,
+  GameSpecCreateQueryFixtures,
   GameSpecFixtures,
   GameUpdateQueryFixtures,
   NonStartedGameFixtures,

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/query/GameSpecCreateQuery.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/query/GameSpecCreateQuery.ts
@@ -3,6 +3,8 @@ import { GameOptionsCreateQuery } from './GameOptionsCreateQuery';
 
 export interface GameSpecCreateQuery {
   readonly cards: GameCardSpec[];
+  readonly gameId: string;
   readonly gameSlotsAmount: number;
+  readonly id: string;
   readonly options: GameOptionsCreateQuery;
 }


### PR DESCRIPTION
### Added
- Added `Add GameSpecDb`.
- Added `CreateGameSpecTypeOrmService`.
- Added `GameSpecPersistenceOutputPort`.
- Added `GameSpecPersistenceTypeOrmAdapter`.

### Changed
- Updated `GameCreatedEventHandler` to persist game spec as `GameSpecDb`.
