### PR TITLE
Update Auth Middleware to provide jwt payload

### DIFF
--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/services/FindGameSpecTypeOrmService.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/services/FindGameSpecTypeOrmService.ts
@@ -1,5 +1,5 @@
 import { Builder } from '@cornie-js/backend-common';
-import { FindTypeOrmService } from '@cornie-js/backend-db/adapter/typeorm';
+import { FindTypeOrmQueryBuilderService } from '@cornie-js/backend-db/adapter/typeorm';
 import {
   GameSpec,
   GameSpecFindQuery,
@@ -18,7 +18,7 @@ import { GameSpecFromGameSpecDbBuilder } from '../builders/GameSpecFromGameSpecD
 import { GameSpecDb } from '../models/GameSpecDb';
 
 @Injectable()
-export class FindGameSpecTypeOrmService extends FindTypeOrmService<
+export class FindGameSpecTypeOrmService extends FindTypeOrmQueryBuilderService<
   GameSpec,
   GameSpecDb,
   GameSpecFindQuery

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/services/FindGameTypeOrmService.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/services/FindGameTypeOrmService.ts
@@ -1,5 +1,5 @@
 import { Builder } from '@cornie-js/backend-common';
-import { FindTypeOrmService } from '@cornie-js/backend-db/adapter/typeorm';
+import { FindTypeOrmQueryBuilderService } from '@cornie-js/backend-db/adapter/typeorm';
 import { Game, GameFindQuery } from '@cornie-js/backend-game-domain/games';
 import { Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -15,7 +15,7 @@ import { GameFromGameDbBuilder } from '../builders/GameFromGameDbBuilder';
 import { GameDb } from '../models/GameDb';
 
 @Injectable()
-export class FindGameTypeOrmService extends FindTypeOrmService<
+export class FindGameTypeOrmService extends FindTypeOrmQueryBuilderService<
   Game,
   GameDb,
   GameFindQuery

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GetGameGameIdEventsV1RequestParamHandler.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GetGameGameIdEventsV1RequestParamHandler.spec.ts
@@ -39,6 +39,9 @@ describe(GetGameGameIdEventsV1RequestParamHandler.name, () => {
           query: {},
           [requestContextProperty]: {
             auth: {
+              jwtPayload: {
+                [Symbol()]: Symbol(),
+              },
               kind: AuthKind.user,
               user: userFixture,
             },

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GetGameGameIdSlotSlotIdCardsV1RequestParamHandler.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GetGameGameIdSlotSlotIdCardsV1RequestParamHandler.spec.ts
@@ -43,6 +43,9 @@ describe(GetGameGameIdSlotSlotIdCardsV1RequestParamHandler.name, () => {
           query: {},
           [requestContextProperty]: {
             auth: {
+              jwtPayload: {
+                [Symbol()]: Symbol(),
+              },
               kind: AuthKind.user,
               user: userFixture,
             },
@@ -145,6 +148,9 @@ describe(GetGameGameIdSlotSlotIdCardsV1RequestParamHandler.name, () => {
           query: {},
           [requestContextProperty]: {
             auth: {
+              jwtPayload: {
+                [Symbol()]: Symbol(),
+              },
               kind: AuthKind.user,
               user: userFixture,
             },
@@ -199,6 +205,9 @@ describe(GetGameGameIdSlotSlotIdCardsV1RequestParamHandler.name, () => {
           query: {},
           [requestContextProperty]: {
             auth: {
+              jwtPayload: {
+                [Symbol()]: Symbol(),
+              },
               kind: AuthKind.user,
               user: userFixture,
             },

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GetGameV1MineRequestParamHandler.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GetGameV1MineRequestParamHandler.spec.ts
@@ -48,6 +48,9 @@ describe(GetGameV1MineRequestParamHandler.name, () => {
         },
         [requestContextProperty]: {
           auth: {
+            jwtPayload: {
+              [Symbol()]: Symbol(),
+            },
             kind: AuthKind.user,
             user: UserV1Fixtures.any,
           },

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GetGamesV1SpecsRequestParamHandler.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GetGamesV1SpecsRequestParamHandler.spec.ts
@@ -242,6 +242,9 @@ describe(GetGamesV1SpecsRequestParamHandler.name, () => {
           query: {},
           [requestContextProperty]: {
             auth: {
+              jwtPayload: {
+                [Symbol()]: Symbol(),
+              },
               kind: AuthKind.user,
               user: UserV1Fixtures.any,
             },

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/PatchGameGameIdV1RequestParamHandler.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/PatchGameGameIdV1RequestParamHandler.spec.ts
@@ -138,6 +138,9 @@ describe(PatchGameGameIdV1RequestParamHandler.name, () => {
       beforeAll(() => {
         gameIdFixture = ActiveGameV1Fixtures.any.id;
         authFixture = {
+          jwtPayload: {
+            [Symbol()]: Symbol(),
+          },
           kind: AuthKind.user,
           user: UserV1Fixtures.any,
         };

--- a/packages/backend/apps/user/backend-user-application/src/users/application/handlers/DeleteUserV1MeRequestParamHandler.spec.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/handlers/DeleteUserV1MeRequestParamHandler.spec.ts
@@ -71,6 +71,9 @@ describe(DeleteUserV1MeRequestParamHandler.name, () => {
 
       beforeAll(() => {
         authFixture = {
+          jwtPayload: {
+            [Symbol()]: Symbol(),
+          },
           kind: AuthKind.user,
           user: UserV1Fixtures.any,
         };

--- a/packages/backend/apps/user/backend-user-application/src/users/application/handlers/GetUserV1MeRequestParamHandler.spec.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/handlers/GetUserV1MeRequestParamHandler.spec.ts
@@ -71,6 +71,9 @@ describe(GetUserV1MeRequestParamHandler.name, () => {
 
       beforeAll(() => {
         authFixture = {
+          jwtPayload: {
+            [Symbol()]: Symbol(),
+          },
           kind: AuthKind.user,
           user: UserV1Fixtures.any,
         };

--- a/packages/backend/apps/user/backend-user-application/src/users/application/handlers/PatchUserV1MeRequestParamHandler.spec.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/handlers/PatchUserV1MeRequestParamHandler.spec.ts
@@ -88,6 +88,9 @@ describe(PatchUserV1MeRequestParamHandler.name, () => {
 
       beforeAll(() => {
         authFixture = {
+          jwtPayload: {
+            [Symbol()]: Symbol(),
+          },
           kind: AuthKind.user,
           user: UserV1Fixtures.any,
         };

--- a/packages/backend/libraries/backend-http/src/auth/application/models/Auth.ts
+++ b/packages/backend/libraries/backend-http/src/auth/application/models/Auth.ts
@@ -1,4 +1,9 @@
 import { BackendServiceAuth } from './BackendServiceAuth';
 import { UserAuth } from './UserAuth';
 
-export type Auth = BackendServiceAuth | UserAuth;
+export type Auth<
+  TPayload extends Record<string | symbol, unknown> = Record<
+    string | symbol,
+    unknown
+  >,
+> = BackendServiceAuth | UserAuth<TPayload>;

--- a/packages/backend/libraries/backend-http/src/auth/application/models/UserAuth.ts
+++ b/packages/backend/libraries/backend-http/src/auth/application/models/UserAuth.ts
@@ -3,6 +3,12 @@ import { UserV1 } from '@cornie-js/api-models/lib/models/types';
 import { AuthKind } from './AuthKind';
 import { BaseAuth } from './BaseAuth';
 
-export interface UserAuth extends BaseAuth<AuthKind.user> {
+export interface UserAuth<
+  TPayload extends Record<string | symbol, unknown> = Record<
+    string | symbol,
+    unknown
+  >,
+> extends BaseAuth<AuthKind.user> {
+  jwtPayload: TPayload;
   user: UserV1;
 }

--- a/packages/backend/libraries/backend-http/src/user/application/middleware/AuthMiddleware.spec.ts
+++ b/packages/backend/libraries/backend-http/src/user/application/middleware/AuthMiddleware.spec.ts
@@ -187,7 +187,7 @@ describe(AuthMiddleware.name, () => {
       describe('when called, and userManagementInputPort.findOne() returns a UserV1', () => {
         let requestFixture: Request;
 
-        let jwtPayloadFixture: Record<string, unknown>;
+        let jwtPayloadFixture: Record<string | symbol, unknown>;
         let userIdFixture: string;
         let userV1Fixture: apiModels.UserV1;
 
@@ -238,6 +238,7 @@ describe(AuthMiddleware.name, () => {
 
         it('should place auth in the request', () => {
           const expectedAuth: UserAuth = {
+            jwtPayload: jwtPayloadFixture,
             kind: AuthKind.user,
             user: userV1Fixture,
           };

--- a/packages/backend/libraries/backend-http/src/user/application/middleware/AuthMiddleware.ts
+++ b/packages/backend/libraries/backend-http/src/user/application/middleware/AuthMiddleware.ts
@@ -4,6 +4,7 @@ import { JwtService } from '@cornie-js/backend-jwt';
 
 import { AuthKind } from '../../../auth/application/models/AuthKind';
 import { AuthRequestContextHolder } from '../../../auth/application/models/AuthRequestContextHolder';
+import { UserAuth } from '../../../auth/application/models/UserAuth';
 import { Request } from '../../../http/application/models/Request';
 import { RequestContextHolder } from '../../../http/application/models/RequestContextHolder';
 import { requestContextProperty } from '../../../http/application/models/requestContextProperty';
@@ -102,9 +103,10 @@ export abstract class AuthMiddleware<
 
     this.#provideContext(request);
 
-    (request as Request & AuthRequestContextHolder)[
+    (request as Request & AuthRequestContextHolder<UserAuth<TPayload>>)[
       requestContextProperty
     ].auth = {
+      jwtPayload,
       kind: AuthKind.user,
       user: userV1OrUndefined,
     };


### PR DESCRIPTION
### Changed
- Updated typeorm services to extend `FindTypeOrmQueryBuilderService`.
- Updated `Auth` and `UserAuth` with `TPayload` generic.
- Updated `UserAuth` with `jwtPayload` property.
- Updated `AuthMiddleware` to provide jwt payload.
