### PR TITLE
Update game db entities with game history ones

### DIFF
--- a/packages/api/libraries/api-openapi-schema/schemas/src/one-game.yaml
+++ b/packages/api/libraries/api-openapi-schema/schemas/src/one-game.yaml
@@ -21,6 +21,7 @@ components:
 paths:
   /v1/auth:
     post:
+      deprecated: true
       summary: Create an authorization token
       operationId: createAuth
       requestBody:
@@ -629,6 +630,18 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              authByCode:
+                summary: User code
+                value:
+                  code: 0077df18851946fb67e552b83f34d58283548c38c4c5f144e6b655280b773528
+                  kind: code
+              authByLogin:
+                summary: User credentials
+                value:
+                  email: mail@example.com
+                  kind: login
+                  password: sample-password
             schema:
               $ref: 'https://onegame.schemas/api/v2/auth/auth-create-query.json'
         required: false

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/app/adapter/typeorm/migrations/1708646400000-AddGameHistory.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/app/adapter/typeorm/migrations/1708646400000-AddGameHistory.ts
@@ -19,6 +19,7 @@ export class AddGameHistory1708646400000 implements MigrationInterface {
     await queryRunner.query(
       `CREATE TABLE "GameInitialSnapshot" ("current_card" bit(16) NOT NULL, "current_color" bit(16) NOT NULL, "current_direction" character varying(32) NOT NULL, "current_playing_slot" smallint NOT NULL, "deck" json NOT NULL, "draw_count" smallint NOT NULL, "id" character varying(36) NOT NULL, "game_id" character varying(36) NOT NULL, CONSTRAINT "PK_79de72d7a2e49d332bd7ad3ec41" PRIMARY KEY ("id"))`,
     );
+    await queryRunner.query(`ALTER TABLE "Game" ADD "turn" smallint`);
     await queryRunner.query(
       `ALTER TABLE "GameAction" ADD CONSTRAINT "FK_4ccd5dc231685b49a5355edaa46" FOREIGN KEY ("game_id") REFERENCES "Game"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
     );
@@ -40,6 +41,7 @@ export class AddGameHistory1708646400000 implements MigrationInterface {
     await queryRunner.query(
       `ALTER TABLE "GameAction" DROP CONSTRAINT "FK_4ccd5dc231685b49a5355edaa46"`,
     );
+    await queryRunner.query(`ALTER TABLE "Game" DROP COLUMN "turn"`);
     await queryRunner.query(`DROP TABLE "GameInitialSnapshot"`);
     await queryRunner.query(`DROP TABLE "GameInitialSnapshotSlot"`);
     await queryRunner.query(

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/app/adapter/typeorm/migrations/1708646400000-AddGameHistory.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/app/adapter/typeorm/migrations/1708646400000-AddGameHistory.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddGameHistory1708646400000 implements MigrationInterface {
+  public readonly name: string = 'AddGameHistory1708646400000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "GameAction" ("id" character varying(36) NOT NULL, "payload" json NOT NULL, "position" smallint NOT NULL, "turn" smallint NOT NULL, "game_id" character varying(36) NOT NULL, CONSTRAINT "PK_504414b3ee4d764e8df48118c0e" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_030557ed95c9537ffb33536d49" ON "GameAction" ("game_id", "turn")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_7ed74975e34bbce332c8b58525" ON "GameAction" ("game_id", "position")`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "GameInitialSnapshotSlot" ("cards" json NOT NULL, "id" character varying(36) NOT NULL, "position" smallint, "user_id" character varying(36) NOT NULL, "game_initial_snapshot_id" character varying(36) NOT NULL, CONSTRAINT "PK_ab9464398b172ed7ff9c00a397d" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "GameInitialSnapshot" ("current_card" bit(16) NOT NULL, "current_color" bit(16) NOT NULL, "current_direction" character varying(32) NOT NULL, "current_playing_slot" smallint NOT NULL, "deck" json NOT NULL, "draw_count" smallint NOT NULL, "id" character varying(36) NOT NULL, "game_id" character varying(36) NOT NULL, CONSTRAINT "PK_79de72d7a2e49d332bd7ad3ec41" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "GameAction" ADD CONSTRAINT "FK_4ccd5dc231685b49a5355edaa46" FOREIGN KEY ("game_id") REFERENCES "Game"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "GameInitialSnapshotSlot" ADD CONSTRAINT "FK_46af31c84986ba21bf4837025a5" FOREIGN KEY ("game_initial_snapshot_id") REFERENCES "GameInitialSnapshot"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "GameInitialSnapshot" ADD CONSTRAINT "FK_be95245a47a081f63be111e22b0" FOREIGN KEY ("game_id") REFERENCES "Game"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "GameInitialSnapshot" DROP CONSTRAINT "FK_be95245a47a081f63be111e22b0"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "GameInitialSnapshotSlot" DROP CONSTRAINT "FK_46af31c84986ba21bf4837025a5"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "GameAction" DROP CONSTRAINT "FK_4ccd5dc231685b49a5355edaa46"`,
+    );
+    await queryRunner.query(`DROP TABLE "GameInitialSnapshot"`);
+    await queryRunner.query(`DROP TABLE "GameInitialSnapshotSlot"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_7ed74975e34bbce332c8b58525"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_030557ed95c9537ffb33536d49"`,
+    );
+    await queryRunner.query(`DROP TABLE "GameAction"`);
+  }
+}

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/foundation/db/adapter/nest/models/entities.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/foundation/db/adapter/nest/models/entities.ts
@@ -1,6 +1,16 @@
+import { GameActionDb } from '../../../../../games/adapter/typeorm/models/GameActionDb';
 import { GameDb } from '../../../../../games/adapter/typeorm/models/GameDb';
+import { GameInitialSnapshotDb } from '../../../../../games/adapter/typeorm/models/GameInitialSnapshotDb';
+import { GameInitialSnapshotSlotDb } from '../../../../../games/adapter/typeorm/models/GameInitialSnapshotSlotDb';
 import { GameSlotDb } from '../../../../../games/adapter/typeorm/models/GameSlotDb';
 import { GameSpecDb } from '../../../../../games/adapter/typeorm/models/GameSpecDb';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export const typeOrmEntities: Function[] = [GameDb, GameSlotDb, GameSpecDb];
+export const typeOrmEntities: Function[] = [
+  GameActionDb,
+  GameDb,
+  GameInitialSnapshotDb,
+  GameInitialSnapshotSlotDb,
+  GameSlotDb,
+  GameSpecDb,
+];

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameFromGameDbBuilder.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameFromGameDbBuilder.spec.ts
@@ -349,6 +349,7 @@ describe(GameFromGameDbBuilder.name, () => {
             drawCount: gameDbFixture.drawCount as number,
             slots: [gameSlotFixture],
             status: GameStatus.active,
+            turn: gameDbFixture.turn as number,
           },
         };
 

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameFromGameDbBuilder.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameFromGameDbBuilder.ts
@@ -120,7 +120,8 @@ export class GameFromGameDbBuilder implements Builder<Game, [GameDb]> {
       gameDb.currentPlayingSlotIndex === null ||
       gameDb.currentTurnCardsPlayed === null ||
       gameDb.deck === null ||
-      gameDb.drawCount === null
+      gameDb.drawCount === null ||
+      gameDb.turn === null
     ) {
       throw new AppError(AppErrorKind.unknown, 'Unexpected card spec db entry');
     }
@@ -146,6 +147,7 @@ export class GameFromGameDbBuilder implements Builder<Game, [GameDb]> {
         drawCount: gameDb.drawCount,
         slots: gameSlots,
         status: GameStatus.active,
+        turn: gameDb.turn,
       },
     };
   }

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSetQueryTypeOrmFromGameUpdateQueryBuilder.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSetQueryTypeOrmFromGameUpdateQueryBuilder.spec.ts
@@ -384,5 +384,37 @@ describe(GameSetQueryTypeOrmFromGameUpdateQueryBuilder.name, () => {
         });
       });
     });
+
+    describe('having a GameUpdateQuery with turn', () => {
+      let gameUpdateQueryFixture: GameUpdateQuery;
+
+      beforeAll(() => {
+        gameUpdateQueryFixture = GameUpdateQueryFixtures.withTurn;
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = gameSetQueryTypeOrmFromGameUpdateQueryBuilder.build(
+            gameUpdateQueryFixture,
+          );
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should return a QueryDeepPartialEntity<GameDb>', () => {
+          const expectedProperties: Partial<QueryDeepPartialEntity<GameDb>> = {
+            turn: gameUpdateQueryFixture.turn as number,
+          };
+
+          expect(result).toStrictEqual(
+            expect.objectContaining(expectedProperties),
+          );
+        });
+      });
+    });
   });
 });

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSetQueryTypeOrmFromGameUpdateQueryBuilder.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSetQueryTypeOrmFromGameUpdateQueryBuilder.ts
@@ -124,6 +124,10 @@ export class GameSetQueryTypeOrmFromGameUpdateQueryBuilder
       gameSetQueryTypeOrm.drawCount = gameUpdateQuery.drawCount;
     }
 
+    if (gameUpdateQuery.turn !== undefined) {
+      gameSetQueryTypeOrm.turn = gameUpdateQuery.turn;
+    }
+
     return gameSetQueryTypeOrm;
   }
 }

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/fixtures/GameDbFixtures.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/fixtures/GameDbFixtures.ts
@@ -84,6 +84,7 @@ export class GameDbFixtures {
     fixture.gameSpecDb = GameSpecDbFixtures.any;
     fixture.id = '6fbcdb6c-b03c-4754-94c1-9f664f036cde';
     fixture.status = GameStatusDb.active;
+    fixture.turn = 1;
 
     return fixture;
   }

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/models/GameActionDb.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/models/GameActionDb.ts
@@ -1,0 +1,53 @@
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  RelationId,
+} from 'typeorm';
+
+import { GameDb } from './GameDb';
+
+@Entity({
+  name: 'GameAction',
+})
+@Index(['game', 'position'])
+@Index(['game', 'turn'])
+export class GameActionDb {
+  @ManyToOne(() => GameDb, undefined, { nullable: false })
+  @JoinColumn({ name: 'game_id' })
+  public readonly game!: GameDb;
+
+  @RelationId((gameAction: GameActionDb) => gameAction.game)
+  public readonly gameId!: string;
+
+  @PrimaryColumn({
+    length: 36,
+    name: 'id',
+    type: 'varchar',
+  })
+  public readonly id!: string;
+
+  @Column({
+    name: 'payload',
+    nullable: false,
+    type: 'json',
+  })
+  public readonly payload!: string;
+
+  @Column({
+    name: 'position',
+    nullable: false,
+    type: 'smallint',
+  })
+  public readonly position!: number;
+
+  @Column({
+    name: 'turn',
+    nullable: false,
+    type: 'smallint',
+  })
+  public readonly turn!: number;
+}

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/models/GameActionKindDb.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/models/GameActionKindDb.ts
@@ -1,0 +1,4 @@
+export enum GameActionKindDb {
+  passTurn = 'passTurn',
+  playCards = 'playCards',
+}

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/models/GameDb.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/models/GameDb.ts
@@ -74,7 +74,7 @@ export class GameDb {
     type: 'smallint',
     width: 4,
   })
-  public drawCount!: number | null;
+  public readonly drawCount!: number | null;
 
   @PrimaryColumn({
     length: 36,
@@ -122,4 +122,11 @@ export class GameDb {
     width: 2,
   })
   public readonly status!: GameStatusDb;
+
+  @Column({
+    name: 'turn',
+    nullable: true,
+    type: 'smallint',
+  })
+  public readonly turn!: number | null;
 }

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/models/GameInitialSnapshotDb.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/models/GameInitialSnapshotDb.ts
@@ -1,0 +1,95 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryColumn,
+  RelationId,
+} from 'typeorm';
+
+import { BinaryToNumberTransformer } from '../../../../foundation/db/adapter/typeorm/transformers/BinaryToNumberTransformer';
+import { GameDb } from './GameDb';
+import { GameDirectionDb } from './GameDirectionDb';
+import { GameInitialSnapshotSlotDb } from './GameInitialSnapshotSlotDb';
+
+@Entity({
+  name: 'GameInitialSnapshot',
+})
+export class GameInitialSnapshotDb {
+  @Column({
+    length: 16,
+    name: 'current_card',
+    nullable: false,
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+    transformer: new BinaryToNumberTransformer(16),
+    type: 'bit',
+  })
+  public readonly currentCard!: number;
+
+  @Column({
+    length: 16,
+    name: 'current_color',
+    nullable: false,
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+    transformer: new BinaryToNumberTransformer(16),
+    type: 'bit',
+  })
+  public readonly currentColor!: number;
+
+  @Column({
+    length: 32,
+    name: 'current_direction',
+    nullable: false,
+    type: 'varchar',
+  })
+  public readonly currentDirection!: GameDirectionDb;
+
+  @Column({
+    name: 'current_playing_slot',
+    nullable: false,
+    type: 'smallint',
+  })
+  public readonly currentPlayingSlotIndex!: number;
+
+  @Column({
+    name: 'deck',
+    nullable: false,
+    type: 'json',
+  })
+  public readonly deck!: string;
+
+  @Column({
+    name: 'draw_count',
+    nullable: false,
+    type: 'smallint',
+    width: 4,
+  })
+  public readonly drawCount!: number;
+
+  @ManyToOne(() => GameDb, undefined, { nullable: false })
+  @JoinColumn({ name: 'game_id' })
+  public readonly game!: GameDb;
+
+  @RelationId(
+    (gameInitialSnapshot: GameInitialSnapshotDb) => gameInitialSnapshot.game,
+  )
+  public readonly gameId!: string;
+
+  @OneToMany(
+    () => GameInitialSnapshotSlotDb,
+    (gameSlotDb: GameInitialSnapshotSlotDb): GameInitialSnapshotDb =>
+      gameSlotDb.gameInitialSnapshot,
+    {
+      eager: true,
+    },
+  )
+  public readonly gameSlotsDb!: GameInitialSnapshotSlotDb[];
+
+  @PrimaryColumn({
+    length: 36,
+    name: 'id',
+    type: 'varchar',
+  })
+  public readonly id!: string;
+}

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/models/GameInitialSnapshotSlotDb.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/models/GameInitialSnapshotSlotDb.ts
@@ -1,0 +1,58 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  RelationId,
+} from 'typeorm';
+
+import { GameInitialSnapshotDb } from './GameInitialSnapshotDb';
+
+@Entity({
+  name: 'GameInitialSnapshotSlot',
+})
+export class GameInitialSnapshotSlotDb {
+  @Column({
+    name: 'cards',
+    nullable: false,
+    type: 'json',
+  })
+  public readonly cards!: string;
+
+  @ManyToOne(
+    () => GameInitialSnapshotDb,
+    (
+      gameInitialSnapshotDb: GameInitialSnapshotDb,
+    ): GameInitialSnapshotSlotDb[] => gameInitialSnapshotDb.gameSlotsDb,
+    { nullable: false },
+  )
+  @JoinColumn({ name: 'game_initial_snapshot_id' })
+  public readonly gameInitialSnapshot!: GameInitialSnapshotDb;
+
+  @RelationId(
+    (gameSlot: GameInitialSnapshotSlotDb) => gameSlot.gameInitialSnapshot,
+  )
+  public readonly gameInitialSnapshotId!: string;
+
+  @PrimaryColumn({
+    length: 36,
+    name: 'id',
+    type: 'varchar',
+  })
+  public readonly id!: string;
+
+  @Column({
+    name: 'position',
+    nullable: true,
+    type: 'smallint',
+  })
+  public readonly position!: number;
+
+  @Column({
+    length: 36,
+    name: 'user_id',
+    type: 'varchar',
+  })
+  public readonly userId!: string;
+}

--- a/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/valueObjects/BaseGameAction.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/valueObjects/BaseGameAction.ts
@@ -1,0 +1,8 @@
+import { GameActionKind } from './GameActionKind';
+
+export interface BaseGameAction<TKind extends GameActionKind> {
+  readonly currentPlayingSlotIndex: number;
+  readonly kind: TKind;
+  readonly position: number;
+  readonly turn: number;
+}

--- a/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/valueObjects/DrawGameAction.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/valueObjects/DrawGameAction.ts
@@ -1,0 +1,7 @@
+import { Card } from '../../../cards/domain/valueObjects/Card';
+import { BaseGameAction } from './BaseGameAction';
+import { GameActionKind } from './GameActionKind';
+
+export interface DrawGameAction extends BaseGameAction<GameActionKind.draw> {
+  readonly draw: Card | null;
+}

--- a/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/valueObjects/GameAction.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/valueObjects/GameAction.ts
@@ -1,0 +1,8 @@
+import { DrawGameAction } from './DrawGameAction';
+import { PassTurnGameAction } from './PassTurnGameAction';
+import { PlayCardsGameAction } from './PlayCardsGameAction';
+
+export type GameAction =
+  | DrawGameAction
+  | PassTurnGameAction
+  | PlayCardsGameAction;

--- a/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/valueObjects/GameActionKind.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/valueObjects/GameActionKind.ts
@@ -1,0 +1,5 @@
+export enum GameActionKind {
+  draw,
+  passTurn,
+  playCards,
+}

--- a/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/valueObjects/PassTurnGameAction.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/valueObjects/PassTurnGameAction.ts
@@ -1,0 +1,4 @@
+import { BaseGameAction } from './BaseGameAction';
+import { GameActionKind } from './GameActionKind';
+
+export type PassTurnGameAction = BaseGameAction<GameActionKind.passTurn>;

--- a/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/valueObjects/PlayCardsGameAction.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/valueObjects/PlayCardsGameAction.ts
@@ -1,0 +1,8 @@
+import { Card } from '../../../cards/domain/valueObjects/Card';
+import { BaseGameAction } from './BaseGameAction';
+import { GameActionKind } from './GameActionKind';
+
+export interface PlayCardsGameAction
+  extends BaseGameAction<GameActionKind.playCards> {
+  readonly cards: Card[];
+}

--- a/packages/backend/apps/game/backend-game-domain/src/gameSnapshots/domain/entities/GameInitialSnapshot.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameSnapshots/domain/entities/GameInitialSnapshot.ts
@@ -1,0 +1,16 @@
+import { Card } from '../../../cards/domain/valueObjects/Card';
+import { CardColor } from '../../../cards/domain/valueObjects/CardColor';
+import { GameCardSpec } from '../../../games/domain/valueObjects/GameCardSpec';
+import { GameDirection } from '../../../games/domain/valueObjects/GameDirection';
+import { GameInitialSnapshotSlot } from './GameInitialSnapshotSlot';
+
+export interface GameInitialSnapshot {
+  readonly currentCard: Card;
+  readonly currentColor: CardColor;
+  readonly currentDirection: GameDirection;
+  readonly currentPlayingSlotIndex: number;
+  readonly deck: GameCardSpec[];
+  readonly drawCount: number;
+  readonly id: string;
+  readonly slots: GameInitialSnapshotSlot[];
+}

--- a/packages/backend/apps/game/backend-game-domain/src/gameSnapshots/domain/entities/GameInitialSnapshotSlot.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameSnapshots/domain/entities/GameInitialSnapshotSlot.ts
@@ -1,0 +1,7 @@
+import { Card } from '../../../cards/domain/valueObjects/Card';
+
+export interface GameInitialSnapshotSlot {
+  readonly cards: Card[];
+  readonly position: number;
+  readonly userId: string;
+}

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/ActiveGameFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/ActiveGameFixtures.ts
@@ -28,6 +28,7 @@ export class ActiveGameFixtures {
         drawCount: 0,
         slots: [ActiveGameSlotFixtures.withPositionZero],
         status: GameStatus.active,
+        turn: 1,
       },
     };
   }

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameUpdateQueryFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameUpdateQueryFixtures.ts
@@ -113,4 +113,13 @@ export class GameUpdateQueryFixtures {
 
     return fixture;
   }
+
+  public static get withTurn(): GameUpdateQuery {
+    const fixture: GameUpdateQuery = {
+      ...GameUpdateQueryFixtures.any,
+      turn: 1,
+    };
+
+    return fixture;
+  }
 }

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/query/GameUpdateQuery.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/query/GameUpdateQuery.ts
@@ -19,4 +19,5 @@ export interface GameUpdateQuery {
   drawCount?: number;
   gameSlotUpdateQueries?: GameSlotUpdateQuery[];
   status?: GameStatus;
+  turn?: number;
 }

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/services/GameService.spec.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/services/GameService.spec.ts
@@ -152,6 +152,7 @@ describe(GameService.name, () => {
                 },
               },
             ],
+            turn: gameFixture.state.turn + 1,
           };
 
           expect(result).toStrictEqual(expectedGameUpdateQuery);
@@ -253,6 +254,7 @@ describe(GameService.name, () => {
                 },
               },
             ],
+            turn: gameFixture.state.turn + 1,
           };
 
           expect(result).toStrictEqual(expectedGameUpdateQuery);
@@ -315,6 +317,7 @@ describe(GameService.name, () => {
                   gameFixture.state.currentPlayingSlotIndex,
               },
             },
+            turn: gameFixture.state.turn + 1,
           };
 
           expect(result).toStrictEqual(expectedGameUpdateQuery);
@@ -357,6 +360,7 @@ describe(GameService.name, () => {
               },
             },
             status: GameStatus.finished,
+            turn: gameFixture.state.turn + 1,
           };
 
           expect(result).toStrictEqual(expectedGameUpdateQuery);
@@ -743,6 +747,7 @@ describe(GameService.name, () => {
               },
             ],
             status: GameStatus.active,
+            turn: 1,
           };
 
           expect(result).toStrictEqual(

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/services/GameService.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/services/GameService.ts
@@ -26,6 +26,7 @@ import { GameDrawService } from './GameDrawService';
 const MIN_CARDS_TO_DRAW: number = 1;
 
 const UNO_ORIGINAL_ACTION_CARDS_PER_COLOR: number = 2;
+const UNO_ORIGINAL_FIRST_TURN: number = 1;
 const UNO_ORIGINAL_NUMBERS_AMOUNT: number = 10;
 const UNO_ORIGINAL_NUMBERED_NON_ZERO_CARDS_PER_COLOR: number = 2;
 const UNO_ORIGINAL_NUMBERED_ZERO_CARDS_PER_COLOR: number = 1;
@@ -66,6 +67,7 @@ export class GameService {
           currentPlayingSlotIndex: game.state.currentPlayingSlotIndex,
         },
       },
+      turn: game.state.turn + 1,
     };
 
     if (this.#isGameFinishedSpec.isSatisfiedBy(game)) {
@@ -165,6 +167,7 @@ export class GameService {
       },
       gameSlotUpdateQueries,
       status: GameStatus.active,
+      turn: UNO_ORIGINAL_FIRST_TURN,
     };
 
     return gameUpdateQuery;

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/valueObjects/ActiveGameState.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/valueObjects/ActiveGameState.ts
@@ -16,4 +16,5 @@ export interface ActiveGameState {
   readonly drawCount: number;
   readonly slots: ActiveGameSlot[];
   readonly status: GameStatus.active;
+  readonly turn: number;
 }

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/valueObjects/BaseGameSlot.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/valueObjects/BaseGameSlot.ts
@@ -1,4 +1,4 @@
 export interface BaseGameSlot {
-  position: number;
-  userId: string;
+  readonly position: number;
+  readonly userId: string;
 }


### PR DESCRIPTION
### Added
- Added `GameAction`.
- Added `GameInitialSnapshot`.
- Added `GameActionDb`.
- Added `GameInitialSnapshotDb`.

### Changed
- Updated `Game` with `turn`.
- Updated builders to handle Game turn.
- Updated `GameService` to properly set game turns.