### PR TITLE
Add refresh token find persistence flow

### DIFF
--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/foundation/db/adapter/typeorm/builders/BaseFindQueryToFindQueryTypeOrmBuilder.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/foundation/db/adapter/typeorm/builders/BaseFindQueryToFindQueryTypeOrmBuilder.ts
@@ -1,0 +1,25 @@
+import {
+  InstanceChecker,
+  ObjectLiteral,
+  QueryBuilder,
+  WhereExpressionBuilder,
+} from 'typeorm';
+
+export abstract class BaseFindQueryToFindQueryTypeOrmBuilder {
+  protected _getEntityPrefix(
+    queryBuilder: QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    entityType: Function,
+  ): string {
+    let gamePropertiesPrefix: string;
+
+    if (InstanceChecker.isSelectQueryBuilder(queryBuilder)) {
+      gamePropertiesPrefix = `${entityType.name}.`;
+    } else {
+      // No prefix should be used due to https://github.com/typeorm/typeorm/issues/1798
+      gamePropertiesPrefix = '';
+    }
+
+    return gamePropertiesPrefix;
+  }
+}

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/tokens/adapter/nest/modules/TokenDbModule.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/tokens/adapter/nest/modules/TokenDbModule.ts
@@ -8,6 +8,7 @@ import { RefreshTokenCreateQueryTypeOrmFromRefreshTokenCreateQueryBuilder } from
 import { RefreshTokenFromRefreshTokenDbBuilder } from '../../typeorm/builders/RefreshTokenFromRefreshTokenDbBuilder';
 import { RefreshTokenDb } from '../../typeorm/models/RefreshTokenDb';
 import { CreateRefreshTokenTypeOrmService } from '../../typeorm/services/CreateRefreshTokenTypeOrmService';
+import { FindRefreshTokenTypeOrmService } from '../../typeorm/services/FindRefreshTokenTypeOrmService';
 
 @Module({})
 export class TokenDbModule {
@@ -22,6 +23,7 @@ export class TokenDbModule {
       module: TokenDbModule,
       providers: [
         CreateRefreshTokenTypeOrmService,
+        FindRefreshTokenTypeOrmService,
         RefreshTokenCreateQueryTypeOrmFromRefreshTokenCreateQueryBuilder,
         RefreshTokenFromRefreshTokenDbBuilder,
         {

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/tokens/adapter/typeorm/adapters/RefreshTokenPersistenceTypeormAdapter.spec.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/tokens/adapter/typeorm/adapters/RefreshTokenPersistenceTypeormAdapter.spec.ts
@@ -4,17 +4,21 @@ import { TransactionWrapper } from '@cornie-js/backend-db/application';
 import {
   RefreshToken,
   RefreshTokenCreateQuery,
+  RefreshTokenFindQuery,
 } from '@cornie-js/backend-user-domain/tokens';
 import {
   RefreshTokenCreateQueryFixtures,
+  RefreshTokenFindQueryFixtures,
   RefreshTokenFixtures,
 } from '@cornie-js/backend-user-domain/tokens/fixtures';
 
 import { CreateRefreshTokenTypeOrmService } from '../services/CreateRefreshTokenTypeOrmService';
+import { FindRefreshTokenTypeOrmService } from '../services/FindRefreshTokenTypeOrmService';
 import { RefreshTokenPersistenceTypeormAdapter } from './RefreshTokenPersistenceTypeormAdapter';
 
 describe(RefreshTokenPersistenceTypeormAdapter.name, () => {
   let createRefreshTokenTypeOrmServiceMock: jest.Mocked<CreateRefreshTokenTypeOrmService>;
+  let findRefreshTokenTypeOrmServiceMock: jest.Mocked<FindRefreshTokenTypeOrmService>;
 
   let refreshTokenPersistenceTypeormAdapter: RefreshTokenPersistenceTypeormAdapter;
 
@@ -25,9 +29,16 @@ describe(RefreshTokenPersistenceTypeormAdapter.name, () => {
       jest.Mocked<CreateRefreshTokenTypeOrmService>
     > as jest.Mocked<CreateRefreshTokenTypeOrmService>;
 
+    findRefreshTokenTypeOrmServiceMock = {
+      findOne: jest.fn(),
+    } as Partial<
+      jest.Mocked<FindRefreshTokenTypeOrmService>
+    > as jest.Mocked<FindRefreshTokenTypeOrmService>;
+
     refreshTokenPersistenceTypeormAdapter =
       new RefreshTokenPersistenceTypeormAdapter(
         createRefreshTokenTypeOrmServiceMock,
+        findRefreshTokenTypeOrmServiceMock,
       );
   });
 
@@ -71,6 +82,54 @@ describe(RefreshTokenPersistenceTypeormAdapter.name, () => {
           createRefreshTokenTypeOrmServiceMock.insertOne,
         ).toHaveBeenCalledWith(
           refreshTokenCreateQueryFixture,
+          transactionWrapperFixture,
+        );
+      });
+
+      it('should return RefreshToken', () => {
+        expect(result).toBe(refreshTokenFixture);
+      });
+    });
+  });
+
+  describe('.findOne', () => {
+    let refreshTokenFindQueryFixture: RefreshTokenFindQuery;
+    let transactionWrapperFixture: TransactionWrapper;
+
+    beforeAll(() => {
+      refreshTokenFindQueryFixture = RefreshTokenFindQueryFixtures.any;
+
+      transactionWrapperFixture = Symbol() as unknown as TransactionWrapper;
+    });
+
+    describe('when called', () => {
+      let refreshTokenFixture: RefreshToken;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        refreshTokenFixture = RefreshTokenFixtures.any;
+
+        findRefreshTokenTypeOrmServiceMock.findOne.mockResolvedValueOnce(
+          refreshTokenFixture,
+        );
+
+        result = await refreshTokenPersistenceTypeormAdapter.findOne(
+          refreshTokenFindQueryFixture,
+          transactionWrapperFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call findRefreshTokenTypeOrmService.findOne()', () => {
+        expect(
+          findRefreshTokenTypeOrmServiceMock.findOne,
+        ).toHaveBeenCalledTimes(1);
+        expect(findRefreshTokenTypeOrmServiceMock.findOne).toHaveBeenCalledWith(
+          refreshTokenFindQueryFixture,
           transactionWrapperFixture,
         );
       });

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/tokens/adapter/typeorm/adapters/RefreshTokenPersistenceTypeormAdapter.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/tokens/adapter/typeorm/adapters/RefreshTokenPersistenceTypeormAdapter.ts
@@ -3,22 +3,28 @@ import { RefreshTokenPersistenceOutputPort } from '@cornie-js/backend-user-appli
 import {
   RefreshTokenCreateQuery,
   RefreshToken,
+  RefreshTokenFindQuery,
 } from '@cornie-js/backend-user-domain/tokens';
 import { Inject, Injectable } from '@nestjs/common';
 
 import { CreateRefreshTokenTypeOrmService } from '../services/CreateRefreshTokenTypeOrmService';
+import { FindRefreshTokenTypeOrmService } from '../services/FindRefreshTokenTypeOrmService';
 
 @Injectable()
 export class RefreshTokenPersistenceTypeormAdapter
   implements RefreshTokenPersistenceOutputPort
 {
   readonly #createRefreshTokenTypeOrmService: CreateRefreshTokenTypeOrmService;
+  readonly #findRefreshTokenTypeOrmService: FindRefreshTokenTypeOrmService;
 
   constructor(
     @Inject(CreateRefreshTokenTypeOrmService)
     createRefreshTokenTypeOrmService: CreateRefreshTokenTypeOrmService,
+    @Inject(FindRefreshTokenTypeOrmService)
+    findRefreshTokenTypeOrmService: FindRefreshTokenTypeOrmService,
   ) {
     this.#createRefreshTokenTypeOrmService = createRefreshTokenTypeOrmService;
+    this.#findRefreshTokenTypeOrmService = findRefreshTokenTypeOrmService;
   }
 
   public async create(
@@ -27,6 +33,16 @@ export class RefreshTokenPersistenceTypeormAdapter
   ): Promise<RefreshToken> {
     return this.#createRefreshTokenTypeOrmService.insertOne(
       refreshTokenCreateQuery,
+      transactionWrapper,
+    );
+  }
+
+  public async findOne(
+    refreshTokenFindQuery: RefreshTokenFindQuery,
+    transactionWrapper?: TransactionWrapper | undefined,
+  ): Promise<RefreshToken | undefined> {
+    return this.#findRefreshTokenTypeOrmService.findOne(
+      refreshTokenFindQuery,
       transactionWrapper,
     );
   }

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/tokens/adapter/typeorm/builders/RefreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder.spec.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/tokens/adapter/typeorm/builders/RefreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder.spec.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('typeorm', () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+  const originalTypeOrmModule: any = jest.requireActual('typeorm');
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const originalInstanceChecker: typeof InstanceChecker =
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    originalTypeOrmModule.InstanceChecker;
+
+  const instanceCheckerMock: typeof InstanceChecker = {
+    ...originalInstanceChecker,
+    isSelectQueryBuilder: jest.fn() as unknown as (
+      obj: unknown,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) => obj is SelectQueryBuilder<any>,
+  } as typeof InstanceChecker;
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return {
+    ...originalTypeOrmModule,
+    InstanceChecker: instanceCheckerMock,
+  };
+});
+
+import { RefreshTokenFindQuery } from '@cornie-js/backend-user-domain/tokens';
+import { RefreshTokenFindQueryFixtures } from '@cornie-js/backend-user-domain/tokens/fixtures';
+import { InstanceChecker, ObjectLiteral, SelectQueryBuilder } from 'typeorm';
+
+import { RefreshTokenDb } from '../models/RefreshTokenDb';
+import { RefreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder } from './RefreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder';
+
+describe(
+  RefreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder.name,
+  () => {
+    let refreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder: RefreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder;
+
+    beforeAll(() => {
+      refreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder =
+        new RefreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder();
+    });
+
+    describe('.build', () => {
+      let queryBuilderFixture: jest.Mocked<SelectQueryBuilder<ObjectLiteral>>;
+
+      beforeAll(() => {
+        queryBuilderFixture = {
+          andWhere: jest.fn().mockReturnThis(),
+        } as Partial<
+          jest.Mocked<SelectQueryBuilder<ObjectLiteral>>
+        > as jest.Mocked<SelectQueryBuilder<ObjectLiteral>>;
+      });
+
+      describe('having a RefreshTokenFindQuery with id', () => {
+        let refreshTokenFindQueryFixture: RefreshTokenFindQuery;
+
+        beforeAll(() => {
+          refreshTokenFindQueryFixture = RefreshTokenFindQueryFixtures.withId;
+        });
+
+        describe('when called', () => {
+          let result: unknown;
+
+          beforeAll(() => {
+            (
+              InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock
+            ).mockReturnValue(true);
+
+            result =
+              refreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder.build(
+                refreshTokenFindQueryFixture,
+                queryBuilderFixture,
+              );
+          });
+
+          afterAll(() => {
+            jest.clearAllMocks();
+
+            (
+              InstanceChecker.isSelectQueryBuilder as unknown as jest.Mock
+            ).mockReset();
+          });
+
+          it('should call queryBuilder.andWhere()', () => {
+            expect(queryBuilderFixture.andWhere).toHaveBeenCalled();
+            expect(queryBuilderFixture.andWhere).toHaveBeenCalledWith(
+              `${RefreshTokenDb.name}.id = :${RefreshTokenDb.name}id`,
+              {
+                [`${RefreshTokenDb.name}id`]: refreshTokenFindQueryFixture.id,
+              },
+            );
+          });
+
+          it('should return a QueryBuilder', () => {
+            expect(result).toBe(queryBuilderFixture);
+          });
+        });
+      });
+    });
+  },
+);

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/tokens/adapter/typeorm/builders/RefreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/tokens/adapter/typeorm/builders/RefreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder.ts
@@ -1,0 +1,41 @@
+import { Builder } from '@cornie-js/backend-common';
+import { RefreshTokenFindQuery } from '@cornie-js/backend-user-domain/tokens';
+import { Injectable } from '@nestjs/common';
+import { ObjectLiteral, QueryBuilder, WhereExpressionBuilder } from 'typeorm';
+
+import { BaseFindQueryToFindQueryTypeOrmBuilder } from '../../../../foundation/db/adapter/typeorm/builders/BaseFindQueryToFindQueryTypeOrmBuilder';
+import { RefreshTokenDb } from '../models/RefreshTokenDb';
+
+@Injectable()
+export class RefreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder
+  extends BaseFindQueryToFindQueryTypeOrmBuilder
+  implements
+    Builder<
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+      [
+        RefreshTokenFindQuery,
+        QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+      ]
+    >
+{
+  public build(
+    refreshTokenFindQuery: RefreshTokenFindQuery,
+    queryBuilder: QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+  ): QueryBuilder<ObjectLiteral> & WhereExpressionBuilder {
+    const gamePropertiesPrefix: string = this._getEntityPrefix(
+      queryBuilder,
+      RefreshTokenDb,
+    );
+
+    if (refreshTokenFindQuery.id !== undefined) {
+      queryBuilder = queryBuilder.andWhere(
+        `${gamePropertiesPrefix}id = :${RefreshTokenDb.name}id`,
+        {
+          [`${RefreshTokenDb.name}id`]: refreshTokenFindQuery.id,
+        },
+      );
+    }
+
+    return queryBuilder;
+  }
+}

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/tokens/adapter/typeorm/services/FindRefreshTokenTypeOrmService.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/tokens/adapter/typeorm/services/FindRefreshTokenTypeOrmService.ts
@@ -1,0 +1,49 @@
+import { Builder } from '@cornie-js/backend-common';
+import { FindTypeOrmService } from '@cornie-js/backend-db/adapter/typeorm';
+import {
+  RefreshToken,
+  RefreshTokenFindQuery,
+} from '@cornie-js/backend-user-domain/tokens';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import {
+  ObjectLiteral,
+  QueryBuilder,
+  Repository,
+  WhereExpressionBuilder,
+} from 'typeorm';
+
+import { RefreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder } from '../builders/RefreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder';
+import { RefreshTokenFromRefreshTokenDbBuilder } from '../builders/RefreshTokenFromRefreshTokenDbBuilder';
+import { RefreshTokenDb } from '../models/RefreshTokenDb';
+
+@Injectable()
+export class FindRefreshTokenTypeOrmService extends FindTypeOrmService<
+  RefreshToken,
+  RefreshTokenDb,
+  RefreshTokenFindQuery
+> {
+  constructor(
+    @InjectRepository(RefreshTokenDb)
+    repository: Repository<RefreshTokenDb>,
+    @Inject(RefreshTokenFromRefreshTokenDbBuilder)
+    refreshTokenFromRefreshTokenDbBuilder: Builder<
+      RefreshTokenDb,
+      [RefreshToken]
+    >,
+    @Inject(RefreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder)
+    refreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder: Builder<
+      QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+      [
+        RefreshTokenFindQuery,
+        QueryBuilder<ObjectLiteral> & WhereExpressionBuilder,
+      ]
+    >,
+  ) {
+    super(
+      repository,
+      refreshTokenFromRefreshTokenDbBuilder,
+      refreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder,
+    );
+  }
+}

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/tokens/adapter/typeorm/services/FindRefreshTokenTypeOrmService.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/tokens/adapter/typeorm/services/FindRefreshTokenTypeOrmService.ts
@@ -1,5 +1,5 @@
 import { Builder } from '@cornie-js/backend-common';
-import { FindTypeOrmService } from '@cornie-js/backend-db/adapter/typeorm';
+import { FindTypeOrmQueryBuilderService } from '@cornie-js/backend-db/adapter/typeorm';
 import {
   RefreshToken,
   RefreshTokenFindQuery,
@@ -18,7 +18,7 @@ import { RefreshTokenFromRefreshTokenDbBuilder } from '../builders/RefreshTokenF
 import { RefreshTokenDb } from '../models/RefreshTokenDb';
 
 @Injectable()
-export class FindRefreshTokenTypeOrmService extends FindTypeOrmService<
+export class FindRefreshTokenTypeOrmService extends FindTypeOrmQueryBuilderService<
   RefreshToken,
   RefreshTokenDb,
   RefreshTokenFindQuery

--- a/packages/backend/apps/user/backend-user-application/src/auth/application/ports/input/AuthManagementInputPort.spec.ts
+++ b/packages/backend/apps/user/backend-user-application/src/auth/application/ports/input/AuthManagementInputPort.spec.ts
@@ -46,6 +46,7 @@ describe(AuthManagementInputPort.name, () => {
     } as Partial<jest.Mocked<JwtService>> as jest.Mocked<JwtService>;
     refreshTokenPersistenceOutputPortMock = {
       create: jest.fn(),
+      findOne: jest.fn(),
     };
     userCanCreateAuthSpecMock = {
       isSatisfiedBy: jest.fn(),

--- a/packages/backend/apps/user/backend-user-application/src/tokens/application/ports/output/RefreshTokenPersistenceOutputPort.ts
+++ b/packages/backend/apps/user/backend-user-application/src/tokens/application/ports/output/RefreshTokenPersistenceOutputPort.ts
@@ -2,6 +2,7 @@ import { TransactionWrapper } from '@cornie-js/backend-db/application';
 import {
   RefreshToken,
   RefreshTokenCreateQuery,
+  RefreshTokenFindQuery,
 } from '@cornie-js/backend-user-domain/tokens';
 
 export const refreshTokenPersistenceOutputPortSymbol: symbol = Symbol.for(
@@ -13,4 +14,9 @@ export interface RefreshTokenPersistenceOutputPort {
     refreshTokenCreateQuery: RefreshTokenCreateQuery,
     transactionWrapper?: TransactionWrapper,
   ): Promise<RefreshToken>;
+
+  findOne(
+    refreshTokenFindQuery: RefreshTokenFindQuery,
+    transactionWrapper?: TransactionWrapper,
+  ): Promise<RefreshToken | undefined>;
 }

--- a/packages/backend/apps/user/backend-user-domain/src/tokens/domain/fixtures/RefreshTokenFindQueryFixtures.ts
+++ b/packages/backend/apps/user/backend-user-domain/src/tokens/domain/fixtures/RefreshTokenFindQueryFixtures.ts
@@ -1,0 +1,9 @@
+import { RefreshTokenFindQuery } from '../queries/RefreshTokenFindQuery';
+
+export class RefreshTokenFindQueryFixtures {
+  public static get withId(): RefreshTokenFindQuery {
+    return {
+      id: 'f3073aec-b81b-4107-97f9-baa46de5d441',
+    };
+  }
+}

--- a/packages/backend/apps/user/backend-user-domain/src/tokens/domain/fixtures/RefreshTokenFindQueryFixtures.ts
+++ b/packages/backend/apps/user/backend-user-domain/src/tokens/domain/fixtures/RefreshTokenFindQueryFixtures.ts
@@ -1,6 +1,12 @@
 import { RefreshTokenFindQuery } from '../queries/RefreshTokenFindQuery';
 
 export class RefreshTokenFindQueryFixtures {
+  public static get any(): RefreshTokenFindQuery {
+    return {
+      id: 'f3073aec-b81b-4107-97f9-baa46de5d441',
+    };
+  }
+
   public static get withId(): RefreshTokenFindQuery {
     return {
       id: 'f3073aec-b81b-4107-97f9-baa46de5d441',

--- a/packages/backend/apps/user/backend-user-domain/src/tokens/domain/fixtures/index.ts
+++ b/packages/backend/apps/user/backend-user-domain/src/tokens/domain/fixtures/index.ts
@@ -1,4 +1,9 @@
 import { RefreshTokenCreateQueryFixtures } from './RefreshTokenCreateQueryFixtures';
+import { RefreshTokenFindQueryFixtures } from './RefreshTokenFindQueryFixtures';
 import { RefreshTokenFixtures } from './RefreshTokenFixtures';
 
-export { RefreshTokenFixtures, RefreshTokenCreateQueryFixtures };
+export {
+  RefreshTokenFixtures,
+  RefreshTokenCreateQueryFixtures,
+  RefreshTokenFindQueryFixtures,
+};

--- a/packages/backend/apps/user/backend-user-domain/src/tokens/domain/index.ts
+++ b/packages/backend/apps/user/backend-user-domain/src/tokens/domain/index.ts
@@ -1,4 +1,5 @@
 import { RefreshTokenCreateQuery } from './queries/RefreshTokenCreateQuery';
+import { RefreshTokenFindQuery } from './queries/RefreshTokenFindQuery';
 import { RefreshToken } from './valueObjects/RefreshToken';
 
-export type { RefreshToken, RefreshTokenCreateQuery };
+export type { RefreshToken, RefreshTokenCreateQuery, RefreshTokenFindQuery };

--- a/packages/backend/apps/user/backend-user-domain/src/tokens/domain/queries/RefreshTokenFindQuery.ts
+++ b/packages/backend/apps/user/backend-user-domain/src/tokens/domain/queries/RefreshTokenFindQuery.ts
@@ -1,0 +1,3 @@
+export interface RefreshTokenFindQuery {
+  readonly id: string;
+}

--- a/packages/backend/services/backend-service-user/src/auth/adapters/nest/controllers/PostAuthV2HttpRequestNestController.ts
+++ b/packages/backend/services/backend-service-user/src/auth/adapters/nest/controllers/PostAuthV2HttpRequestNestController.ts
@@ -1,25 +1,28 @@
 import { Builder, Handler } from '@cornie-js/backend-common';
 import {
-  RequestWithBodyFromFastifyRequestBuilder,
   FastifyReplyFromResponseBuilder,
   HttpNestFastifyController,
+  Request,
   RequestWithBody,
   Response,
   ResponseWithBody,
   ErrorV1ResponseFromErrorBuilder,
+  RequestWithOptionalBodyFromFastifyRequestBuilder,
 } from '@cornie-js/backend-http';
 import { PostAuthV2HttpRequestController } from '@cornie-js/backend-user-application/auth';
 import { Controller, Inject, Post, Req, Res } from '@nestjs/common';
 import { FastifyReply, FastifyRequest } from 'fastify';
 
 @Controller('v2/auth')
-export class PostAuthV2HttpRequestNestController extends HttpNestFastifyController<RequestWithBody> {
+export class PostAuthV2HttpRequestNestController extends HttpNestFastifyController<
+  Request | RequestWithBody
+> {
   constructor(
-    @Inject(RequestWithBodyFromFastifyRequestBuilder)
-    requestBuilder: Builder<RequestWithBody, [FastifyRequest]>,
+    @Inject(RequestWithOptionalBodyFromFastifyRequestBuilder)
+    requestBuilder: Builder<Request | RequestWithBody, [FastifyRequest]>,
     @Inject(PostAuthV2HttpRequestController)
     requestController: Handler<
-      [RequestWithBody],
+      [Request | RequestWithBody],
       Response | ResponseWithBody<unknown>
     >,
     @Inject(ErrorV1ResponseFromErrorBuilder)


### PR DESCRIPTION
### Added
- Added `RefreshTokenFindQuery`.
- Added `RefreshTokenFindQueryTypeOrmFromRefreshTokenFindQueryBuilder`.
- Added `FindRefreshTokenTypeOrmService`.

### Changed
- Updated `FindTypeOrmQueryBuilderService` to accept optional transaction wrapper.
- Updated `RefreshTokenPersistenceOutputPort` with `findOne`.