### PR TITLE
Update create user flow to rely on db transactions

### DIFF
--- a/packages/backend/apps/user/backend-user-application/src/users/application/handlers/UserCreatedEventHandler.spec.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/handlers/UserCreatedEventHandler.spec.ts
@@ -156,6 +156,7 @@ describe(UserCreatedEventHandler.name, () => {
         );
         expect(userCodePersistenceOutputPortMock.create).toHaveBeenCalledWith(
           userCodeCreateQueryFixture,
+          userCreatedEventFixture.transactionContext,
         );
       });
 

--- a/packages/backend/apps/user/backend-user-application/src/users/application/handlers/UserCreatedEventHandler.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/handlers/UserCreatedEventHandler.ts
@@ -75,9 +75,7 @@ export class UserCreatedEventHandler
   }
 
   public async handle(userCreatedEvent: UserCreatedEvent): Promise<void> {
-    const userCode: UserCode = await this.#createUserCode(
-      userCreatedEvent.user,
-    );
+    const userCode: UserCode = await this.#createUserCode(userCreatedEvent);
 
     const mailDeliveryOptions: MailDeliveryOptions =
       this.#userActivationMailDeliveryOptionsFromUserBuilder.build(
@@ -88,13 +86,16 @@ export class UserCreatedEventHandler
     await this.#mailDeliveryOutputPort.send(mailDeliveryOptions);
   }
 
-  async #createUserCode(user: User): Promise<UserCode> {
+  async #createUserCode(userCreatedEvent: UserCreatedEvent): Promise<UserCode> {
     const userCodeCreateQuery: UserCodeCreateQuery =
-      this.#userCodeCreateQueryFromUserBuilder.build(user, {
+      this.#userCodeCreateQueryFromUserBuilder.build(userCreatedEvent.user, {
         userCode: this.#randomHexStringBuilder.build(USER_CODE_LENGHT),
         uuid: this.#uuidProviderOutputPort.generateV4(),
       });
 
-    return this.#userCodePersistenceOutputPort.create(userCodeCreateQuery);
+    return this.#userCodePersistenceOutputPort.create(
+      userCodeCreateQuery,
+      userCreatedEvent.transactionContext,
+    );
   }
 }

--- a/packages/backend/apps/user/backend-user-application/src/users/application/models/UserCreatedEvent.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/models/UserCreatedEvent.ts
@@ -1,6 +1,8 @@
+import { TransactionContext } from '@cornie-js/backend-db/application';
 import { User, UserCreateQuery } from '@cornie-js/backend-user-domain/users';
 
 export interface UserCreatedEvent {
+  transactionContext?: TransactionContext;
   user: User;
   userCreateQuery: UserCreateQuery;
 }

--- a/packages/backend/services/backend-service-user/src/auth/adapters/nest/modules/AuthHttpApiModule.ts
+++ b/packages/backend/services/backend-service-user/src/auth/adapters/nest/modules/AuthHttpApiModule.ts
@@ -1,5 +1,8 @@
 import { MailModule } from '@cornie-js/backend-adapter-nodemailer';
-import { UserDbModule } from '@cornie-js/backend-user-adapter-typeorm';
+import {
+  DbModule,
+  UserDbModule,
+} from '@cornie-js/backend-user-adapter-typeorm';
 import { AuthHttpApiModule as AuthHttpApiApplicationModule } from '@cornie-js/backend-user-application';
 import { Module } from '@nestjs/common';
 
@@ -12,6 +15,7 @@ import { PostAuthV1HttpRequestNestController } from '../controllers/PostAuthV1Ht
   controllers: [PostAuthV1HttpRequestNestController],
   imports: [
     AuthHttpApiApplicationModule.forRootAsync([
+      DbModule.forTransaction(),
       MailModule.forRootAsync(buildMailClientOptions()),
       UserDbModule.forRootAsync(buildDbModuleOptions()),
     ]),

--- a/packages/backend/services/backend-service-user/src/user/adapter/nest/modules/UserHttpApiModule.ts
+++ b/packages/backend/services/backend-service-user/src/user/adapter/nest/modules/UserHttpApiModule.ts
@@ -1,5 +1,8 @@
 import { MailModule } from '@cornie-js/backend-adapter-nodemailer';
-import { UserDbModule } from '@cornie-js/backend-user-adapter-typeorm';
+import {
+  UserDbModule,
+  DbModule,
+} from '@cornie-js/backend-user-adapter-typeorm';
 import { UserHttpApiModule as UserHttpApiApplicationModule } from '@cornie-js/backend-user-application';
 import { Module } from '@nestjs/common';
 
@@ -27,6 +30,7 @@ import { PostUserV1HttpRequestNestController } from '../controllers/PostUserV1Ht
   ],
   imports: [
     UserHttpApiApplicationModule.forRootAsync([
+      DbModule.forTransaction(),
       MailModule.forRootAsync(buildMailClientOptions()),
       UserDbModule.forRootAsync(buildDbModuleOptions()),
     ]),

--- a/packages/backend/tools/backend-typescript-config/tsconfig.base.json
+++ b/packages/backend/tools/backend-typescript-config/tsconfig.base.json
@@ -7,7 +7,7 @@
     "esModuleInterop": true,
     "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "ESNext.Disposable"],
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
### Changed
- Updated `CreateUserUseCaseHandler` to rely on db transaction.
- Updated `UserCreatedEvent` with optional `transactionContext`.
- Updated base tsconfig to rely on disposable polyfill.