### PR TITLE
Update apollo server to rely on Context

### DIFF
--- a/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/ApplicationResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/ApplicationResolver.ts
@@ -1,7 +1,7 @@
 import { models as graphqlModels } from '@cornie-js/api-graphql-models';
-import { Request } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
+import { Context } from '../../../foundation/graphql/application/models/Context';
 import { GameResolver } from '../../../games/application/resolvers/GameResolver';
 import { RootMutationResolver } from './RootMutationResolver';
 import { RootQueryResolver } from './RootQueryResolver';
@@ -9,19 +9,19 @@ import { RootQueryResolver } from './RootQueryResolver';
 @Injectable()
 export class ApplicationResolver implements Partial<graphqlModels.Resolvers> {
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  public readonly Game: graphqlModels.GameResolvers<Request>;
+  public readonly Game: graphqlModels.GameResolvers<Context>;
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  public readonly RootMutation: graphqlModels.RootMutationResolvers<Request>;
+  public readonly RootMutation: graphqlModels.RootMutationResolvers<Context>;
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  public readonly RootQuery: graphqlModels.RootQueryResolvers<Request>;
+  public readonly RootQuery: graphqlModels.RootQueryResolvers<Context>;
 
   constructor(
     @Inject(GameResolver)
-    gameResolver: graphqlModels.GameResolvers<Request>,
+    gameResolver: graphqlModels.GameResolvers<Context>,
     @Inject(RootMutationResolver)
-    rootMutationResolver: graphqlModels.RootMutationResolvers<Request>,
+    rootMutationResolver: graphqlModels.RootMutationResolvers<Context>,
     @Inject(RootQueryResolver)
-    rootQueryResolver: graphqlModels.RootQueryResolvers<Request>,
+    rootQueryResolver: graphqlModels.RootQueryResolvers<Context>,
   ) {
     this.Game = gameResolver;
     this.RootMutation = rootMutationResolver;

--- a/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootMutationResolver.spec.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootMutationResolver.spec.ts
@@ -1,10 +1,10 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 import { models as graphqlModels } from '@cornie-js/api-graphql-models';
-import { Request } from '@cornie-js/backend-http';
 import { GraphQLResolveInfo } from 'graphql';
 
 import { CanonicalResolver } from '../../../foundation/graphql/application/models/CanonicalResolver';
+import { Context } from '../../../foundation/graphql/application/models/Context';
 import { RootMutationResolver } from './RootMutationResolver';
 
 function buildTestTuples(): [
@@ -12,44 +12,44 @@ function buildTestTuples(): [
   graphqlModels.ResolverFn<
     unknown,
     graphqlModels.RootMutation,
-    Request,
+    Context,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     any
   >,
   jest.Mock,
 ][] {
   const authMutationMock: jest.Mocked<
-    CanonicalResolver<graphqlModels.AuthMutationResolvers<Request>>
+    CanonicalResolver<graphqlModels.AuthMutationResolvers<Context>>
   > = {
     createAuthByCode: jest.fn(),
     createAuthByCredentials: jest.fn(),
   } as Partial<
-    jest.Mocked<CanonicalResolver<graphqlModels.AuthMutationResolvers<Request>>>
+    jest.Mocked<CanonicalResolver<graphqlModels.AuthMutationResolvers<Context>>>
   > as jest.Mocked<
-    CanonicalResolver<graphqlModels.AuthMutationResolvers<Request>>
+    CanonicalResolver<graphqlModels.AuthMutationResolvers<Context>>
   >;
 
   const gameMutationMock: jest.Mocked<
-    CanonicalResolver<graphqlModels.GameMutationResolvers<Request>>
+    CanonicalResolver<graphqlModels.GameMutationResolvers<Context>>
   > = {
     createGame: jest.fn(),
     passGameTurn: jest.fn(),
     playGameCards: jest.fn(),
   } as Partial<
-    jest.Mocked<CanonicalResolver<graphqlModels.GameMutationResolvers<Request>>>
+    jest.Mocked<CanonicalResolver<graphqlModels.GameMutationResolvers<Context>>>
   > as jest.Mocked<
-    CanonicalResolver<graphqlModels.GameMutationResolvers<Request>>
+    CanonicalResolver<graphqlModels.GameMutationResolvers<Context>>
   >;
 
   const userMutationMock: jest.Mocked<
-    CanonicalResolver<graphqlModels.UserMutationResolvers<Request>>
+    CanonicalResolver<graphqlModels.UserMutationResolvers<Context>>
   > = {
     createUser: jest.fn(),
     updateUserMe: jest.fn(),
   } as Partial<
-    jest.Mocked<CanonicalResolver<graphqlModels.UserMutationResolvers<Request>>>
+    jest.Mocked<CanonicalResolver<graphqlModels.UserMutationResolvers<Context>>>
   > as jest.Mocked<
-    CanonicalResolver<graphqlModels.UserMutationResolvers<Request>>
+    CanonicalResolver<graphqlModels.UserMutationResolvers<Context>>
   >;
 
   const rootMutationResolver: RootMutationResolver = new RootMutationResolver(
@@ -104,7 +104,7 @@ describe(RootMutationResolver.name, () => {
       graphqlModels.ResolverFn<
         unknown,
         graphqlModels.RootMutation,
-        Request,
+        Context,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         any
       >,
@@ -117,7 +117,7 @@ describe(RootMutationResolver.name, () => {
       resolver: graphqlModels.ResolverFn<
         unknown,
         graphqlModels.RootMutation,
-        Request,
+        Context,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         any
       >,
@@ -126,7 +126,7 @@ describe(RootMutationResolver.name, () => {
       describe('when called', () => {
         let parentFixture: graphqlModels.RootMutation;
         let argsFixture: unknown;
-        let requestFixture: Request;
+        let contextFixture: Context;
         let infoFixture: GraphQLResolveInfo;
 
         let resolverResultFixture: unknown;
@@ -136,7 +136,7 @@ describe(RootMutationResolver.name, () => {
         beforeAll(async () => {
           parentFixture = Symbol() as unknown as graphqlModels.RootMutation;
           argsFixture = Symbol();
-          requestFixture = Symbol() as unknown as Request;
+          contextFixture = Symbol() as unknown as Context;
           infoFixture = Symbol() as unknown as GraphQLResolveInfo;
 
           resolverResultFixture = Symbol();
@@ -148,7 +148,7 @@ describe(RootMutationResolver.name, () => {
           result = await resolver(
             parentFixture,
             argsFixture,
-            requestFixture,
+            contextFixture,
             infoFixture,
           );
         });
@@ -162,7 +162,7 @@ describe(RootMutationResolver.name, () => {
           expect(resolverMock).toHaveBeenCalledWith(
             parentFixture,
             argsFixture,
-            requestFixture,
+            contextFixture,
             infoFixture,
           );
         });

--- a/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootMutationResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootMutationResolver.ts
@@ -1,40 +1,40 @@
 import { models as graphqlModels } from '@cornie-js/api-graphql-models';
-import { Request } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 import { GraphQLResolveInfo } from 'graphql';
 
 import { AuthMutationResolver } from '../../../auth/application/resolvers/AuthMutationResolver';
 import { CanonicalResolver } from '../../../foundation/graphql/application/models/CanonicalResolver';
+import { Context } from '../../../foundation/graphql/application/models/Context';
 import { GameMutationResolver } from '../../../games/application/resolvers/GameMutationResolver';
 import { UserMutationResolver } from '../../../users/application/resolvers/UserMutationResolver';
 
 @Injectable()
 export class RootMutationResolver
   implements
-    graphqlModels.RootMutationResolvers<Request, graphqlModels.RootMutation>
+    graphqlModels.RootMutationResolvers<Context, graphqlModels.RootMutation>
 {
   readonly #authMutationResolver: CanonicalResolver<
-    graphqlModels.AuthMutationResolvers<Request>
+    graphqlModels.AuthMutationResolvers<Context>
   >;
   readonly #gameMutationResolver: CanonicalResolver<
-    graphqlModels.GameMutationResolvers<Request>
+    graphqlModels.GameMutationResolvers<Context>
   >;
   readonly #userMutationResolver: CanonicalResolver<
-    graphqlModels.UserMutationResolvers<Request>
+    graphqlModels.UserMutationResolvers<Context>
   >;
 
   constructor(
     @Inject(AuthMutationResolver)
     authMutationResolver: CanonicalResolver<
-      graphqlModels.AuthMutationResolvers<Request>
+      graphqlModels.AuthMutationResolvers<Context>
     >,
     @Inject(GameMutationResolver)
     gameMutationResolver: CanonicalResolver<
-      graphqlModels.GameMutationResolvers<Request>
+      graphqlModels.GameMutationResolvers<Context>
     >,
     @Inject(UserMutationResolver)
     userMutationResolver: CanonicalResolver<
-      graphqlModels.UserMutationResolvers<Request>
+      graphqlModels.UserMutationResolvers<Context>
     >,
   ) {
     this.#authMutationResolver = authMutationResolver;
@@ -45,13 +45,13 @@ export class RootMutationResolver
   public async createAuthByCode(
     parent: graphqlModels.RootMutation,
     args: graphqlModels.AuthMutationCreateAuthByCodeArgs,
-    request: Request,
+    context: Context,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.Auth> {
     return this.#authMutationResolver.createAuthByCode(
       parent,
       args,
-      request,
+      context,
       info,
     );
   }
@@ -59,13 +59,13 @@ export class RootMutationResolver
   public async createAuthByCredentials(
     parent: graphqlModels.RootMutation,
     args: graphqlModels.AuthMutationCreateAuthByCredentialsArgs,
-    request: Request,
+    context: Context,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.Auth> {
     return this.#authMutationResolver.createAuthByCredentials(
       parent,
       args,
-      request,
+      context,
       info,
     );
   }
@@ -73,40 +73,40 @@ export class RootMutationResolver
   public async createGame(
     parent: graphqlModels.RootMutation,
     args: graphqlModels.GameMutationCreateGameArgs,
-    request: Request,
+    context: Context,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.Game> {
-    return this.#gameMutationResolver.createGame(parent, args, request, info);
+    return this.#gameMutationResolver.createGame(parent, args, context, info);
   }
 
   public async createUser(
     parent: graphqlModels.RootMutation,
     args: graphqlModels.UserMutationCreateUserArgs,
-    request: Request,
+    context: Context,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.User> {
-    return this.#userMutationResolver.createUser(parent, args, request, info);
+    return this.#userMutationResolver.createUser(parent, args, context, info);
   }
 
   public async passGameTurn(
     parent: graphqlModels.RootMutation,
     args: graphqlModels.GameMutationPassGameTurnArgs,
-    request: Request,
+    context: Context,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.Game | null> {
-    return this.#gameMutationResolver.passGameTurn(parent, args, request, info);
+    return this.#gameMutationResolver.passGameTurn(parent, args, context, info);
   }
 
   public async playGameCards(
     parent: graphqlModels.RootMutation,
     args: graphqlModels.GameMutationPlayGameCardsArgs,
-    request: Request,
+    context: Context,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.Game | null> {
     return this.#gameMutationResolver.playGameCards(
       parent,
       args,
-      request,
+      context,
       info,
     );
   }
@@ -114,9 +114,9 @@ export class RootMutationResolver
   public async updateUserMe(
     parent: graphqlModels.RootMutation,
     args: graphqlModels.UserMutationUpdateUserMeArgs,
-    request: Request,
+    context: Context,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.User> {
-    return this.#userMutationResolver.updateUserMe(parent, args, request, info);
+    return this.#userMutationResolver.updateUserMe(parent, args, context, info);
   }
 }

--- a/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootQueryResolver.spec.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootQueryResolver.spec.ts
@@ -1,10 +1,10 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 import { models as graphqlModels } from '@cornie-js/api-graphql-models';
-import { Request } from '@cornie-js/backend-http';
 import { GraphQLResolveInfo } from 'graphql';
 
 import { CanonicalResolver } from '../../../foundation/graphql/application/models/CanonicalResolver';
+import { Context } from '../../../foundation/graphql/application/models/Context';
 import { RootQueryResolver } from './RootQueryResolver';
 
 function buildTestTuples(): [
@@ -12,32 +12,32 @@ function buildTestTuples(): [
   graphqlModels.ResolverFn<
     unknown,
     graphqlModels.RootQuery,
-    Request,
+    Context,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     any
   >,
   jest.Mock,
 ][] {
   const gameQueryResolverMock: jest.Mocked<
-    CanonicalResolver<graphqlModels.GameQueryResolvers<Request>>
+    CanonicalResolver<graphqlModels.GameQueryResolvers<Context>>
   > = {
     gameById: jest.fn(),
     myGames: jest.fn(),
   } as Partial<
-    jest.Mocked<CanonicalResolver<graphqlModels.GameQueryResolvers<Request>>>
+    jest.Mocked<CanonicalResolver<graphqlModels.GameQueryResolvers<Context>>>
   > as jest.Mocked<
-    CanonicalResolver<graphqlModels.GameQueryResolvers<Request>>
+    CanonicalResolver<graphqlModels.GameQueryResolvers<Context>>
   >;
 
   const userQueryResolverMock: jest.Mocked<
-    CanonicalResolver<graphqlModels.UserQueryResolvers<Request>>
+    CanonicalResolver<graphqlModels.UserQueryResolvers<Context>>
   > = {
     userById: jest.fn(),
     userMe: jest.fn(),
   } as Partial<
-    jest.Mocked<CanonicalResolver<graphqlModels.UserQueryResolvers<Request>>>
+    jest.Mocked<CanonicalResolver<graphqlModels.UserQueryResolvers<Context>>>
   > as jest.Mocked<
-    CanonicalResolver<graphqlModels.UserQueryResolvers<Request>>
+    CanonicalResolver<graphqlModels.UserQueryResolvers<Context>>
   >;
 
   const rootQueryResolver: RootQueryResolver = new RootQueryResolver(
@@ -76,7 +76,7 @@ describe(RootQueryResolver.name, () => {
       graphqlModels.ResolverFn<
         unknown,
         graphqlModels.RootQuery,
-        Request,
+        Context,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         any
       >,
@@ -89,7 +89,7 @@ describe(RootQueryResolver.name, () => {
       resolver: graphqlModels.ResolverFn<
         unknown,
         graphqlModels.RootQuery,
-        Request,
+        Context,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         any
       >,
@@ -98,7 +98,7 @@ describe(RootQueryResolver.name, () => {
       describe('when called', () => {
         let parentFixture: graphqlModels.RootQuery;
         let argsFixture: unknown;
-        let requestFixture: Request;
+        let contextFixture: Context;
         let infoFixture: GraphQLResolveInfo;
 
         let resolverResultFixture: unknown;
@@ -108,7 +108,7 @@ describe(RootQueryResolver.name, () => {
         beforeAll(async () => {
           parentFixture = Symbol() as unknown as graphqlModels.RootQuery;
           argsFixture = Symbol();
-          requestFixture = Symbol() as unknown as Request;
+          contextFixture = Symbol() as unknown as Context;
           infoFixture = Symbol() as unknown as GraphQLResolveInfo;
 
           resolverResultFixture = Symbol();
@@ -120,7 +120,7 @@ describe(RootQueryResolver.name, () => {
           result = await resolver(
             parentFixture,
             argsFixture,
-            requestFixture,
+            contextFixture,
             infoFixture,
           );
         });
@@ -134,7 +134,7 @@ describe(RootQueryResolver.name, () => {
           expect(resolverMock).toHaveBeenCalledWith(
             parentFixture,
             argsFixture,
-            requestFixture,
+            contextFixture,
             infoFixture,
           );
         });

--- a/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootQueryResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/app/application/resolvers/RootQueryResolver.ts
@@ -1,35 +1,35 @@
 import { models as graphqlModels } from '@cornie-js/api-graphql-models';
-import { Request } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 import { GraphQLResolveInfo } from 'graphql';
 
 import { CanonicalResolver } from '../../../foundation/graphql/application/models/CanonicalResolver';
+import { Context } from '../../../foundation/graphql/application/models/Context';
 import { GameQueryResolver } from '../../../games/application/resolvers/GameQueryResolver';
 import { UserQueryResolver } from '../../../users/application/resolvers/UserQueryResolver';
 
 type ResolverFnReturnType<TResult, TArgs> = ReturnType<
-  graphqlModels.ResolverFn<TResult, graphqlModels.RootQuery, Request, TArgs>
+  graphqlModels.ResolverFn<TResult, graphqlModels.RootQuery, Context, TArgs>
 >;
 
 @Injectable()
 export class RootQueryResolver
-  implements graphqlModels.RootQueryResolvers<Request, graphqlModels.RootQuery>
+  implements graphqlModels.RootQueryResolvers<Context, graphqlModels.RootQuery>
 {
   readonly #gameQueryResolver: CanonicalResolver<
-    graphqlModels.GameQueryResolvers<Request>
+    graphqlModels.GameQueryResolvers<Context>
   >;
   readonly #userQueryResolver: CanonicalResolver<
-    graphqlModels.UserQueryResolvers<Request>
+    graphqlModels.UserQueryResolvers<Context>
   >;
 
   constructor(
     @Inject(GameQueryResolver)
     gameQueryResolver: CanonicalResolver<
-      graphqlModels.GameQueryResolvers<Request>
+      graphqlModels.GameQueryResolvers<Context>
     >,
     @Inject(UserQueryResolver)
     userQueryResolver: CanonicalResolver<
-      graphqlModels.UserQueryResolvers<Request>
+      graphqlModels.UserQueryResolvers<Context>
     >,
   ) {
     this.#gameQueryResolver = gameQueryResolver;
@@ -39,39 +39,39 @@ export class RootQueryResolver
   public async gameById(
     parent: graphqlModels.RootQuery,
     args: graphqlModels.GameQueryGameByIdArgs,
-    request: Request,
+    context: Context,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.Game | null> {
-    return this.#gameQueryResolver.gameById(parent, args, request, info);
+    return this.#gameQueryResolver.gameById(parent, args, context, info);
   }
 
   public myGames(
     parent: graphqlModels.RootQuery,
     args: Partial<graphqlModels.RootQueryMyGamesArgs>,
-    request: Request,
+    context: Context,
     info: GraphQLResolveInfo,
   ): ResolverFnReturnType<
     Array<graphqlModels.ResolversTypes['Game']>,
     Partial<graphqlModels.RootQueryMyGamesArgs>
   > {
-    return this.#gameQueryResolver.myGames(parent, args, request, info);
+    return this.#gameQueryResolver.myGames(parent, args, context, info);
   }
 
   public async userById(
     parent: graphqlModels.RootQuery,
     args: graphqlModels.UserQueryUserByIdArgs,
-    request: Request,
+    context: Context,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.User | null> {
-    return this.#userQueryResolver.userById(parent, args, request, info);
+    return this.#userQueryResolver.userById(parent, args, context, info);
   }
 
   public async userMe(
     parent: graphqlModels.RootQuery,
     args: Record<string, unknown>,
-    request: Request,
+    context: Context,
     info: GraphQLResolveInfo,
   ): Promise<graphqlModels.User> {
-    return this.#userQueryResolver.userMe(parent, args, request, info);
+    return this.#userQueryResolver.userMe(parent, args, context, info);
   }
 }

--- a/packages/backend/apps/gateway/backend-gateway-application/src/auth/application/resolvers/AuthMutationResolver.spec.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/auth/application/resolvers/AuthMutationResolver.spec.ts
@@ -3,9 +3,9 @@ import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { HttpClient } from '@cornie-js/api-http-client';
 import { models as apiModels } from '@cornie-js/api-models';
 import { AppError, AppErrorKind } from '@cornie-js/backend-common';
-import { Request } from '@cornie-js/backend-http';
 import { HttpStatus } from '@nestjs/common';
 
+import { Context } from '../../../foundation/graphql/application/models/Context';
 import { AuthMutationResolver } from './AuthMutationResolver';
 
 describe(AuthMutationResolver.name, () => {
@@ -30,7 +30,7 @@ describe(AuthMutationResolver.name, () => {
 
     describe('when called, and httpClient.createAuth() returns an OK response', () => {
       let authV1: apiModels.AuthV1;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let result: unknown;
 
@@ -39,12 +39,14 @@ describe(AuthMutationResolver.name, () => {
           jwt: 'jwt fixture',
         };
 
-        requestFixture = {
-          headers: {
-            foo: 'bar',
+        contextFixture = {
+          request: {
+            headers: {
+              foo: 'bar',
+            },
+            query: {},
+            urlParameters: {},
           },
-          query: {},
-          urlParameters: {},
         };
 
         httpClientMock.createAuth.mockResolvedValueOnce({
@@ -60,7 +62,7 @@ describe(AuthMutationResolver.name, () => {
               code: codeFixture,
             },
           },
-          requestFixture,
+          contextFixture,
         );
       });
 
@@ -75,7 +77,7 @@ describe(AuthMutationResolver.name, () => {
 
         expect(httpClientMock.createAuth).toHaveBeenCalledTimes(1);
         expect(httpClientMock.createAuth).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           expectedBody,
         );
       });
@@ -87,7 +89,7 @@ describe(AuthMutationResolver.name, () => {
 
     describe('when called, and httpClient.createAuth() returns an BAD_REQUEST response', () => {
       let errorV1: apiModels.ErrorV1;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let result: unknown;
 
@@ -96,12 +98,14 @@ describe(AuthMutationResolver.name, () => {
           description: 'error description fixture',
         };
 
-        requestFixture = {
-          headers: {
-            foo: 'bar',
+        contextFixture = {
+          request: {
+            headers: {
+              foo: 'bar',
+            },
+            query: {},
+            urlParameters: {},
           },
-          query: {},
-          urlParameters: {},
         };
 
         httpClientMock.createAuth.mockResolvedValueOnce({
@@ -118,7 +122,7 @@ describe(AuthMutationResolver.name, () => {
                 code: codeFixture,
               },
             },
-            requestFixture,
+            contextFixture,
           );
         } catch (error) {
           result = error;
@@ -136,7 +140,7 @@ describe(AuthMutationResolver.name, () => {
 
         expect(httpClientMock.createAuth).toHaveBeenCalledTimes(1);
         expect(httpClientMock.createAuth).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           expectedBody,
         );
       });
@@ -166,7 +170,7 @@ describe(AuthMutationResolver.name, () => {
 
     describe('when called, and httpClient.createAuth() returns an OK response', () => {
       let authV1: apiModels.AuthV1;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let result: unknown;
 
@@ -175,12 +179,14 @@ describe(AuthMutationResolver.name, () => {
           jwt: 'jwt fixture',
         };
 
-        requestFixture = {
-          headers: {
-            foo: 'bar',
+        contextFixture = {
+          request: {
+            headers: {
+              foo: 'bar',
+            },
+            query: {},
+            urlParameters: {},
           },
-          query: {},
-          urlParameters: {},
         };
 
         httpClientMock.createAuth.mockResolvedValueOnce({
@@ -197,7 +203,7 @@ describe(AuthMutationResolver.name, () => {
               password: passwordFixture,
             },
           },
-          requestFixture,
+          contextFixture,
         );
       });
 
@@ -213,7 +219,7 @@ describe(AuthMutationResolver.name, () => {
 
         expect(httpClientMock.createAuth).toHaveBeenCalledTimes(1);
         expect(httpClientMock.createAuth).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           expectedBody,
         );
       });
@@ -225,7 +231,7 @@ describe(AuthMutationResolver.name, () => {
 
     describe('when called, and httpClient.createAuth() returns an BAD_REQUEST response', () => {
       let errorV1: apiModels.ErrorV1;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let result: unknown;
 
@@ -234,12 +240,14 @@ describe(AuthMutationResolver.name, () => {
           description: 'error description fixture',
         };
 
-        requestFixture = {
-          headers: {
-            foo: 'bar',
+        contextFixture = {
+          request: {
+            headers: {
+              foo: 'bar',
+            },
+            query: {},
+            urlParameters: {},
           },
-          query: {},
-          urlParameters: {},
         };
 
         httpClientMock.createAuth.mockResolvedValueOnce({
@@ -257,7 +265,7 @@ describe(AuthMutationResolver.name, () => {
                 password: passwordFixture,
               },
             },
-            requestFixture,
+            contextFixture,
           );
         } catch (error) {
           result = error;
@@ -276,7 +284,7 @@ describe(AuthMutationResolver.name, () => {
 
         expect(httpClientMock.createAuth).toHaveBeenCalledTimes(1);
         expect(httpClientMock.createAuth).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           expectedBody,
         );
       });

--- a/packages/backend/apps/gateway/backend-gateway-application/src/auth/application/resolvers/AuthMutationResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/auth/application/resolvers/AuthMutationResolver.ts
@@ -2,14 +2,14 @@
 import { models as graphqlModels } from '@cornie-js/api-graphql-models';
 import { HttpClient } from '@cornie-js/api-http-client';
 import { AppError, AppErrorKind } from '@cornie-js/backend-common';
-import { Request } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
 import { CanonicalResolver } from '../../../foundation/graphql/application/models/CanonicalResolver';
+import { Context } from '../../../foundation/graphql/application/models/Context';
 
 @Injectable()
 export class AuthMutationResolver
-  implements CanonicalResolver<graphqlModels.AuthMutationResolvers<Request>>
+  implements CanonicalResolver<graphqlModels.AuthMutationResolvers<Context>>
 {
   readonly #httpClient: HttpClient;
 
@@ -20,10 +20,10 @@ export class AuthMutationResolver
   public async createAuthByCode(
     _: unknown,
     args: graphqlModels.AuthMutationCreateAuthByCodeArgs,
-    request: Request,
+    context: Context,
   ): Promise<graphqlModels.Auth> {
     const httpResponse: Awaited<ReturnType<HttpClient['createAuth']>> =
-      await this.#httpClient.createAuth(request.headers, {
+      await this.#httpClient.createAuth(context.request.headers, {
         code: args.codeAuthCreateInput.code,
       });
 
@@ -42,10 +42,10 @@ export class AuthMutationResolver
   public async createAuthByCredentials(
     _: unknown,
     args: graphqlModels.AuthMutationCreateAuthByCredentialsArgs,
-    request: Request,
+    context: Context,
   ): Promise<graphqlModels.Auth> {
     const httpResponse: Awaited<ReturnType<HttpClient['createAuth']>> =
-      await this.#httpClient.createAuth(request.headers, {
+      await this.#httpClient.createAuth(context.request.headers, {
         email: args.emailPasswordAuthCreateInput.email,
         password: args.emailPasswordAuthCreateInput.password,
       });

--- a/packages/backend/apps/gateway/backend-gateway-application/src/foundation/graphql/application/models/Context.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/foundation/graphql/application/models/Context.ts
@@ -1,0 +1,5 @@
+import { Request } from '@cornie-js/backend-http';
+
+export interface Context {
+  request: Request;
+}

--- a/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameMutationResolver.spec.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameMutationResolver.spec.ts
@@ -4,9 +4,9 @@ import { models as graphqlModels } from '@cornie-js/api-graphql-models';
 import { HttpClient } from '@cornie-js/api-http-client';
 import { models as apiModels } from '@cornie-js/api-models';
 import { AppError, AppErrorKind, Builder } from '@cornie-js/backend-common';
-import { Request } from '@cornie-js/backend-http';
 import { HttpStatus } from '@nestjs/common';
 
+import { Context } from '../../../foundation/graphql/application/models/Context';
 import { GameMutationResolver } from './GameMutationResolver';
 
 describe(GameMutationResolver.name, () => {
@@ -56,7 +56,7 @@ describe(GameMutationResolver.name, () => {
       let gameV1Fixture: apiModels.NonStartedGameV1;
       let gameGraphQlFixture: graphqlModels.Game;
 
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let result: unknown;
 
@@ -64,12 +64,14 @@ describe(GameMutationResolver.name, () => {
         gameV1Fixture = Symbol() as unknown as apiModels.NonStartedGameV1;
         gameGraphQlFixture = Symbol() as unknown as graphqlModels.Game;
 
-        requestFixture = {
-          headers: {
-            foo: 'bar',
+        contextFixture = {
+          request: {
+            headers: {
+              foo: 'bar',
+            },
+            query: {},
+            urlParameters: {},
           },
-          query: {},
-          urlParameters: {},
         };
 
         httpClientMock.createGame.mockResolvedValueOnce({
@@ -91,7 +93,7 @@ describe(GameMutationResolver.name, () => {
               options: optionsFixture,
             },
           },
-          requestFixture,
+          contextFixture,
         );
       });
 
@@ -108,7 +110,7 @@ describe(GameMutationResolver.name, () => {
 
         expect(httpClientMock.createGame).toHaveBeenCalledTimes(1);
         expect(httpClientMock.createGame).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           expectedBody,
         );
       });
@@ -127,7 +129,7 @@ describe(GameMutationResolver.name, () => {
 
     describe('when called, and httpClient.createGame() returns an BAD_REQUEST response', () => {
       let errorV1: apiModels.ErrorV1;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let result: unknown;
 
@@ -136,12 +138,14 @@ describe(GameMutationResolver.name, () => {
           description: 'error description fixture',
         };
 
-        requestFixture = {
-          headers: {
-            foo: 'bar',
+        contextFixture = {
+          request: {
+            headers: {
+              foo: 'bar',
+            },
+            query: {},
+            urlParameters: {},
           },
-          query: {},
-          urlParameters: {},
         };
 
         httpClientMock.createGame.mockResolvedValueOnce({
@@ -160,7 +164,7 @@ describe(GameMutationResolver.name, () => {
                 options: optionsFixture,
               },
             },
-            requestFixture,
+            contextFixture,
           );
         } catch (error) {
           result = error;
@@ -180,7 +184,7 @@ describe(GameMutationResolver.name, () => {
 
         expect(httpClientMock.createGame).toHaveBeenCalledTimes(1);
         expect(httpClientMock.createGame).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           expectedBody,
         );
       });
@@ -212,7 +216,7 @@ describe(GameMutationResolver.name, () => {
       let gameV1Fixture: apiModels.NonStartedGameV1;
       let gameGraphQlFixture: graphqlModels.Game;
 
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let result: unknown;
 
@@ -220,12 +224,14 @@ describe(GameMutationResolver.name, () => {
         gameV1Fixture = Symbol() as unknown as apiModels.NonStartedGameV1;
         gameGraphQlFixture = Symbol() as unknown as graphqlModels.Game;
 
-        requestFixture = {
-          headers: {
-            foo: 'bar',
+        contextFixture = {
+          request: {
+            headers: {
+              foo: 'bar',
+            },
+            query: {},
+            urlParameters: {},
           },
-          query: {},
-          urlParameters: {},
         };
 
         httpClientMock.updateGame.mockResolvedValueOnce({
@@ -246,7 +252,7 @@ describe(GameMutationResolver.name, () => {
               slotIndex: slotIndexFixture,
             },
           },
-          requestFixture,
+          contextFixture,
         );
       });
 
@@ -262,7 +268,7 @@ describe(GameMutationResolver.name, () => {
 
         expect(httpClientMock.updateGame).toHaveBeenCalledTimes(1);
         expect(httpClientMock.updateGame).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           {
             gameId: gameIdFixture,
           },
@@ -284,7 +290,7 @@ describe(GameMutationResolver.name, () => {
 
     describe('when called, and httpClient.updateGame() returns an UNAUTHORIZED response', () => {
       let errorV1: apiModels.ErrorV1;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let result: unknown;
 
@@ -293,12 +299,14 @@ describe(GameMutationResolver.name, () => {
           description: 'error description fixture',
         };
 
-        requestFixture = {
-          headers: {
-            foo: 'bar',
+        contextFixture = {
+          request: {
+            headers: {
+              foo: 'bar',
+            },
+            query: {},
+            urlParameters: {},
           },
-          query: {},
-          urlParameters: {},
         };
 
         httpClientMock.updateGame.mockResolvedValueOnce({
@@ -316,7 +324,7 @@ describe(GameMutationResolver.name, () => {
                 slotIndex: slotIndexFixture,
               },
             },
-            requestFixture,
+            contextFixture,
           );
         } catch (error) {
           result = error;
@@ -335,7 +343,7 @@ describe(GameMutationResolver.name, () => {
 
         expect(httpClientMock.updateGame).toHaveBeenCalledTimes(1);
         expect(httpClientMock.updateGame).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           {
             gameId: gameIdFixture,
           },
@@ -358,7 +366,7 @@ describe(GameMutationResolver.name, () => {
 
     describe('when called, and httpClient.updateGame() returns an FORBIDDEN response', () => {
       let errorV1: apiModels.ErrorV1;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let result: unknown;
 
@@ -367,12 +375,14 @@ describe(GameMutationResolver.name, () => {
           description: 'error description fixture',
         };
 
-        requestFixture = {
-          headers: {
-            foo: 'bar',
+        contextFixture = {
+          request: {
+            headers: {
+              foo: 'bar',
+            },
+            query: {},
+            urlParameters: {},
           },
-          query: {},
-          urlParameters: {},
         };
 
         httpClientMock.updateGame.mockResolvedValueOnce({
@@ -390,7 +400,7 @@ describe(GameMutationResolver.name, () => {
                 slotIndex: slotIndexFixture,
               },
             },
-            requestFixture,
+            contextFixture,
           );
         } catch (error) {
           result = error;
@@ -409,7 +419,7 @@ describe(GameMutationResolver.name, () => {
 
         expect(httpClientMock.updateGame).toHaveBeenCalledTimes(1);
         expect(httpClientMock.updateGame).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           {
             gameId: gameIdFixture,
           },
@@ -446,7 +456,7 @@ describe(GameMutationResolver.name, () => {
       let gameV1Fixture: apiModels.NonStartedGameV1;
       let gameGraphQlFixture: graphqlModels.Game;
 
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let result: unknown;
 
@@ -454,12 +464,14 @@ describe(GameMutationResolver.name, () => {
         gameV1Fixture = Symbol() as unknown as apiModels.NonStartedGameV1;
         gameGraphQlFixture = Symbol() as unknown as graphqlModels.Game;
 
-        requestFixture = {
-          headers: {
-            foo: 'bar',
+        contextFixture = {
+          request: {
+            headers: {
+              foo: 'bar',
+            },
+            query: {},
+            urlParameters: {},
           },
-          query: {},
-          urlParameters: {},
         };
 
         httpClientMock.updateGame.mockResolvedValueOnce({
@@ -482,7 +494,7 @@ describe(GameMutationResolver.name, () => {
               slotIndex: slotIndexFixture,
             },
           },
-          requestFixture,
+          contextFixture,
         );
       });
 
@@ -499,7 +511,7 @@ describe(GameMutationResolver.name, () => {
 
         expect(httpClientMock.updateGame).toHaveBeenCalledTimes(1);
         expect(httpClientMock.updateGame).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           {
             gameId: gameIdFixture,
           },
@@ -521,7 +533,7 @@ describe(GameMutationResolver.name, () => {
 
     describe('when called, and httpClient.updateGame() returns an UNAUTHORIZED response', () => {
       let errorV1: apiModels.ErrorV1;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let result: unknown;
 
@@ -530,12 +542,14 @@ describe(GameMutationResolver.name, () => {
           description: 'error description fixture',
         };
 
-        requestFixture = {
-          headers: {
-            foo: 'bar',
+        contextFixture = {
+          request: {
+            headers: {
+              foo: 'bar',
+            },
+            query: {},
+            urlParameters: {},
           },
-          query: {},
-          urlParameters: {},
         };
 
         httpClientMock.updateGame.mockResolvedValueOnce({
@@ -555,7 +569,7 @@ describe(GameMutationResolver.name, () => {
                 slotIndex: slotIndexFixture,
               },
             },
-            requestFixture,
+            contextFixture,
           );
         } catch (error) {
           result = error;
@@ -575,7 +589,7 @@ describe(GameMutationResolver.name, () => {
 
         expect(httpClientMock.updateGame).toHaveBeenCalledTimes(1);
         expect(httpClientMock.updateGame).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           {
             gameId: gameIdFixture,
           },
@@ -598,7 +612,7 @@ describe(GameMutationResolver.name, () => {
 
     describe('when called, and httpClient.updateGame() returns an FORBIDDEN response', () => {
       let errorV1: apiModels.ErrorV1;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let result: unknown;
 
@@ -607,12 +621,14 @@ describe(GameMutationResolver.name, () => {
           description: 'error description fixture',
         };
 
-        requestFixture = {
-          headers: {
-            foo: 'bar',
+        contextFixture = {
+          request: {
+            headers: {
+              foo: 'bar',
+            },
+            query: {},
+            urlParameters: {},
           },
-          query: {},
-          urlParameters: {},
         };
 
         httpClientMock.updateGame.mockResolvedValueOnce({
@@ -632,7 +648,7 @@ describe(GameMutationResolver.name, () => {
                 slotIndex: slotIndexFixture,
               },
             },
-            requestFixture,
+            contextFixture,
           );
         } catch (error) {
           result = error;
@@ -652,7 +668,7 @@ describe(GameMutationResolver.name, () => {
 
         expect(httpClientMock.updateGame).toHaveBeenCalledTimes(1);
         expect(httpClientMock.updateGame).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           {
             gameId: gameIdFixture,
           },

--- a/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameMutationResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameMutationResolver.ts
@@ -3,15 +3,15 @@ import { models as graphqlModels } from '@cornie-js/api-graphql-models';
 import { HttpClient } from '@cornie-js/api-http-client';
 import { models as apiModels } from '@cornie-js/api-models';
 import { AppError, AppErrorKind, Builder } from '@cornie-js/backend-common';
-import { Request } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
 import { CanonicalResolver } from '../../../foundation/graphql/application/models/CanonicalResolver';
+import { Context } from '../../../foundation/graphql/application/models/Context';
 import { GameGraphQlFromGameV1Builder } from '../builders/GameGraphQlFromGameV1Builder';
 
 @Injectable()
 export class GameMutationResolver
-  implements CanonicalResolver<graphqlModels.GameMutationResolvers<Request>>
+  implements CanonicalResolver<graphqlModels.GameMutationResolvers<Context>>
 {
   readonly #gameGraphQlFromGameV1Builder: Builder<
     graphqlModels.Game,
@@ -34,7 +34,7 @@ export class GameMutationResolver
   public async createGame(
     _: unknown,
     args: graphqlModels.GameMutationCreateGameArgs,
-    request: Request,
+    context: Context,
   ): Promise<graphqlModels.Game> {
     const gameCreateQuery: apiModels.GameCreateQueryV1 = {
       gameSlotsAmount: args.gameCreateInput.gameSlotsAmount,
@@ -48,7 +48,10 @@ export class GameMutationResolver
     }
 
     const httpResponse: Awaited<ReturnType<HttpClient['createGame']>> =
-      await this.#httpClient.createGame(request.headers, gameCreateQuery);
+      await this.#httpClient.createGame(
+        context.request.headers,
+        gameCreateQuery,
+      );
 
     switch (httpResponse.statusCode) {
       case 200:
@@ -74,7 +77,7 @@ export class GameMutationResolver
   public async passGameTurn(
     _: unknown,
     args: graphqlModels.GameMutationPassGameTurnArgs,
-    request: Request,
+    context: Context,
   ): Promise<graphqlModels.Game | null> {
     const gamePassTurnQueryV1: apiModels.GameIdPassTurnQueryV1 = {
       kind: 'passTurn',
@@ -82,7 +85,7 @@ export class GameMutationResolver
     };
 
     return this.#handleUpdateGameV1(
-      request.headers,
+      context.request.headers,
       args.gameId,
       gamePassTurnQueryV1,
     );
@@ -91,7 +94,7 @@ export class GameMutationResolver
   public async playGameCards(
     _: unknown,
     args: graphqlModels.GameMutationPlayGameCardsArgs,
-    request: Request,
+    context: Context,
   ): Promise<graphqlModels.Game | null> {
     const gamePlayCardsQueryV1: apiModels.GameIdPlayCardsQueryV1 = {
       cardIndexes: args.gamePlayCardsInput.cardIndexes,
@@ -104,7 +107,7 @@ export class GameMutationResolver
     }
 
     return this.#handleUpdateGameV1(
-      request.headers,
+      context.request.headers,
       args.gameId,
       gamePlayCardsQueryV1,
     );

--- a/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameQueryResolver.spec.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameQueryResolver.spec.ts
@@ -4,9 +4,9 @@ import { models as graphqlModels } from '@cornie-js/api-graphql-models';
 import { HttpClient, Response } from '@cornie-js/api-http-client';
 import { models as apiModels } from '@cornie-js/api-models';
 import { AppError, AppErrorKind, Builder } from '@cornie-js/backend-common';
-import { Request } from '@cornie-js/backend-http';
 import { HttpStatus } from '@nestjs/common';
 
+import { Context } from '../../../foundation/graphql/application/models/Context';
 import { GameQueryResolver } from './GameQueryResolver';
 
 describe(GameQueryResolver.name, () => {
@@ -37,7 +37,7 @@ describe(GameQueryResolver.name, () => {
     describe('when called, and httpClient.getGame() returns a Response with status code 200', () => {
       let firstArgFixture: unknown;
       let argsFixture: graphqlModels.GameQueryGameByIdArgs;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let responseFixture: Response<
         Record<string, string>,
@@ -54,10 +54,12 @@ describe(GameQueryResolver.name, () => {
         argsFixture = {
           id: 'game-id',
         };
-        requestFixture = {
-          headers: {},
-          query: {},
-          urlParameters: {},
+        contextFixture = {
+          request: {
+            headers: {},
+            query: {},
+            urlParameters: {},
+          },
         };
 
         responseFixture = {
@@ -73,7 +75,7 @@ describe(GameQueryResolver.name, () => {
         result = await gameQueryResolver.gameById(
           firstArgFixture,
           argsFixture,
-          requestFixture,
+          contextFixture,
         );
       });
 
@@ -84,7 +86,7 @@ describe(GameQueryResolver.name, () => {
       it('should call httpClient.getGame()', () => {
         expect(httpClientMock.getGame).toHaveBeenCalledTimes(1);
         expect(httpClientMock.getGame).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           {
             gameId: argsFixture.id,
           },
@@ -106,7 +108,7 @@ describe(GameQueryResolver.name, () => {
     describe('when called, and httpClient.getGame() returns a Response with status code 401', () => {
       let firstArgFixture: unknown;
       let argsFixture: graphqlModels.GameQueryGameByIdArgs;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let responseFixture: Response<
         Record<string, string>,
@@ -121,10 +123,12 @@ describe(GameQueryResolver.name, () => {
         argsFixture = {
           id: 'game-id',
         };
-        requestFixture = {
-          headers: {},
-          query: {},
-          urlParameters: {},
+        contextFixture = {
+          request: {
+            headers: {},
+            query: {},
+            urlParameters: {},
+          },
         };
 
         responseFixture = {
@@ -141,7 +145,7 @@ describe(GameQueryResolver.name, () => {
           await gameQueryResolver.gameById(
             firstArgFixture,
             argsFixture,
-            requestFixture,
+            contextFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -155,7 +159,7 @@ describe(GameQueryResolver.name, () => {
       it('should call httpClient.getGame()', () => {
         expect(httpClientMock.getGame).toHaveBeenCalledTimes(1);
         expect(httpClientMock.getGame).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           {
             gameId: argsFixture.id,
           },
@@ -178,7 +182,7 @@ describe(GameQueryResolver.name, () => {
     describe('when called, and httpClient.getGame() returns a Response with status code 404', () => {
       let firstArgFixture: unknown;
       let argsFixture: graphqlModels.GameQueryGameByIdArgs;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let responseFixture: Response<
         Record<string, string>,
@@ -193,10 +197,12 @@ describe(GameQueryResolver.name, () => {
         argsFixture = {
           id: 'game-id',
         };
-        requestFixture = {
-          headers: {},
-          query: {},
-          urlParameters: {},
+        contextFixture = {
+          request: {
+            headers: {},
+            query: {},
+            urlParameters: {},
+          },
         };
 
         responseFixture = {
@@ -212,7 +218,7 @@ describe(GameQueryResolver.name, () => {
         result = await gameQueryResolver.gameById(
           firstArgFixture,
           argsFixture,
-          requestFixture,
+          contextFixture,
         );
       });
 
@@ -223,7 +229,7 @@ describe(GameQueryResolver.name, () => {
       it('should call httpClient.getGame()', () => {
         expect(httpClientMock.getGame).toHaveBeenCalledTimes(1);
         expect(httpClientMock.getGame).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           {
             gameId: argsFixture.id,
           },
@@ -237,13 +243,15 @@ describe(GameQueryResolver.name, () => {
   });
 
   describe('.myGames', () => {
-    let requestFixture: Request;
+    let contextFixture: Context;
 
     beforeAll(() => {
-      requestFixture = {
-        headers: {},
-        query: {},
-        urlParameters: {},
+      contextFixture = {
+        request: {
+          headers: {},
+          query: {},
+          urlParameters: {},
+        },
       };
     });
 
@@ -284,7 +292,7 @@ describe(GameQueryResolver.name, () => {
           result = await gameQueryResolver.myGames(
             Symbol(),
             argsFixture,
-            requestFixture,
+            contextFixture,
           );
         });
 
@@ -295,7 +303,7 @@ describe(GameQueryResolver.name, () => {
         it('should call httpClient.getGamesMine()', () => {
           expect(httpClientMock.getGamesMine).toHaveBeenCalledTimes(1);
           expect(httpClientMock.getGamesMine).toHaveBeenCalledWith(
-            requestFixture.headers,
+            contextFixture.request.headers,
             {
               page: (argsFixture.findMyGamesInput?.page as number).toString(),
             },
@@ -354,7 +362,7 @@ describe(GameQueryResolver.name, () => {
           result = await gameQueryResolver.myGames(
             Symbol(),
             argsFixture,
-            requestFixture,
+            contextFixture,
           );
         });
 
@@ -365,7 +373,7 @@ describe(GameQueryResolver.name, () => {
         it('should call httpClient.getGamesMine()', () => {
           expect(httpClientMock.getGamesMine).toHaveBeenCalledTimes(1);
           expect(httpClientMock.getGamesMine).toHaveBeenCalledWith(
-            requestFixture.headers,
+            contextFixture.request.headers,
             {
               pageSize: (
                 argsFixture.findMyGamesInput?.pageSize as number
@@ -426,7 +434,7 @@ describe(GameQueryResolver.name, () => {
           result = await gameQueryResolver.myGames(
             Symbol(),
             argsFixture,
-            requestFixture,
+            contextFixture,
           );
         });
 
@@ -437,7 +445,7 @@ describe(GameQueryResolver.name, () => {
         it('should call httpClient.getGamesMine()', () => {
           expect(httpClientMock.getGamesMine).toHaveBeenCalledTimes(1);
           expect(httpClientMock.getGamesMine).toHaveBeenCalledWith(
-            requestFixture.headers,
+            contextFixture.request.headers,
             {
               status: argsFixture.findMyGamesInput?.status,
             },
@@ -500,7 +508,7 @@ describe(GameQueryResolver.name, () => {
             await gameQueryResolver.myGames(
               Symbol(),
               argsFixture,
-              requestFixture,
+              contextFixture,
             );
           } catch (error: unknown) {
             result = error;
@@ -514,7 +522,7 @@ describe(GameQueryResolver.name, () => {
         it('should call httpClient.getGamesMine()', () => {
           expect(httpClientMock.getGamesMine).toHaveBeenCalledTimes(1);
           expect(httpClientMock.getGamesMine).toHaveBeenCalledWith(
-            requestFixture.headers,
+            contextFixture.request.headers,
             {
               page: (argsFixture.findMyGamesInput?.page as number).toString(),
               pageSize: (

--- a/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameQueryResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameQueryResolver.ts
@@ -4,10 +4,10 @@ import { models as graphqlModels } from '@cornie-js/api-graphql-models';
 import { HttpClient } from '@cornie-js/api-http-client';
 import { models as apiModels } from '@cornie-js/api-models';
 import { AppError, AppErrorKind, Builder } from '@cornie-js/backend-common';
-import { Request } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
 import { CanonicalResolver } from '../../../foundation/graphql/application/models/CanonicalResolver';
+import { Context } from '../../../foundation/graphql/application/models/Context';
 import { GameGraphQlFromGameV1Builder } from '../builders/GameGraphQlFromGameV1Builder';
 
 interface GetGamesMineQueryArgs extends Record<string, string | string[]> {
@@ -18,7 +18,7 @@ interface GetGamesMineQueryArgs extends Record<string, string | string[]> {
 
 @Injectable()
 export class GameQueryResolver
-  implements CanonicalResolver<graphqlModels.GameQueryResolvers<Request>>
+  implements CanonicalResolver<graphqlModels.GameQueryResolvers<Context>>
 {
   readonly #gameGraphQlFromGameV1Builder: Builder<
     graphqlModels.Game,
@@ -41,10 +41,10 @@ export class GameQueryResolver
   public async gameById(
     _: unknown,
     args: graphqlModels.GameQueryGameByIdArgs,
-    request: Request,
+    context: Context,
   ): Promise<graphqlModels.Game | null> {
     const httpResponse: Awaited<ReturnType<HttpClient['getGame']>> =
-      await this.#httpClient.getGame(request.headers, {
+      await this.#httpClient.getGame(context.request.headers, {
         gameId: args.id,
       });
 
@@ -69,11 +69,11 @@ export class GameQueryResolver
   public async myGames(
     _: unknown,
     args: Partial<graphqlModels.GameQueryMyGamesArgs>,
-    request: Request,
+    context: Context,
   ): Promise<graphqlModels.Game[]> {
     const httpResponse: Awaited<ReturnType<HttpClient['getGamesMine']>> =
       await this.#httpClient.getGamesMine(
-        request.headers,
+        context.request.headers,
         this.#buildGetGamesMineQuery(args),
       );
 

--- a/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/games/application/resolvers/GameResolver.ts
@@ -1,6 +1,7 @@
 import { models as graphqlModels } from '@cornie-js/api-graphql-models';
-import { Request } from '@cornie-js/backend-http';
 import { Injectable } from '@nestjs/common';
+
+import { Context } from '../../../foundation/graphql/application/models/Context';
 
 type GameResolvedType = ReturnType<GameResolver['__resolveType']>;
 
@@ -13,7 +14,7 @@ const GAME_STATUS_TO_GAME_RESOLVED_TYPE: {
 };
 
 @Injectable()
-export class GameResolver implements graphqlModels.GameResolvers<Request> {
+export class GameResolver implements graphqlModels.GameResolvers<Context> {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public __resolveType(
     game: graphqlModels.Game,

--- a/packages/backend/apps/gateway/backend-gateway-application/src/index.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/index.ts
@@ -1,4 +1,7 @@
 import { ApplicationModule } from './app/adapter/nest/modules/ApplicationModule';
 import { ApplicationResolver } from './app/application/resolvers/ApplicationResolver';
+import { Context } from './foundation/graphql/application/models/Context';
+
+export type { Context };
 
 export { ApplicationModule, ApplicationResolver };

--- a/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserMutationResolver.spec.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserMutationResolver.spec.ts
@@ -3,9 +3,9 @@ import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { HttpClient } from '@cornie-js/api-http-client';
 import { models as apiModels } from '@cornie-js/api-models';
 import { AppError, AppErrorKind } from '@cornie-js/backend-common';
-import { Request } from '@cornie-js/backend-http';
 import { HttpStatus } from '@nestjs/common';
 
+import { Context } from '../../../foundation/graphql/application/models/Context';
 import { UserMutationResolver } from './UserMutationResolver';
 
 describe(UserMutationResolver.name, () => {
@@ -34,7 +34,7 @@ describe(UserMutationResolver.name, () => {
 
     describe('when called, and httpClient.createUser() returns an OK response', () => {
       let userV1: apiModels.UserV1;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let result: unknown;
 
@@ -45,12 +45,14 @@ describe(UserMutationResolver.name, () => {
           name: 'name',
         };
 
-        requestFixture = {
-          headers: {
-            foo: 'bar',
+        contextFixture = {
+          request: {
+            headers: {
+              foo: 'bar',
+            },
+            query: {},
+            urlParameters: {},
           },
-          query: {},
-          urlParameters: {},
         };
 
         httpClientMock.createUser.mockResolvedValueOnce({
@@ -68,7 +70,7 @@ describe(UserMutationResolver.name, () => {
               password: passwordFixture,
             },
           },
-          requestFixture,
+          contextFixture,
         );
       });
 
@@ -85,7 +87,7 @@ describe(UserMutationResolver.name, () => {
 
         expect(httpClientMock.createUser).toHaveBeenCalledTimes(1);
         expect(httpClientMock.createUser).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           expectedBody,
         );
       });
@@ -97,7 +99,7 @@ describe(UserMutationResolver.name, () => {
 
     describe('when called, and httpClient.createUser() returns an BAD_REQUEST response', () => {
       let errorV1: apiModels.ErrorV1;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let result: unknown;
 
@@ -106,12 +108,14 @@ describe(UserMutationResolver.name, () => {
           description: 'error description fixture',
         };
 
-        requestFixture = {
-          headers: {
-            foo: 'bar',
+        contextFixture = {
+          request: {
+            headers: {
+              foo: 'bar',
+            },
+            query: {},
+            urlParameters: {},
           },
-          query: {},
-          urlParameters: {},
         };
 
         httpClientMock.createUser.mockResolvedValueOnce({
@@ -130,7 +134,7 @@ describe(UserMutationResolver.name, () => {
                 password: passwordFixture,
               },
             },
-            requestFixture,
+            contextFixture,
           );
         } catch (error) {
           result = error;
@@ -150,7 +154,7 @@ describe(UserMutationResolver.name, () => {
 
         expect(httpClientMock.createUser).toHaveBeenCalledTimes(1);
         expect(httpClientMock.createUser).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           expectedBody,
         );
       });

--- a/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserMutationResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserMutationResolver.ts
@@ -3,14 +3,14 @@ import { models as graphqlModels } from '@cornie-js/api-graphql-models';
 import { HttpClient } from '@cornie-js/api-http-client';
 import { models as apiModels } from '@cornie-js/api-models';
 import { AppError, AppErrorKind } from '@cornie-js/backend-common';
-import { Request } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
 import { CanonicalResolver } from '../../../foundation/graphql/application/models/CanonicalResolver';
+import { Context } from '../../../foundation/graphql/application/models/Context';
 
 @Injectable()
 export class UserMutationResolver
-  implements CanonicalResolver<graphqlModels.UserMutationResolvers<Request>>
+  implements CanonicalResolver<graphqlModels.UserMutationResolvers<Context>>
 {
   readonly #httpClient: HttpClient;
 
@@ -21,10 +21,10 @@ export class UserMutationResolver
   public async createUser(
     _: unknown,
     args: graphqlModels.UserMutationCreateUserArgs,
-    request: Request,
+    context: Context,
   ): Promise<graphqlModels.User> {
     const httpResponse: Awaited<ReturnType<HttpClient['createUser']>> =
-      await this.#httpClient.createUser(request.headers, {
+      await this.#httpClient.createUser(context.request.headers, {
         email: args.userCreateInput.email,
         name: args.userCreateInput.name,
         password: args.userCreateInput.password,
@@ -49,11 +49,11 @@ export class UserMutationResolver
   public async updateUserMe(
     _: unknown,
     args: graphqlModels.UserMutationUpdateUserMeArgs,
-    request: Request,
+    context: Context,
   ): Promise<graphqlModels.User> {
     const httpResponse: Awaited<ReturnType<HttpClient['updateUserMe']>> =
       await this.#httpClient.updateUserMe(
-        request.headers,
+        context.request.headers,
         this.#buildUserMeUpdateQueryV1(args),
       );
 

--- a/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserQueryResolver.spec.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserQueryResolver.spec.ts
@@ -4,9 +4,9 @@ import { models as graphqlModels } from '@cornie-js/api-graphql-models';
 import { HttpClient, Response } from '@cornie-js/api-http-client';
 import { models as apiModels } from '@cornie-js/api-models';
 import { AppError, AppErrorKind } from '@cornie-js/backend-common';
-import { Request } from '@cornie-js/backend-http';
 import { HttpStatus } from '@nestjs/common';
 
+import { Context } from '../../../foundation/graphql/application/models/Context';
 import { UserQueryResolver } from './UserQueryResolver';
 
 describe(UserQueryResolver.name, () => {
@@ -27,7 +27,7 @@ describe(UserQueryResolver.name, () => {
     describe('when called, and httpClient.getUser() returns a Response with status code 200', () => {
       let firstArgFixture: unknown;
       let argsFixture: graphqlModels.UserQueryUserByIdArgs;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let responseFixture: Response<
         Record<string, string>,
@@ -42,10 +42,8 @@ describe(UserQueryResolver.name, () => {
         argsFixture = {
           id: 'user-id',
         };
-        requestFixture = {
-          headers: {},
-          query: {},
-          urlParameters: {},
+        contextFixture = {
+          request: { headers: {}, query: {}, urlParameters: {} },
         };
 
         responseFixture = {
@@ -63,7 +61,7 @@ describe(UserQueryResolver.name, () => {
         result = await userQueryResolver.userById(
           firstArgFixture,
           argsFixture,
-          requestFixture,
+          contextFixture,
         );
       });
 
@@ -74,7 +72,7 @@ describe(UserQueryResolver.name, () => {
       it('should call httpClient.getUser()', () => {
         expect(httpClientMock.getUser).toHaveBeenCalledTimes(1);
         expect(httpClientMock.getUser).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           {
             userId: argsFixture.id,
           },
@@ -89,7 +87,7 @@ describe(UserQueryResolver.name, () => {
     describe('when called, and httpClient.getUser() returns a Response with status code 401', () => {
       let firstArgFixture: unknown;
       let argsFixture: graphqlModels.UserQueryUserByIdArgs;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let responseFixture: Response<
         Record<string, string>,
@@ -104,10 +102,8 @@ describe(UserQueryResolver.name, () => {
         argsFixture = {
           id: 'user-id',
         };
-        requestFixture = {
-          headers: {},
-          query: {},
-          urlParameters: {},
+        contextFixture = {
+          request: { headers: {}, query: {}, urlParameters: {} },
         };
 
         responseFixture = {
@@ -124,7 +120,7 @@ describe(UserQueryResolver.name, () => {
           await userQueryResolver.userById(
             firstArgFixture,
             argsFixture,
-            requestFixture,
+            contextFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -138,7 +134,7 @@ describe(UserQueryResolver.name, () => {
       it('should call httpClient.getUser()', () => {
         expect(httpClientMock.getUser).toHaveBeenCalledTimes(1);
         expect(httpClientMock.getUser).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           {
             userId: argsFixture.id,
           },
@@ -161,7 +157,7 @@ describe(UserQueryResolver.name, () => {
     describe('when called, and httpClient.getUser() returns a Response with status code 404', () => {
       let firstArgFixture: unknown;
       let argsFixture: graphqlModels.UserQueryUserByIdArgs;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let responseFixture: Response<
         Record<string, string>,
@@ -176,10 +172,8 @@ describe(UserQueryResolver.name, () => {
         argsFixture = {
           id: 'user-id',
         };
-        requestFixture = {
-          headers: {},
-          query: {},
-          urlParameters: {},
+        contextFixture = {
+          request: { headers: {}, query: {}, urlParameters: {} },
         };
 
         responseFixture = {
@@ -195,7 +189,7 @@ describe(UserQueryResolver.name, () => {
         result = await userQueryResolver.userById(
           firstArgFixture,
           argsFixture,
-          requestFixture,
+          contextFixture,
         );
       });
 
@@ -206,7 +200,7 @@ describe(UserQueryResolver.name, () => {
       it('should call httpClient.getUser()', () => {
         expect(httpClientMock.getUser).toHaveBeenCalledTimes(1);
         expect(httpClientMock.getUser).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
           {
             userId: argsFixture.id,
           },
@@ -223,7 +217,7 @@ describe(UserQueryResolver.name, () => {
     describe('when called, and httpClient.getUserMe() returns a Response with status code 200', () => {
       let firstArgFixture: unknown;
       let argsFixture: Record<string, string>;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let responseFixture: Response<
         Record<string, string>,
@@ -236,10 +230,8 @@ describe(UserQueryResolver.name, () => {
       beforeAll(async () => {
         firstArgFixture = Symbol();
         argsFixture = {};
-        requestFixture = {
-          headers: {},
-          query: {},
-          urlParameters: {},
+        contextFixture = {
+          request: { headers: {}, query: {}, urlParameters: {} },
         };
 
         responseFixture = {
@@ -257,7 +249,7 @@ describe(UserQueryResolver.name, () => {
         result = await userQueryResolver.userMe(
           firstArgFixture,
           argsFixture,
-          requestFixture,
+          contextFixture,
         );
       });
 
@@ -268,7 +260,7 @@ describe(UserQueryResolver.name, () => {
       it('should call httpClient.getUserMe()', () => {
         expect(httpClientMock.getUserMe).toHaveBeenCalledTimes(1);
         expect(httpClientMock.getUserMe).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
         );
       });
 
@@ -280,7 +272,7 @@ describe(UserQueryResolver.name, () => {
     describe('when called, and httpClient.getUserMe() returns a Response with status code 401', () => {
       let firstArgFixture: unknown;
       let argsFixture: Record<string, string>;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let responseFixture: Response<
         Record<string, string>,
@@ -293,10 +285,8 @@ describe(UserQueryResolver.name, () => {
       beforeAll(async () => {
         firstArgFixture = Symbol();
         argsFixture = {};
-        requestFixture = {
-          headers: {},
-          query: {},
-          urlParameters: {},
+        contextFixture = {
+          request: { headers: {}, query: {}, urlParameters: {} },
         };
 
         responseFixture = {
@@ -313,7 +303,7 @@ describe(UserQueryResolver.name, () => {
           await userQueryResolver.userMe(
             firstArgFixture,
             argsFixture,
-            requestFixture,
+            contextFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -327,7 +317,7 @@ describe(UserQueryResolver.name, () => {
       it('should call httpClient.getUserMe()', () => {
         expect(httpClientMock.getUserMe).toHaveBeenCalledTimes(1);
         expect(httpClientMock.getUserMe).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
         );
       });
 
@@ -347,7 +337,7 @@ describe(UserQueryResolver.name, () => {
     describe('when called, and httpClient.getUserMe() returns a Response with status code 403', () => {
       let firstArgFixture: unknown;
       let argsFixture: Record<string, string>;
-      let requestFixture: Request;
+      let contextFixture: Context;
 
       let responseFixture: Response<
         Record<string, string>,
@@ -360,10 +350,8 @@ describe(UserQueryResolver.name, () => {
       beforeAll(async () => {
         firstArgFixture = Symbol();
         argsFixture = {};
-        requestFixture = {
-          headers: {},
-          query: {},
-          urlParameters: {},
+        contextFixture = {
+          request: { headers: {}, query: {}, urlParameters: {} },
         };
 
         responseFixture = {
@@ -380,7 +368,7 @@ describe(UserQueryResolver.name, () => {
           await userQueryResolver.userMe(
             firstArgFixture,
             argsFixture,
-            requestFixture,
+            contextFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -394,7 +382,7 @@ describe(UserQueryResolver.name, () => {
       it('should call httpClient.getUserMe()', () => {
         expect(httpClientMock.getUserMe).toHaveBeenCalledTimes(1);
         expect(httpClientMock.getUserMe).toHaveBeenCalledWith(
-          requestFixture.headers,
+          contextFixture.request.headers,
         );
       });
 

--- a/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserQueryResolver.ts
+++ b/packages/backend/apps/gateway/backend-gateway-application/src/users/application/resolvers/UserQueryResolver.ts
@@ -3,14 +3,14 @@
 import { models as graphqlModels } from '@cornie-js/api-graphql-models';
 import { HttpClient } from '@cornie-js/api-http-client';
 import { AppError, AppErrorKind } from '@cornie-js/backend-common';
-import { Request } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
 import { CanonicalResolver } from '../../../foundation/graphql/application/models/CanonicalResolver';
+import { Context } from '../../../foundation/graphql/application/models/Context';
 
 @Injectable()
 export class UserQueryResolver
-  implements CanonicalResolver<graphqlModels.UserQueryResolvers<Request>>
+  implements CanonicalResolver<graphqlModels.UserQueryResolvers<Context>>
 {
   readonly #httpClient: HttpClient;
 
@@ -21,10 +21,10 @@ export class UserQueryResolver
   public async userById(
     _: unknown,
     args: graphqlModels.UserQueryUserByIdArgs,
-    request: Request,
+    context: Context,
   ): Promise<graphqlModels.User | null> {
     const httpResponse: Awaited<ReturnType<HttpClient['getUser']>> =
-      await this.#httpClient.getUser(request.headers, {
+      await this.#httpClient.getUser(context.request.headers, {
         userId: args.id,
       });
 
@@ -44,10 +44,10 @@ export class UserQueryResolver
   public async userMe(
     _: unknown,
     _args: unknown,
-    request: Request,
+    context: Context,
   ): Promise<graphqlModels.User> {
     const httpResponse: Awaited<ReturnType<HttpClient['getUserMe']>> =
-      await this.#httpClient.getUserMe(request.headers);
+      await this.#httpClient.getUserMe(context.request.headers);
 
     switch (httpResponse.statusCode) {
       case 200:

--- a/packages/backend/services/backend-service-gateway/src/app/adapter/apollo/calculations/buildApolloApplicationResolver.ts
+++ b/packages/backend/services/backend-service-gateway/src/app/adapter/apollo/calculations/buildApolloApplicationResolver.ts
@@ -1,7 +1,9 @@
 import { models as graphqlModels } from '@cornie-js/api-graphql-models';
 import { Builder } from '@cornie-js/backend-common';
-import { ApplicationResolver } from '@cornie-js/backend-gateway-application';
-import { Request } from '@cornie-js/backend-http';
+import {
+  ApplicationResolver,
+  Context,
+} from '@cornie-js/backend-gateway-application';
 import { GraphQLError, GraphQLResolveInfo } from 'graphql';
 
 export function buildApolloApplicationResolver(
@@ -74,8 +76,8 @@ export function buildApolloApplicationResolver(
 
 function getResolverFunction<TParent, TResult, TArgs>(
   self: unknown,
-  resolver: graphqlModels.Resolver<TResult, TParent, Request, TArgs>,
-): graphqlModels.ResolverFn<TResult, TParent, Request, TArgs> {
+  resolver: graphqlModels.Resolver<TResult, TParent, Context, TArgs>,
+): graphqlModels.ResolverFn<TResult, TParent, Context, TArgs> {
   if (typeof resolver === 'function') {
     return resolver.bind(self);
   } else {
@@ -86,12 +88,12 @@ function getResolverFunction<TParent, TResult, TArgs>(
 function buildApolloResolver<TParent, TResult, TArgs>(
   self: unknown,
   graphQlErrorFromErrorBuilder: Builder<GraphQLError, [unknown]>,
-  resolver: graphqlModels.Resolver<TResult, TParent, Request, TArgs>,
-): graphqlModels.ResolverFn<TResult, TParent, Request, TArgs> {
+  resolver: graphqlModels.Resolver<TResult, TParent, Context, TArgs>,
+): graphqlModels.ResolverFn<TResult, TParent, Context, TArgs> {
   return async (
     parent: TParent,
     args: TArgs,
-    context: Request,
+    context: Context,
     info: GraphQLResolveInfo,
   ): Promise<TResult> => {
     try {

--- a/packages/backend/services/backend-service-gateway/src/app/adapter/nest/actions/registerFastifyApolloHandler.ts
+++ b/packages/backend/services/backend-service-gateway/src/app/adapter/nest/actions/registerFastifyApolloHandler.ts
@@ -1,5 +1,6 @@
 import { ApolloServer } from '@apollo/server';
 import { fastifyApolloHandler } from '@as-integrations/fastify';
+import { Context } from '@cornie-js/backend-gateway-application';
 import {
   Request,
   RequestFromFastifyRequestBuilder,
@@ -10,7 +11,7 @@ import { FastifyInstance, FastifyRequest } from 'fastify';
 const HEADER_WHITELIST: string[] = ['authorization'];
 
 export function registerFastifyApolloHandler(
-  apolloServer: ApolloServer<Request>,
+  apolloServer: ApolloServer<Context>,
   fastifyServer: FastifyInstance,
   nestApplicationContext: INestApplicationContext,
 ): void {
@@ -20,7 +21,7 @@ export function registerFastifyApolloHandler(
   fastifyServer.post(
     '/',
     fastifyApolloHandler(apolloServer, {
-      context: async (fastifyRequest: FastifyRequest): Promise<Request> => {
+      context: async (fastifyRequest: FastifyRequest): Promise<Context> => {
         const request: Request =
           requestFromFastifyRequestBuilder.build(fastifyRequest);
 
@@ -31,7 +32,9 @@ export function registerFastifyApolloHandler(
           }
         }
 
-        return request;
+        return {
+          request,
+        };
       },
     }),
   );

--- a/packages/backend/services/backend-service-gateway/src/app/adapter/nest/actions/registerSignalHandlers.ts
+++ b/packages/backend/services/backend-service-gateway/src/app/adapter/nest/actions/registerSignalHandlers.ts
@@ -1,15 +1,15 @@
 import { ApolloServer } from '@apollo/server';
-import { Request } from '@cornie-js/backend-http';
+import { Context } from '@cornie-js/backend-gateway-application';
 import { ConsoleLogger, LoggerService } from '@nestjs/common';
 
-export function registerSignalHandlers(server: ApolloServer<Request>): void {
+export function registerSignalHandlers(server: ApolloServer<Context>): void {
   const logger: LoggerService = new ConsoleLogger();
 
   registerExitSignalHandlers(server, logger, ['SIGINT', 'SIGTERM']);
 }
 
 async function closeServerGracefully(
-  server: ApolloServer<Request>,
+  server: ApolloServer<Context>,
   logger: LoggerService,
 ): Promise<void> {
   logger.log('Closing signal received.');
@@ -21,7 +21,7 @@ async function closeServerGracefully(
 }
 
 function exitSignalHandler(
-  server: ApolloServer<Request>,
+  server: ApolloServer<Context>,
   logger: LoggerService,
 ): () => void {
   return () => {
@@ -30,7 +30,7 @@ function exitSignalHandler(
 }
 
 function registerExitSignalHandlers(
-  server: ApolloServer<Request>,
+  server: ApolloServer<Context>,
   logger: LoggerService,
   signals: NodeJS.Signals[],
 ): void {

--- a/packages/backend/services/backend-service-gateway/src/app/adapter/nest/calculations/buildApolloServer.ts
+++ b/packages/backend/services/backend-service-gateway/src/app/adapter/nest/calculations/buildApolloServer.ts
@@ -2,9 +2,11 @@ import { ApolloServer } from '@apollo/server';
 import { fastifyApolloDrainPlugin } from '@as-integrations/fastify';
 import { readApiGraphqlSchemas } from '@cornie-js/api-graphql-schemas-provider';
 import { Builder } from '@cornie-js/backend-common';
-import { ApplicationResolver } from '@cornie-js/backend-gateway-application';
+import {
+  ApplicationResolver,
+  Context,
+} from '@cornie-js/backend-gateway-application';
 import { GraphQlErrorFromErrorBuilder } from '@cornie-js/backend-graphql';
-import { Request } from '@cornie-js/backend-http';
 import { INestApplicationContext } from '@nestjs/common';
 import { FastifyInstance } from 'fastify';
 import { GraphQLError } from 'graphql';
@@ -14,7 +16,7 @@ import { buildApolloApplicationResolver } from '../../apollo/calculations/buildA
 export async function buildApolloServer(
   fastifyServer: FastifyInstance,
   nestApplicationContext: INestApplicationContext,
-): Promise<ApolloServer<Request>> {
+): Promise<ApolloServer<Context>> {
   const graphqlSchemas: string[] = await readApiGraphqlSchemas();
 
   const applicationResolver: ApplicationResolver =
@@ -23,7 +25,7 @@ export async function buildApolloServer(
   const graphQlErrorFromErrorBuilder: Builder<GraphQLError, [unknown]> =
     nestApplicationContext.get(GraphQlErrorFromErrorBuilder);
 
-  const apolloServer: ApolloServer<Request> = new ApolloServer({
+  const apolloServer: ApolloServer<Context> = new ApolloServer({
     plugins: [fastifyApolloDrainPlugin(fastifyServer)],
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     resolvers: buildApolloApplicationResolver(

--- a/packages/backend/services/backend-service-gateway/src/app/adapter/nest/scripts/bootstrap.ts
+++ b/packages/backend/services/backend-service-gateway/src/app/adapter/nest/scripts/bootstrap.ts
@@ -1,9 +1,9 @@
 import { ApolloServer } from '@apollo/server';
+import { Context } from '@cornie-js/backend-gateway-application';
 import {
   Environment,
   EnvironmentService,
 } from '@cornie-js/backend-gateway-env';
-import { Request } from '@cornie-js/backend-http';
 import { INestApplicationContext } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { FastifyInstance } from 'fastify';
@@ -25,7 +25,7 @@ async function bootstrap(): Promise<void> {
 
   const fastifyServer: FastifyInstance = await buildFastifyServer(env);
 
-  const apolloServer: ApolloServer<Request> = await buildApolloServer(
+  const apolloServer: ApolloServer<Context> = await buildApolloServer(
     fastifyServer,
     nestApplicationContext,
   );


### PR DESCRIPTION
### Changed
- Updated server to rely on `Context`.
- Update resolvers to rely on `Context`.