### PR TITLE
Update GameSpecPersistenceOutputPort.create with optional TransactionContext

### DIFF
--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/adapters/GamePersistenceTypeOrmAdapter.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/adapters/GamePersistenceTypeOrmAdapter.spec.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
+import { TransactionContext } from '@cornie-js/backend-db/application';
 import { GameSlotPersistenceOutputPort } from '@cornie-js/backend-game-application/games';
 import {
   Game,
@@ -61,9 +62,11 @@ describe(GamePersistenceTypeOrmAdapter.name, () => {
 
   describe('.create', () => {
     let gameCreateQueryFixture: GameCreateQuery;
+    let transactionContextFixture: TransactionContext;
 
     beforeAll(() => {
       gameCreateQueryFixture = GameCreateQueryFixtures.any;
+      transactionContextFixture = Symbol() as unknown as TransactionContext;
     });
 
     describe('when called', () => {
@@ -80,6 +83,7 @@ describe(GamePersistenceTypeOrmAdapter.name, () => {
 
         result = await gamePersistenceTypeOrmAdapter.create(
           gameCreateQueryFixture,
+          transactionContextFixture,
         );
       });
 
@@ -91,6 +95,7 @@ describe(GamePersistenceTypeOrmAdapter.name, () => {
         expect(createGameTypeOrmServiceMock.insertOne).toHaveBeenCalledTimes(1);
         expect(createGameTypeOrmServiceMock.insertOne).toHaveBeenCalledWith(
           gameCreateQueryFixture,
+          transactionContextFixture,
         );
       });
 

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/adapters/GamePersistenceTypeOrmAdapter.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/adapters/GamePersistenceTypeOrmAdapter.ts
@@ -1,3 +1,4 @@
+import { TransactionContext } from '@cornie-js/backend-db/application';
 import {
   GamePersistenceOutputPort,
   GameSlotPersistenceOutputPort,
@@ -41,8 +42,14 @@ export class GamePersistenceTypeOrmAdapter
     this.#updateGameTypeOrmService = updateGameTypeOrmService;
   }
 
-  public async create(gameCreateQuery: GameCreateQuery): Promise<Game> {
-    return this.#createGameTypeOrmService.insertOne(gameCreateQuery);
+  public async create(
+    gameCreateQuery: GameCreateQuery,
+    transactionContext?: TransactionContext,
+  ): Promise<Game> {
+    return this.#createGameTypeOrmService.insertOne(
+      gameCreateQuery,
+      transactionContext,
+    );
   }
 
   public async find(gameFindQuery: GameFindQuery): Promise<Game[]> {

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/adapters/GameSpecPersistenceTypeOrmAdapter.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/adapters/GameSpecPersistenceTypeOrmAdapter.spec.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
+import { TransactionContext } from '@cornie-js/backend-db/application';
 import {
   GameSpec,
   GameSpecCreateQuery,
@@ -43,9 +44,11 @@ describe(GameSpecPersistenceTypeOrmAdapter.name, () => {
 
   describe('.create', () => {
     let gameSpecCreateQueryFixture: GameSpecCreateQuery;
+    let transactionContextFixture: TransactionContext;
 
     beforeAll(() => {
       gameSpecCreateQueryFixture = GameSpecCreateQueryFixtures.any;
+      transactionContextFixture = Symbol() as unknown as TransactionContext;
     });
 
     describe('when called', () => {
@@ -62,6 +65,7 @@ describe(GameSpecPersistenceTypeOrmAdapter.name, () => {
 
         result = await gameSpecPersistenceTypeOrmAdapter.create(
           gameSpecCreateQueryFixture,
+          transactionContextFixture,
         );
       });
 
@@ -75,6 +79,7 @@ describe(GameSpecPersistenceTypeOrmAdapter.name, () => {
         ).toHaveBeenCalledTimes(1);
         expect(createGameSpecTypeOrmServiceMock.insertOne).toHaveBeenCalledWith(
           gameSpecCreateQueryFixture,
+          transactionContextFixture,
         );
       });
 

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/adapters/GameSpecPersistenceTypeOrmAdapter.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/adapters/GameSpecPersistenceTypeOrmAdapter.ts
@@ -1,3 +1,4 @@
+import { TransactionContext } from '@cornie-js/backend-db/application';
 import { GameSpecPersistenceOutputPort } from '@cornie-js/backend-game-application/games';
 import {
   GameSpecCreateQuery,
@@ -28,8 +29,12 @@ export class GameSpecPersistenceTypeOrmAdapter
 
   public async create(
     gameSpecCreateQuery: GameSpecCreateQuery,
+    transactionContext?: TransactionContext,
   ): Promise<GameSpec> {
-    return this.#createGameSpecTypeOrmService.insertOne(gameSpecCreateQuery);
+    return this.#createGameSpecTypeOrmService.insertOne(
+      gameSpecCreateQuery,
+      transactionContext,
+    );
   }
 
   public async find(gameSpecFindQuery: GameSpecFindQuery): Promise<GameSpec[]> {

--- a/packages/backend/apps/game/backend-game-application/package.json
+++ b/packages/backend/apps/game/backend-game-application/package.json
@@ -12,6 +12,7 @@
     "@cornie-js/backend-app-jwt": "workspace:*",
     "@cornie-js/backend-app-uuid": "workspace:*",
     "@cornie-js/backend-common": "workspace:*",
+    "@cornie-js/backend-db": "workspace:*",
     "@cornie-js/backend-game-domain": "workspace:*",
     "@cornie-js/backend-http": "workspace:*",
     "@cornie-js/backend-pub-sub": "workspace:*",

--- a/packages/backend/apps/game/backend-game-application/src/games/application/ports/output/GamePersistenceOutputPort.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/ports/output/GamePersistenceOutputPort.ts
@@ -1,3 +1,4 @@
+import { TransactionContext } from '@cornie-js/backend-db/application';
 import {
   Game,
   GameCreateQuery,
@@ -6,7 +7,10 @@ import {
 } from '@cornie-js/backend-game-domain/games';
 
 export interface GamePersistenceOutputPort {
-  create(gameCreateQuery: GameCreateQuery): Promise<Game>;
+  create(
+    gameCreateQuery: GameCreateQuery,
+    transactionContext?: TransactionContext,
+  ): Promise<Game>;
   find(gameFindQuery: GameFindQuery): Promise<Game[]>;
   findOne(gameFindQuery: GameFindQuery): Promise<Game | undefined>;
   update(gameUpdateQuery: GameUpdateQuery): Promise<void>;

--- a/packages/backend/apps/game/backend-game-application/src/games/application/ports/output/GameSpecPersistenceOutputPort.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/ports/output/GameSpecPersistenceOutputPort.ts
@@ -1,3 +1,4 @@
+import { TransactionContext } from '@cornie-js/backend-db/application';
 import {
   GameSpec,
   GameSpecCreateQuery,
@@ -5,7 +6,10 @@ import {
 } from '@cornie-js/backend-game-domain/games';
 
 export interface GameSpecPersistenceOutputPort {
-  create(gameSpecCreateQuery: GameSpecCreateQuery): Promise<GameSpec>;
+  create(
+    gameSpecCreateQuery: GameSpecCreateQuery,
+    transactionContext?: TransactionContext,
+  ): Promise<GameSpec>;
   find(gameSpecFindQuery: GameSpecFindQuery): Promise<GameSpec[]>;
   findOne(gameSpecFindQuery: GameSpecFindQuery): Promise<GameSpec | undefined>;
 }


### PR DESCRIPTION
### Changed
- Updated `GamePersistenceOutputPort.create` with optional TransactionContext.
- Updated `GameSpecPersistenceOutputPort.create` with optional TransactionContext.