### PR TITLE
Update PostAuthV2HttpRequestController to provide auth by refresh token if provided

### DIFF
--- a/packages/backend/apps/game/backend-game-application/src/users/application/models/AccessTokenJwtPayload.ts
+++ b/packages/backend/apps/game/backend-game-application/src/users/application/models/AccessTokenJwtPayload.ts
@@ -1,0 +1,7 @@
+export interface AccessTokenJwtPayload
+  extends Record<string | symbol, unknown> {
+  aud: string;
+  iat: number;
+  iss: string;
+  sub: string;
+}

--- a/packages/backend/apps/game/backend-game-application/src/users/application/models/UserJwtPayload.ts
+++ b/packages/backend/apps/game/backend-game-application/src/users/application/models/UserJwtPayload.ts
@@ -1,6 +1,0 @@
-export interface UserJwtPayload extends Record<string | symbol, unknown> {
-  aud: string;
-  iat: number;
-  iss: string;
-  sub: string;
-}

--- a/packages/backend/apps/user/backend-user-application/src/auth/adapter/nest/modules/AuthApplicationModule.ts
+++ b/packages/backend/apps/user/backend-user-application/src/auth/adapter/nest/modules/AuthApplicationModule.ts
@@ -7,7 +7,7 @@ import { DynamicModule, ForwardReference, Module, Type } from '@nestjs/common';
 import { HashModule } from '../../../../foundation/hash/adapter/nest/modules/HashModule';
 import { buildJwtModuleOptions } from '../../../../foundation/jwt/adapter/nest/calculations/buildJwtModuleOptions';
 import { UserApplicationModule } from '../../../../users/adapter/nest/modules/UserApplicationModule';
-import { AuthMiddleware } from '../../../application/middlewares/AuthMiddleware';
+import { AccessTokenAuthMiddleware } from '../../../application/middlewares/AccessTokenAuthMiddleware';
 import { RefreshTokenAuthMiddleware } from '../../../application/middlewares/RefreshTokenAuthMiddleware';
 import { AuthManagementInputPort } from '../../../application/ports/input/AuthManagementInputPort';
 
@@ -21,7 +21,7 @@ export class AuthApplicationModule {
     return {
       exports: [
         AuthManagementInputPort,
-        AuthMiddleware,
+        AccessTokenAuthMiddleware,
         RefreshTokenAuthMiddleware,
       ],
       global: false,
@@ -37,7 +37,7 @@ export class AuthApplicationModule {
       module: AuthApplicationModule,
       providers: [
         AuthManagementInputPort,
-        AuthMiddleware,
+        AccessTokenAuthMiddleware,
         RefreshTokenAuthMiddleware,
       ],
     };

--- a/packages/backend/apps/user/backend-user-application/src/auth/application/handlers/PostAuthV2RequestParamHandler.ts
+++ b/packages/backend/apps/user/backend-user-application/src/auth/application/handlers/PostAuthV2RequestParamHandler.ts
@@ -1,8 +1,17 @@
 import { models as apiModels } from '@cornie-js/api-models';
-import { Handler } from '@cornie-js/backend-common';
-import { Request, RequestWithBody } from '@cornie-js/backend-http';
+import { AppError, AppErrorKind, Handler } from '@cornie-js/backend-common';
+import {
+  Auth,
+  AuthKind,
+  AuthRequestContext,
+  AuthRequestContextHolder,
+  Request,
+  RequestWithBody,
+  requestContextProperty,
+} from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
+import { RefreshTokenJwtPayload } from '../../../tokens/application/models/RefreshTokenJwtPayload';
 import { PostAuthV2RequestBodyParamHandler } from './PostAuthV2RequestBodyParamHandler';
 
 @Injectable()
@@ -10,7 +19,10 @@ export class PostAuthV2RequestParamHandler
   implements
     Handler<
       [Request | RequestWithBody],
-      [apiModels.AuthCreateQueryV2 | undefined, Request | RequestWithBody]
+      [
+        apiModels.AuthCreateQueryV2 | undefined,
+        RefreshTokenJwtPayload | undefined,
+      ]
     >
 {
   readonly #postAuthV2RequestBodyParamHandler: Handler<
@@ -31,16 +43,44 @@ export class PostAuthV2RequestParamHandler
   public async handle(
     request: Request | RequestWithBody,
   ): Promise<
-    [apiModels.AuthCreateQueryV2 | undefined, Request | RequestWithBody]
+    [
+      apiModels.AuthCreateQueryV2 | undefined,
+      RefreshTokenJwtPayload | undefined,
+    ]
   > {
+    const refreshTokenJwtPayload: RefreshTokenJwtPayload | undefined =
+      this.#tryGetRefreshTokenPayload(request);
+
     if (this.#isRequestWithBody(request)) {
       const [authCreateQueryV2]: [apiModels.AuthCreateQueryV2] =
         await this.#postAuthV2RequestBodyParamHandler.handle(request);
 
-      return [authCreateQueryV2, request];
+      return [authCreateQueryV2, refreshTokenJwtPayload];
     }
 
-    return [undefined, request];
+    return [undefined, refreshTokenJwtPayload];
+  }
+
+  #tryGetRefreshTokenPayload(
+    request: Request &
+      Partial<AuthRequestContextHolder<Auth<RefreshTokenJwtPayload>>>,
+  ): RefreshTokenJwtPayload | undefined {
+    const context:
+      | AuthRequestContext<Auth<RefreshTokenJwtPayload>>
+      | undefined = request[requestContextProperty];
+
+    if (context === undefined) {
+      return undefined;
+    }
+
+    if (context.auth.kind !== AuthKind.user) {
+      throw new AppError(
+        AppErrorKind.invalidCredentials,
+        'Expecting user based credentials',
+      );
+    }
+
+    return context.auth.jwtPayload;
   }
 
   #isRequestWithBody(

--- a/packages/backend/apps/user/backend-user-application/src/auth/application/index.ts
+++ b/packages/backend/apps/user/backend-user-application/src/auth/application/index.ts
@@ -1,9 +1,4 @@
 import { PostAuthV1HttpRequestController } from './controllers/PostAuthV1HttpRequestController';
 import { PostAuthV2HttpRequestController } from './controllers/PostAuthV2HttpRequestController';
-import { AuthMiddleware } from './middlewares/AuthMiddleware';
 
-export {
-  AuthMiddleware,
-  PostAuthV1HttpRequestController,
-  PostAuthV2HttpRequestController,
-};
+export { PostAuthV1HttpRequestController, PostAuthV2HttpRequestController };

--- a/packages/backend/apps/user/backend-user-application/src/auth/application/middlewares/AccessTokenAuthMiddleware.ts
+++ b/packages/backend/apps/user/backend-user-application/src/auth/application/middlewares/AccessTokenAuthMiddleware.ts
@@ -1,16 +1,13 @@
-import { UserV1 } from '@cornie-js/api-models/lib/models/types';
-import { EnvironmentService } from '@cornie-js/backend-app-game-env';
 import { JwtService } from '@cornie-js/backend-app-jwt';
-import * as backendHttp from '@cornie-js/backend-http';
+import { EnvironmentService } from '@cornie-js/backend-app-user-env';
 import { Inject, Injectable } from '@nestjs/common';
 
-import { AccessTokenJwtPayload } from '../../../users/application/models/AccessTokenJwtPayload';
+import { AccessTokenJwtPayload } from '../../../tokens/application/models/AccessTokenJwtPayload';
 import { UserManagementInputPort } from '../../../users/application/ports/input/UserManagementInputPort';
+import { AuthMiddleware } from './AuthMiddleware';
 
 @Injectable()
-export class AuthMiddleware extends backendHttp.AuthMiddleware<AccessTokenJwtPayload> {
-  readonly #userManagementInputPort: UserManagementInputPort;
-
+export class AccessTokenAuthMiddleware extends AuthMiddleware<AccessTokenJwtPayload> {
   constructor(
     @Inject(EnvironmentService)
     environmentService: EnvironmentService,
@@ -19,20 +16,7 @@ export class AuthMiddleware extends backendHttp.AuthMiddleware<AccessTokenJwtPay
     @Inject(UserManagementInputPort)
     userManagementInputPort: UserManagementInputPort,
   ) {
-    super(
-      environmentService.getEnvironment().apiBackendServiceSecret,
-      jwtService,
-    );
-
-    this.#userManagementInputPort = userManagementInputPort;
-  }
-
-  protected override async _findUser(id: string): Promise<UserV1 | undefined> {
-    return this.#userManagementInputPort.findOne(id);
-  }
-
-  protected override _getUserId(jwtPayload: AccessTokenJwtPayload): string {
-    return jwtPayload.sub;
+    super(environmentService, jwtService, userManagementInputPort);
   }
 
   protected override _verifyJwtPayload(

--- a/packages/backend/apps/user/backend-user-application/src/auth/application/middlewares/AuthMiddleware.ts
+++ b/packages/backend/apps/user/backend-user-application/src/auth/application/middlewares/AuthMiddleware.ts
@@ -1,25 +1,20 @@
-import { UserV1 } from '@cornie-js/api-models/lib/models/types';
+import { models as apiModels } from '@cornie-js/api-models';
 import { JwtService } from '@cornie-js/backend-app-jwt';
 import { EnvironmentService } from '@cornie-js/backend-app-user-env';
 import * as backendHttp from '@cornie-js/backend-http';
-import { Inject, Injectable } from '@nestjs/common';
 
 import { AccessTokenJwtPayload } from '../../../tokens/application/models/AccessTokenJwtPayload';
 import { RefreshTokenJwtPayload } from '../../../tokens/application/models/RefreshTokenJwtPayload';
 import { UserManagementInputPort } from '../../../users/application/ports/input/UserManagementInputPort';
 
-@Injectable()
-export class AuthMiddleware extends backendHttp.AuthMiddleware<
-  AccessTokenJwtPayload | RefreshTokenJwtPayload
-> {
+export abstract class AuthMiddleware<
+  TPayload extends AccessTokenJwtPayload | RefreshTokenJwtPayload,
+> extends backendHttp.AuthMiddleware<TPayload> {
   readonly #userManagementInputPort: UserManagementInputPort;
 
   constructor(
-    @Inject(EnvironmentService)
     environmentService: EnvironmentService,
-    @Inject(JwtService)
     jwtService: JwtService,
-    @Inject(UserManagementInputPort)
     userManagementInputPort: UserManagementInputPort,
   ) {
     super(
@@ -30,13 +25,13 @@ export class AuthMiddleware extends backendHttp.AuthMiddleware<
     this.#userManagementInputPort = userManagementInputPort;
   }
 
-  protected override async _findUser(id: string): Promise<UserV1 | undefined> {
+  protected override async _findUser(
+    id: string,
+  ): Promise<apiModels.UserV1 | undefined> {
     return this.#userManagementInputPort.findOne(id);
   }
 
-  protected override _getUserId(
-    jwtPayload: AccessTokenJwtPayload | RefreshTokenJwtPayload,
-  ): string {
+  protected override _getUserId(jwtPayload: TPayload): string {
     return jwtPayload.sub;
   }
 }

--- a/packages/backend/apps/user/backend-user-application/src/auth/application/middlewares/RefreshTokenAuthMiddleware.ts
+++ b/packages/backend/apps/user/backend-user-application/src/auth/application/middlewares/RefreshTokenAuthMiddleware.ts
@@ -9,11 +9,12 @@ import {
 } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
+import { RefreshTokenJwtPayload } from '../../../tokens/application/models/RefreshTokenJwtPayload';
 import { UserManagementInputPort } from '../../../users/application/ports/input/UserManagementInputPort';
 import { AuthMiddleware } from './AuthMiddleware';
 
 @Injectable()
-export class RefreshTokenAuthMiddleware extends AuthMiddleware {
+export class RefreshTokenAuthMiddleware extends AuthMiddleware<RefreshTokenJwtPayload> {
   constructor(
     @Inject(EnvironmentService)
     environmentService: EnvironmentService,
@@ -36,5 +37,21 @@ export class RefreshTokenAuthMiddleware extends AuthMiddleware {
         throw error;
       }
     }
+  }
+
+  protected override _verifyJwtPayload(
+    jwtPayload: unknown,
+  ): jwtPayload is RefreshTokenJwtPayload {
+    return (
+      jwtPayload !== null &&
+      typeof jwtPayload === 'object' &&
+      typeof (jwtPayload as Partial<RefreshTokenJwtPayload>).aud === 'string' &&
+      typeof (jwtPayload as Partial<RefreshTokenJwtPayload>).familyId ===
+        'string' &&
+      typeof (jwtPayload as Partial<RefreshTokenJwtPayload>).iat === 'number' &&
+      typeof (jwtPayload as Partial<RefreshTokenJwtPayload>).id === 'string' &&
+      typeof (jwtPayload as Partial<RefreshTokenJwtPayload>).iss === 'string' &&
+      typeof (jwtPayload as Partial<RefreshTokenJwtPayload>).sub === 'string'
+    );
   }
 }

--- a/packages/backend/apps/user/backend-user-application/src/auth/application/ports/input/AuthManagementInputPort.spec.ts
+++ b/packages/backend/apps/user/backend-user-application/src/auth/application/ports/input/AuthManagementInputPort.spec.ts
@@ -4,7 +4,11 @@ import { models as apiModels } from '@cornie-js/api-models';
 import { JwtService } from '@cornie-js/backend-app-jwt';
 import { UuidProviderOutputPort } from '@cornie-js/backend-app-uuid';
 import { AppError, AppErrorKind } from '@cornie-js/backend-common';
-import { RefreshTokenCreateQuery } from '@cornie-js/backend-user-domain/tokens';
+import {
+  RefreshToken,
+  RefreshTokenCreateQuery,
+} from '@cornie-js/backend-user-domain/tokens';
+import { RefreshTokenFixtures } from '@cornie-js/backend-user-domain/tokens/fixtures';
 import {
   User,
   UserCanCreateAuthSpec,
@@ -19,6 +23,7 @@ import {
 
 import { BcryptHashProviderOutputPort } from '../../../../foundation/hash/application/ports/output/BcryptHashProviderOutputPort';
 import { AccessTokenJwtPayload } from '../../../../tokens/application/models/AccessTokenJwtPayload';
+import { RefreshTokenJwtPayload } from '../../../../tokens/application/models/RefreshTokenJwtPayload';
 import { RefreshTokenPersistenceOutputPort } from '../../../../tokens/application/ports/output/RefreshTokenPersistenceOutputPort';
 import { UserCodePersistenceOutputPort } from '../../../../users/application/ports/output/UserCodePersistenceOutputPort';
 import { UserPersistenceOutputPort } from '../../../../users/application/ports/output/UserPersistenceOutputPort';
@@ -30,7 +35,7 @@ describe(AuthManagementInputPort.name, () => {
   let refreshTokenPersistenceOutputPortMock: jest.Mocked<RefreshTokenPersistenceOutputPort>;
   let userCanCreateAuthSpecMock: jest.Mocked<UserCanCreateAuthSpec>;
   let userCodePersistenceOuptutPortMock: jest.Mocked<UserCodePersistenceOutputPort>;
-  let userPersistenceOuptutPortMock: jest.Mocked<UserPersistenceOutputPort>;
+  let userPersistenceOutputPortMock: jest.Mocked<UserPersistenceOutputPort>;
   let uuidProviderOutputPortMock: jest.Mocked<UuidProviderOutputPort>;
 
   let authManagementInputPort: AuthManagementInputPort;
@@ -56,7 +61,7 @@ describe(AuthManagementInputPort.name, () => {
     } as Partial<
       jest.Mocked<UserCodePersistenceOutputPort>
     > as jest.Mocked<UserCodePersistenceOutputPort>;
-    userPersistenceOuptutPortMock = {
+    userPersistenceOutputPortMock = {
       findOne: jest.fn(),
     } as Partial<
       jest.Mocked<UserPersistenceOutputPort>
@@ -71,7 +76,7 @@ describe(AuthManagementInputPort.name, () => {
       refreshTokenPersistenceOutputPortMock,
       userCanCreateAuthSpecMock,
       userCodePersistenceOuptutPortMock,
-      userPersistenceOuptutPortMock,
+      userPersistenceOutputPortMock,
       uuidProviderOutputPortMock,
     );
   });
@@ -91,7 +96,7 @@ describe(AuthManagementInputPort.name, () => {
         let result: unknown;
 
         beforeAll(async () => {
-          userPersistenceOuptutPortMock.findOne.mockResolvedValueOnce(
+          userPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
             undefined,
           );
 
@@ -111,10 +116,10 @@ describe(AuthManagementInputPort.name, () => {
             email: authCreateQueryV1Fixture.email,
           };
 
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledTimes(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(
             1,
           );
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledWith(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
             expectedUserFindQuery,
           );
         });
@@ -152,7 +157,7 @@ describe(AuthManagementInputPort.name, () => {
 
           userCanCreateAuthSpecMock.isSatisfiedBy.mockReturnValueOnce(true);
 
-          userPersistenceOuptutPortMock.findOne.mockResolvedValueOnce(
+          userPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
             userFixture,
           );
 
@@ -174,10 +179,10 @@ describe(AuthManagementInputPort.name, () => {
             email: authCreateQueryV1Fixture.email,
           };
 
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledTimes(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(
             1,
           );
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledWith(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
             expectedUserFindQuery,
           );
         });
@@ -225,7 +230,7 @@ describe(AuthManagementInputPort.name, () => {
         beforeAll(async () => {
           userFixture = UserFixtures.any;
 
-          userPersistenceOuptutPortMock.findOne.mockResolvedValueOnce(
+          userPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
             userFixture,
           );
 
@@ -247,10 +252,10 @@ describe(AuthManagementInputPort.name, () => {
             email: authCreateQueryV1Fixture.email,
           };
 
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledTimes(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(
             1,
           );
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledWith(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
             expectedUserFindQuery,
           );
         });
@@ -284,7 +289,7 @@ describe(AuthManagementInputPort.name, () => {
         beforeAll(async () => {
           userFixture = UserFixtures.any;
 
-          userPersistenceOuptutPortMock.findOne.mockResolvedValueOnce(
+          userPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
             userFixture,
           );
           userCanCreateAuthSpecMock.isSatisfiedBy.mockReturnValueOnce(true);
@@ -306,10 +311,10 @@ describe(AuthManagementInputPort.name, () => {
             email: authCreateQueryV1Fixture.email,
           };
 
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledTimes(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(
             1,
           );
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledWith(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
             expectedUserFindQuery,
           );
         });
@@ -408,7 +413,7 @@ describe(AuthManagementInputPort.name, () => {
             userCodeFixture,
           );
 
-          userPersistenceOuptutPortMock.findOne.mockResolvedValueOnce(
+          userPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
             undefined,
           );
 
@@ -441,10 +446,10 @@ describe(AuthManagementInputPort.name, () => {
             id: userCodeFixture.userId,
           };
 
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledTimes(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(
             1,
           );
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledWith(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
             expectedUserFindQuery,
           );
         });
@@ -480,7 +485,7 @@ describe(AuthManagementInputPort.name, () => {
             userCodeFixture,
           );
 
-          userPersistenceOuptutPortMock.findOne.mockResolvedValueOnce(
+          userPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
             userFixture,
           );
 
@@ -513,10 +518,10 @@ describe(AuthManagementInputPort.name, () => {
             id: userCodeFixture.userId,
           };
 
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledTimes(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(
             1,
           );
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledWith(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
             expectedUserFindQuery,
           );
         });
@@ -559,7 +564,7 @@ describe(AuthManagementInputPort.name, () => {
         let result: unknown;
 
         beforeAll(async () => {
-          userPersistenceOuptutPortMock.findOne.mockResolvedValueOnce(
+          userPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
             undefined,
           );
 
@@ -581,10 +586,10 @@ describe(AuthManagementInputPort.name, () => {
             email: loginAuthCreateQueryV2.email,
           };
 
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledTimes(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(
             1,
           );
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledWith(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
             expectedUserFindQuery,
           );
         });
@@ -628,7 +633,7 @@ describe(AuthManagementInputPort.name, () => {
 
           userCanCreateAuthSpecMock.isSatisfiedBy.mockReturnValueOnce(true);
 
-          userPersistenceOuptutPortMock.findOne.mockResolvedValueOnce(
+          userPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
             userFixture,
           );
 
@@ -656,10 +661,10 @@ describe(AuthManagementInputPort.name, () => {
             email: loginAuthCreateQueryV2.email,
           };
 
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledTimes(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(
             1,
           );
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledWith(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
             expectedUserFindQuery,
           );
         });
@@ -736,7 +741,7 @@ describe(AuthManagementInputPort.name, () => {
         beforeAll(async () => {
           userFixture = UserFixtures.any;
 
-          userPersistenceOuptutPortMock.findOne.mockResolvedValueOnce(
+          userPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
             userFixture,
           );
 
@@ -760,10 +765,10 @@ describe(AuthManagementInputPort.name, () => {
             email: loginAuthCreateQueryV2.email,
           };
 
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledTimes(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(
             1,
           );
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledWith(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
             expectedUserFindQuery,
           );
         });
@@ -797,7 +802,7 @@ describe(AuthManagementInputPort.name, () => {
         beforeAll(async () => {
           userFixture = UserFixtures.any;
 
-          userPersistenceOuptutPortMock.findOne.mockResolvedValueOnce(
+          userPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
             userFixture,
           );
           userCanCreateAuthSpecMock.isSatisfiedBy.mockReturnValueOnce(true);
@@ -821,10 +826,10 @@ describe(AuthManagementInputPort.name, () => {
             email: loginAuthCreateQueryV2.email,
           };
 
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledTimes(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(
             1,
           );
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledWith(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
             expectedUserFindQuery,
           );
         });
@@ -926,7 +931,7 @@ describe(AuthManagementInputPort.name, () => {
             userCodeFixture,
           );
 
-          userPersistenceOuptutPortMock.findOne.mockResolvedValueOnce(
+          userPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
             undefined,
           );
 
@@ -961,10 +966,10 @@ describe(AuthManagementInputPort.name, () => {
             id: userCodeFixture.userId,
           };
 
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledTimes(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(
             1,
           );
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledWith(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
             expectedUserFindQuery,
           );
         });
@@ -1006,7 +1011,7 @@ describe(AuthManagementInputPort.name, () => {
             userCodeFixture,
           );
 
-          userPersistenceOuptutPortMock.findOne.mockResolvedValueOnce(
+          userPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
             userFixture,
           );
 
@@ -1045,10 +1050,10 @@ describe(AuthManagementInputPort.name, () => {
             id: userCodeFixture.userId,
           };
 
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledTimes(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(
             1,
           );
-          expect(userPersistenceOuptutPortMock.findOne).toHaveBeenCalledWith(
+          expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
             expectedUserFindQuery,
           );
         });
@@ -1096,6 +1101,235 @@ describe(AuthManagementInputPort.name, () => {
 
           expect(result).toStrictEqual(expected);
         });
+      });
+    });
+  });
+
+  describe('.createByRefreshTokenV2', () => {
+    let refreshTokenJwtPayloadFixture: RefreshTokenJwtPayload;
+
+    beforeAll(() => {
+      refreshTokenJwtPayloadFixture = {
+        aud: 'aud',
+        familyId: 'family-id',
+        iat: 1000,
+        id: 'id',
+        iss: 'iss',
+        sub: 'sub',
+      };
+    });
+
+    describe('when called, and userPersistenceOuptutPort.findOne() returns undefined and refreshTokenPersistenceOutputPort.findOne() returns token', () => {
+      let refreshTokenValueObjectFixture: RefreshToken;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        refreshTokenValueObjectFixture = RefreshTokenFixtures.any;
+
+        refreshTokenPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          refreshTokenValueObjectFixture,
+        );
+        userPersistenceOutputPortMock.findOne.mockResolvedValueOnce(undefined);
+
+        try {
+          await authManagementInputPort.createByRefreshTokenV2(
+            refreshTokenJwtPayloadFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call refreshTokenPersistenceOutputPort.findOne()', () => {
+        expect(
+          refreshTokenPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          refreshTokenPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledWith({
+          id: refreshTokenJwtPayloadFixture.id,
+        });
+      });
+
+      it('should call userTokenPersistenceOutputPort.findOne()', () => {
+        expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(1);
+        expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledWith({
+          id: refreshTokenJwtPayloadFixture.sub,
+        });
+      });
+
+      it('should throw an AppError', () => {
+        const expectedErrorProprerties: Partial<AppError> = {
+          kind: AppErrorKind.missingCredentials,
+          message: 'Invalid credentials',
+        };
+
+        expect(result).toBeInstanceOf(AppError);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProprerties),
+        );
+      });
+    });
+
+    describe('when called, and userPersistenceOuptutPort.findOne() returns User and refreshTokenPersistenceOutputPort.findOne() returns undefined', () => {
+      let userFixture: User;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        userFixture = UserFixtures.any;
+
+        refreshTokenPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          undefined,
+        );
+        userPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          userFixture,
+        );
+
+        try {
+          await authManagementInputPort.createByRefreshTokenV2(
+            refreshTokenJwtPayloadFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call refreshTokenPersistenceOutputPort.findOne()', () => {
+        expect(
+          refreshTokenPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          refreshTokenPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledWith({
+          id: refreshTokenJwtPayloadFixture.id,
+        });
+      });
+
+      it('should call userTokenPersistenceOutputPort.findOne()', () => {
+        expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(1);
+        expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledWith({
+          id: refreshTokenJwtPayloadFixture.sub,
+        });
+      });
+
+      it('should throw an AppError', () => {
+        const expectedErrorProprerties: Partial<AppError> = {
+          kind: AppErrorKind.missingCredentials,
+          message: 'Invalid credentials',
+        };
+
+        expect(result).toBeInstanceOf(AppError);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProprerties),
+        );
+      });
+    });
+
+    describe('when called, and userPersistenceOuptutPort.findOne() returns User and refreshTokenPersistenceOutputPort.findOne() returns token', () => {
+      let accessTokenFixture: string;
+      let refreshTokenFixture: string;
+      let refreshTokenIdFixture: string;
+      let refreshTokenValueObjectFixture: RefreshToken;
+      let userFixture: User;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        refreshTokenValueObjectFixture = RefreshTokenFixtures.any;
+        userFixture = UserFixtures.any;
+
+        refreshTokenPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          refreshTokenValueObjectFixture,
+        );
+        userPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
+          userFixture,
+        );
+
+        uuidProviderOutputPortMock.generateV4.mockReturnValueOnce(
+          refreshTokenIdFixture,
+        );
+
+        jwtServiceMock.create
+          .mockResolvedValueOnce(accessTokenFixture)
+          .mockResolvedValueOnce(refreshTokenFixture);
+
+        result = await authManagementInputPort.createByRefreshTokenV2(
+          refreshTokenJwtPayloadFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call refreshTokenPersistenceOutputPort.findOne()', () => {
+        expect(
+          refreshTokenPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          refreshTokenPersistenceOutputPortMock.findOne,
+        ).toHaveBeenCalledWith({
+          id: refreshTokenJwtPayloadFixture.id,
+        });
+      });
+
+      it('should call userTokenPersistenceOutputPort.findOne()', () => {
+        expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(1);
+        expect(userPersistenceOutputPortMock.findOne).toHaveBeenCalledWith({
+          id: refreshTokenJwtPayloadFixture.sub,
+        });
+      });
+
+      it('should call uuidProviderOutputPort.generateV4', () => {
+        expect(uuidProviderOutputPortMock.generateV4).toHaveBeenCalledTimes(1);
+        expect(uuidProviderOutputPortMock.generateV4).toHaveBeenCalledWith();
+      });
+
+      it('should call jwtServiceMock.create()', () => {
+        expect(jwtServiceMock.create).toHaveBeenCalledTimes(2);
+        expect(jwtServiceMock.create).toHaveBeenNthCalledWith(1, {
+          sub: userFixture.id,
+        });
+        expect(jwtServiceMock.create).toHaveBeenNthCalledWith(2, {
+          familyId: refreshTokenJwtPayloadFixture.familyId,
+          id: refreshTokenIdFixture,
+          sub: userFixture.id,
+        });
+      });
+
+      it('should call refreshTokenPersistenceOutputPort.create()', () => {
+        const expected: RefreshTokenCreateQuery = {
+          active: true,
+          family: refreshTokenJwtPayloadFixture.familyId,
+          id: refreshTokenIdFixture,
+          token: refreshTokenFixture,
+        };
+
+        expect(
+          refreshTokenPersistenceOutputPortMock.create,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          refreshTokenPersistenceOutputPortMock.create,
+        ).toHaveBeenCalledWith(expected);
+      });
+
+      it('should return AuthV2', () => {
+        const expected: apiModels.AuthV2 = {
+          accessToken: accessTokenFixture,
+          refreshToken: refreshTokenFixture,
+        };
+
+        expect(result).toStrictEqual(expected);
       });
     });
   });

--- a/packages/backend/apps/user/backend-user-application/src/auth/application/ports/input/AuthManagementInputPort.ts
+++ b/packages/backend/apps/user/backend-user-application/src/auth/application/ports/input/AuthManagementInputPort.ts
@@ -5,7 +5,10 @@ import {
   uuidProviderOutputPortSymbol,
 } from '@cornie-js/backend-app-uuid';
 import { AppError, AppErrorKind } from '@cornie-js/backend-common';
-import { RefreshTokenCreateQuery } from '@cornie-js/backend-user-domain/tokens';
+import {
+  RefreshToken,
+  RefreshTokenCreateQuery,
+} from '@cornie-js/backend-user-domain/tokens';
 import {
   User,
   UserCanCreateAuthSpec,
@@ -94,20 +97,33 @@ export class AuthManagementInputPort {
     const user: User =
       await this.#getUserFromAuthCreateQueryV2(authCreateQueryV2);
 
-    const family: string = this.#uuidProviderOutputPort.generateV4();
-    const refreshTokenId: string = this.#uuidProviderOutputPort.generateV4();
+    const familyId: string = this.#uuidProviderOutputPort.generateV4();
 
-    const [accessToken, refreshToken]: [string, string] = await Promise.all([
-      this.#generateAccessToken(user),
-      this.#generateRefreshToken(family, refreshTokenId, user),
+    return this.#createAuthV2(familyId, user);
+  }
+
+  public async createByRefreshTokenV2(
+    refreshTokenJwtPayload: RefreshTokenJwtPayload,
+  ): Promise<apiModels.AuthV2> {
+    const [user, refreshTokenValueObject]: [
+      User | undefined,
+      RefreshToken | undefined,
+    ] = await Promise.all([
+      this.#userPersistenceOuptutPort.findOne({
+        id: refreshTokenJwtPayload.sub,
+      }),
+      this.#refreshTokenPersistenceOutputPort.findOne({
+        id: refreshTokenJwtPayload.id,
+      }),
     ]);
 
-    await this.#persistRefreshToken(family, refreshTokenId, refreshToken);
+    if (user === undefined || refreshTokenValueObject === undefined) {
+      this.#throwInvalidCredentialsError();
+    }
 
-    return {
-      accessToken,
-      refreshToken,
-    };
+    const familyId: string = refreshTokenJwtPayload.familyId;
+
+    return this.#createAuthV2(familyId, user);
   }
 
   async #getUserFromAuthCreateQueryV2(
@@ -188,6 +204,22 @@ export class AuthManagementInputPort {
     };
 
     return this.#jwtService.create(userJwtPayload);
+  }
+
+  async #createAuthV2(familyId: string, user: User): Promise<apiModels.AuthV2> {
+    const refreshTokenId: string = this.#uuidProviderOutputPort.generateV4();
+
+    const [accessToken, refreshToken]: [string, string] = await Promise.all([
+      this.#generateAccessToken(user),
+      this.#generateRefreshToken(familyId, refreshTokenId, user),
+    ]);
+
+    await this.#persistRefreshToken(familyId, refreshTokenId, refreshToken);
+
+    return {
+      accessToken,
+      refreshToken,
+    };
   }
 
   async #generateRefreshToken(

--- a/packages/backend/apps/user/backend-user-application/src/users/application/controllers/DeleteUserV1MeHttpRequestController.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/controllers/DeleteUserV1MeHttpRequestController.ts
@@ -11,7 +11,7 @@ import {
 } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
-import { AuthMiddleware } from '../../../auth/application/middlewares/AuthMiddleware';
+import { AccessTokenAuthMiddleware } from '../../../auth/application/middlewares/AccessTokenAuthMiddleware';
 import { DeleteUserV1MeRequestParamHandler } from '../handlers/DeleteUserV1MeRequestParamHandler';
 import { UserManagementInputPort } from '../ports/input/UserManagementInputPort';
 
@@ -33,8 +33,8 @@ export class DeleteUserV1MeHttpRequestController extends HttpRequestController<
       Response | ResponseWithBody<unknown>,
       [unknown]
     >,
-    @Inject(AuthMiddleware)
-    authMiddleware: AuthMiddleware,
+    @Inject(AccessTokenAuthMiddleware)
+    authMiddleware: AccessTokenAuthMiddleware,
     @Inject(UserManagementInputPort)
     userManagementInputPort: UserManagementInputPort,
   ) {

--- a/packages/backend/apps/user/backend-user-application/src/users/application/controllers/GetUserV1MeHttpRequestController.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/controllers/GetUserV1MeHttpRequestController.ts
@@ -11,7 +11,7 @@ import {
 } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
-import { AuthMiddleware } from '../../../auth/application/middlewares/AuthMiddleware';
+import { AccessTokenAuthMiddleware } from '../../../auth/application/middlewares/AccessTokenAuthMiddleware';
 import { GetUserV1MeRequestParamHandler } from '../handlers/GetUserV1MeRequestParamHandler';
 
 @Injectable()
@@ -30,8 +30,8 @@ export class GetUserV1MeHttpRequestController extends HttpRequestController<
       Response | ResponseWithBody<unknown>,
       [unknown]
     >,
-    @Inject(AuthMiddleware)
-    authMiddleware: AuthMiddleware,
+    @Inject(AccessTokenAuthMiddleware)
+    authMiddleware: AccessTokenAuthMiddleware,
   ) {
     super(
       requestParamHandler,

--- a/packages/backend/apps/user/backend-user-application/src/users/application/controllers/GetUserV1UserIdHttpRequestController.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/controllers/GetUserV1UserIdHttpRequestController.ts
@@ -11,7 +11,7 @@ import {
 } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
-import { AuthMiddleware } from '../../../auth/application/middlewares/AuthMiddleware';
+import { AccessTokenAuthMiddleware } from '../../../auth/application/middlewares/AccessTokenAuthMiddleware';
 import { GetUserV1UserIdRequestParamHandler } from '../handlers/GetUserV1UserIdRequestParamHandler';
 import { UserManagementInputPort } from '../ports/input/UserManagementInputPort';
 
@@ -35,8 +35,8 @@ export class GetUserV1UserIdHttpRequestController extends HttpRequestController<
     >,
     @Inject(UserManagementInputPort)
     userManagementInputPort: UserManagementInputPort,
-    @Inject(AuthMiddleware)
-    authMiddleware: AuthMiddleware,
+    @Inject(AccessTokenAuthMiddleware)
+    authMiddleware: AccessTokenAuthMiddleware,
   ) {
     super(
       requestParamHandler,

--- a/packages/backend/apps/user/backend-user-application/src/users/application/controllers/PatchUserV1MeHttpRequestController.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/controllers/PatchUserV1MeHttpRequestController.ts
@@ -12,7 +12,7 @@ import {
 } from '@cornie-js/backend-http';
 import { Inject, Injectable } from '@nestjs/common';
 
-import { AuthMiddleware } from '../../../auth/application/middlewares/AuthMiddleware';
+import { AccessTokenAuthMiddleware } from '../../../auth/application/middlewares/AccessTokenAuthMiddleware';
 import { PatchUserV1MeRequestParamHandler } from '../handlers/PatchUserV1MeRequestParamHandler';
 import { UserManagementInputPort } from '../ports/input/UserManagementInputPort';
 
@@ -37,8 +37,8 @@ export class PatchUserV1MeHttpRequestController extends HttpRequestController<
       Response | ResponseWithBody<unknown>,
       [unknown]
     >,
-    @Inject(AuthMiddleware)
-    authMiddleware: AuthMiddleware,
+    @Inject(AccessTokenAuthMiddleware)
+    authMiddleware: AccessTokenAuthMiddleware,
     @Inject(UserManagementInputPort)
     userManagementInputPort: UserManagementInputPort,
   ) {

--- a/packages/backend/libraries/backend-http/src/user/application/middleware/AuthMiddleware.spec.ts
+++ b/packages/backend/libraries/backend-http/src/user/application/middleware/AuthMiddleware.spec.ts
@@ -21,6 +21,9 @@ class AuthMiddlewareMock extends AuthMiddleware<Record<string, unknown>> {
   readonly #getUserIdMock: jest.Mock<
     (jwtPayload: Record<string, unknown>) => string
   >;
+  readonly #verifyJwtPayloadMock: jest.Mock<
+    (jwtPayload: unknown) => jwtPayload is Record<string, unknown>
+  >;
 
   constructor(
     backendServicesSecret: string,
@@ -29,11 +32,15 @@ class AuthMiddlewareMock extends AuthMiddleware<Record<string, unknown>> {
       (id: string) => Promise<apiModels.UserV1 | undefined>
     >,
     getUserIdMock: jest.Mock<(jwtPayload: Record<string, unknown>) => string>,
+    verifyJwtPayloadMock: jest.Mock<
+      (jwtPayload: unknown) => jwtPayload is Record<string, unknown>
+    >,
   ) {
     super(backendServicesSecret, jwtService);
 
     this.#findUserMock = findUserMock;
     this.#getUserIdMock = getUserIdMock;
+    this.#verifyJwtPayloadMock = verifyJwtPayloadMock;
   }
 
   protected override async _findUser(
@@ -45,6 +52,12 @@ class AuthMiddlewareMock extends AuthMiddleware<Record<string, unknown>> {
   protected override _getUserId(jwtPayload: Record<string, unknown>): string {
     return this.#getUserIdMock(jwtPayload);
   }
+
+  protected override _verifyJwtPayload(
+    jwtPayload: unknown,
+  ): jwtPayload is Record<string, unknown> {
+    return this.#verifyJwtPayloadMock(jwtPayload);
+  }
 }
 
 describe(AuthMiddleware.name, () => {
@@ -54,6 +67,9 @@ describe(AuthMiddleware.name, () => {
     (id: string) => Promise<apiModels.UserV1 | undefined>
   >;
   let getUserIdMock: jest.Mock<(jwtPayload: Record<string, unknown>) => string>;
+  let verifyJwtPayloadMock: jest.Mock<
+    (jwtPayload: unknown) => jwtPayload is Record<string, unknown>
+  >;
 
   let authMiddlewareMock: AuthMiddlewareMock;
 
@@ -64,14 +80,15 @@ describe(AuthMiddleware.name, () => {
     } as Partial<jest.Mocked<JwtService>> as jest.Mocked<JwtService>;
 
     findUserMock = jest.fn();
-
     getUserIdMock = jest.fn();
+    verifyJwtPayloadMock = jest.fn();
 
     authMiddlewareMock = new AuthMiddlewareMock(
       backendServicesSecretFixture,
       jwtServiceMock,
       findUserMock,
       getUserIdMock,
+      verifyJwtPayloadMock,
     );
   });
 
@@ -184,7 +201,62 @@ describe(AuthMiddleware.name, () => {
         jwtFixture = 'token';
       });
 
-      describe('when called, and userManagementInputPort.findOne() returns a UserV1', () => {
+      describe('when called, and verifyJwtPayload() returns false', () => {
+        let requestFixture: Request;
+
+        let jwtPayloadFixture: Record<string | symbol, unknown>;
+
+        let result: unknown;
+
+        beforeAll(async () => {
+          requestFixture = {
+            headers: {
+              authorization: `Bearer ${jwtFixture}`,
+            },
+            query: {},
+            urlParameters: {},
+          };
+
+          jwtPayloadFixture = { [Symbol()]: Symbol() };
+
+          jwtServiceMock.parse.mockResolvedValueOnce(jwtPayloadFixture);
+          verifyJwtPayloadMock.mockReturnValueOnce(true);
+
+          try {
+            await authMiddlewareMock.handle(requestFixture, haltMock);
+          } catch (error: unknown) {
+            result = error;
+          }
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call jwtService.parse()', () => {
+          expect(jwtServiceMock.parse).toHaveBeenCalledTimes(1);
+          expect(jwtServiceMock.parse).toHaveBeenCalledWith(jwtFixture);
+        });
+
+        it('should call verifyJwtPayload()', () => {
+          expect(verifyJwtPayloadMock).toHaveBeenCalledTimes(1);
+          expect(verifyJwtPayloadMock).toHaveBeenCalledWith(jwtPayloadFixture);
+        });
+
+        it('should throw an Error', () => {
+          const errorProperties: Partial<AppError> = {
+            kind: AppErrorKind.invalidCredentials,
+            message: 'No user was found matching current credentials',
+          };
+
+          expect(result).toBeInstanceOf(AppError);
+          expect(result).toStrictEqual(
+            expect.objectContaining(errorProperties),
+          );
+        });
+      });
+
+      describe('when called, and verifyJwtPayload() returns true and userManagementInputPort.findOne() returns a UserV1', () => {
         let requestFixture: Request;
 
         let jwtPayloadFixture: Record<string | symbol, unknown>;
@@ -211,6 +283,7 @@ describe(AuthMiddleware.name, () => {
           };
 
           jwtServiceMock.parse.mockResolvedValueOnce(jwtPayloadFixture);
+          verifyJwtPayloadMock.mockReturnValueOnce(true);
           getUserIdMock.mockReturnValueOnce(userIdFixture);
           findUserMock.mockResolvedValueOnce(userV1Fixture);
 
@@ -224,6 +297,11 @@ describe(AuthMiddleware.name, () => {
         it('should call jwtService.parse()', () => {
           expect(jwtServiceMock.parse).toHaveBeenCalledTimes(1);
           expect(jwtServiceMock.parse).toHaveBeenCalledWith(jwtFixture);
+        });
+
+        it('should call verifyJwtPayload()', () => {
+          expect(verifyJwtPayloadMock).toHaveBeenCalledTimes(1);
+          expect(verifyJwtPayloadMock).toHaveBeenCalledWith(jwtPayloadFixture);
         });
 
         it('should call getUserId()', () => {
@@ -251,7 +329,7 @@ describe(AuthMiddleware.name, () => {
         });
       });
 
-      describe('when called, and userManagementInputPort.findOne() returns undefined', () => {
+      describe('when called, and verifyJwtPayload() returns true and userManagementInputPort.findOne() returns undefined', () => {
         let result: unknown;
 
         let requestFixture: Request;
@@ -273,6 +351,7 @@ describe(AuthMiddleware.name, () => {
           userIdFixture = 'idFixture';
 
           jwtServiceMock.parse.mockResolvedValueOnce(jwtPayloadFixture);
+          verifyJwtPayloadMock.mockReturnValueOnce(true);
           getUserIdMock.mockReturnValueOnce(userIdFixture);
           findUserMock.mockResolvedValueOnce(undefined);
 
@@ -290,6 +369,11 @@ describe(AuthMiddleware.name, () => {
         it('should call jwtService.parse()', () => {
           expect(jwtServiceMock.parse).toHaveBeenCalledTimes(1);
           expect(jwtServiceMock.parse).toHaveBeenCalledWith(jwtFixture);
+        });
+
+        it('should call verifyJwtPayload()', () => {
+          expect(verifyJwtPayloadMock).toHaveBeenCalledTimes(1);
+          expect(verifyJwtPayloadMock).toHaveBeenCalledWith(jwtPayloadFixture);
         });
 
         it('should call getUserId()', () => {

--- a/packages/backend/libraries/backend-http/src/user/application/middleware/AuthMiddleware.ts
+++ b/packages/backend/libraries/backend-http/src/user/application/middleware/AuthMiddleware.ts
@@ -87,7 +87,14 @@ export abstract class AuthMiddleware<
     authBearerToken: string,
     request: Request | RequestWithBody,
   ): Promise<void> {
-    const jwtPayload: TPayload = await this.#jwtService.parse(authBearerToken);
+    const jwtPayload: unknown = await this.#jwtService.parse(authBearerToken);
+
+    if (!this._verifyJwtPayload(jwtPayload)) {
+      throw new AppError(
+        AppErrorKind.invalidCredentials,
+        'Unexpected jwt claims were found when parsing request authorization',
+      );
+    }
 
     const userId: string = this._getUserId(jwtPayload);
 
@@ -117,4 +124,8 @@ export abstract class AuthMiddleware<
   ): Promise<apiModels.UserV1 | undefined>;
 
   protected abstract _getUserId(jwtPayload: TPayload): string;
+
+  protected abstract _verifyJwtPayload(
+    jwtPayload: unknown,
+  ): jwtPayload is TPayload;
 }


### PR DESCRIPTION
### Changed
- Updated `PostAuthV2HttpRequestController` to provide auth by refresh token if provided.
- Updated `AuthMiddleware` with `_verifyJwtPayload`.
- Updated `AuthManagementInputPort` with `createByRefreshTokenV2`.