### PR TITLE
Update user port create contracts with optional transaction context

### DIFF
--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/adapters/UserCodePersistenceTypeOrmAdapter.spec.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/adapters/UserCodePersistenceTypeOrmAdapter.spec.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
+import { TransactionContext } from '@cornie-js/backend-db/application';
 import {
   UserCode,
   UserCodeCreateQuery,
@@ -52,12 +53,16 @@ describe(UserCodePersistenceTypeOrmAdapter, () => {
   describe('.create', () => {
     describe('when called', () => {
       let userCodeCreateQueryFixture: UserCodeCreateQuery;
+      let transactionContextFixture: TransactionContext;
+
       let userCodeFixture: UserCode;
 
       let result: unknown;
 
       beforeAll(async () => {
         userCodeCreateQueryFixture = UserCodeCreateQueryFixtures.any;
+        transactionContextFixture = Symbol() as unknown as TransactionContext;
+
         userCodeFixture = Symbol() as unknown as UserCode;
 
         createUserCodeTypeOrmServiceMock.insertOne.mockResolvedValueOnce(
@@ -66,6 +71,7 @@ describe(UserCodePersistenceTypeOrmAdapter, () => {
 
         result = await userCodePersistenceTypeOrmAdapter.create(
           userCodeCreateQueryFixture,
+          transactionContextFixture,
         );
       });
 
@@ -75,6 +81,7 @@ describe(UserCodePersistenceTypeOrmAdapter, () => {
         ).toHaveBeenCalledTimes(1);
         expect(createUserCodeTypeOrmServiceMock.insertOne).toHaveBeenCalledWith(
           userCodeCreateQueryFixture,
+          transactionContextFixture,
         );
       });
 

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/adapters/UserCodePersistenceTypeOrmAdapter.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/adapters/UserCodePersistenceTypeOrmAdapter.ts
@@ -1,3 +1,4 @@
+import { TransactionContext } from '@cornie-js/backend-db/application';
 import { UserCodePersistenceOutputPort } from '@cornie-js/backend-user-application/users';
 import {
   UserCode,
@@ -33,8 +34,12 @@ export class UserCodePersistenceTypeOrmAdapter
 
   public async create(
     userCodeCreateQuery: UserCodeCreateQuery,
+    transactionContext?: TransactionContext,
   ): Promise<UserCode> {
-    return this.#createUserCodeTypeOrmService.insertOne(userCodeCreateQuery);
+    return this.#createUserCodeTypeOrmService.insertOne(
+      userCodeCreateQuery,
+      transactionContext,
+    );
   }
 
   public async delete(userCodeFindQuery: UserCodeFindQuery): Promise<void> {

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/adapters/UserPersistenceTypeOrmAdapter.spec.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/adapters/UserPersistenceTypeOrmAdapter.spec.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
+import { TransactionContext } from '@cornie-js/backend-db/application';
 import {
   User,
   UserCreateQuery,
@@ -63,12 +64,16 @@ describe(UserPersistenceTypeOrmAdapter, () => {
   describe('.create', () => {
     describe('when called', () => {
       let userCreateQueryFixture: UserCreateQuery;
+      let transactionContextFixture: TransactionContext;
+
       let userFixture: User;
 
       let result: unknown;
 
       beforeAll(async () => {
         userCreateQueryFixture = UserCreateQueryFixtures.any;
+        transactionContextFixture = Symbol() as unknown as TransactionContext;
+
         userFixture = Symbol() as unknown as User;
 
         createUserTypeOrmServiceMock.insertOne.mockResolvedValueOnce(
@@ -77,6 +82,7 @@ describe(UserPersistenceTypeOrmAdapter, () => {
 
         result = await userPersistenceTypeOrmAdapter.create(
           userCreateQueryFixture,
+          transactionContextFixture,
         );
       });
 
@@ -84,6 +90,7 @@ describe(UserPersistenceTypeOrmAdapter, () => {
         expect(createUserTypeOrmServiceMock.insertOne).toHaveBeenCalledTimes(1);
         expect(createUserTypeOrmServiceMock.insertOne).toHaveBeenCalledWith(
           userCreateQueryFixture,
+          transactionContextFixture,
         );
       });
 

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/adapters/UserPersistenceTypeOrmAdapter.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/adapters/UserPersistenceTypeOrmAdapter.ts
@@ -1,3 +1,4 @@
+import { TransactionContext } from '@cornie-js/backend-db/application';
 import { UserPersistenceOutputPort } from '@cornie-js/backend-user-application/users';
 import {
   User,
@@ -37,8 +38,14 @@ export class UserPersistenceTypeOrmAdapter
     this.#updateUserTypeOrmService = updateUserTypeOrmService;
   }
 
-  public async create(userCreateQuery: UserCreateQuery): Promise<User> {
-    return this.#createUserTypeOrmService.insertOne(userCreateQuery);
+  public async create(
+    userCreateQuery: UserCreateQuery,
+    transactionContext?: TransactionContext,
+  ): Promise<User> {
+    return this.#createUserTypeOrmService.insertOne(
+      userCreateQuery,
+      transactionContext,
+    );
   }
 
   public async delete(userFindQuery: UserFindQuery): Promise<void> {

--- a/packages/backend/apps/user/backend-user-application/src/users/application/ports/output/UserCodePersistenceOutputPort.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/ports/output/UserCodePersistenceOutputPort.ts
@@ -1,3 +1,4 @@
+import { TransactionContext } from '@cornie-js/backend-db/application';
 import {
   UserCode,
   UserCodeCreateQuery,
@@ -5,7 +6,10 @@ import {
 } from '@cornie-js/backend-user-domain/users';
 
 export interface UserCodePersistenceOutputPort {
-  create(userCodeCreateQuery: UserCodeCreateQuery): Promise<UserCode>;
+  create(
+    userCodeCreateQuery: UserCodeCreateQuery,
+    transactionContext?: TransactionContext,
+  ): Promise<UserCode>;
   delete(userCodeFindQuery: UserCodeFindQuery): Promise<void>;
   findOne(userCodeFindQuery: UserCodeFindQuery): Promise<UserCode | undefined>;
 }

--- a/packages/backend/apps/user/backend-user-application/src/users/application/ports/output/UserPersistenceOutputPort.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/ports/output/UserPersistenceOutputPort.ts
@@ -1,3 +1,4 @@
+import { TransactionContext } from '@cornie-js/backend-db/application';
 import {
   User,
   UserCreateQuery,
@@ -6,7 +7,10 @@ import {
 } from '@cornie-js/backend-user-domain/users';
 
 export interface UserPersistenceOutputPort {
-  create(userCreateQuery: UserCreateQuery): Promise<User>;
+  create(
+    userCreateQuery: UserCreateQuery,
+    transactionContext?: TransactionContext,
+  ): Promise<User>;
   delete(userFindQuery: UserFindQuery): Promise<void>;
   findOne(userFindQuery: UserFindQuery): Promise<User | undefined>;
   update(userUpdateQuery: UserUpdateQuery): Promise<void>;


### PR DESCRIPTION
### Changed
- Updated `UserPersistenceOutputPort.create` with optional `TransactionContext`.
- Updated `UserCodePersistenceOutputPort.create` with optional `TransactionContext`.