### PR TITLE
Update ActiveGameState with skipCount

### DIFF
--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/app/adapter/typeorm/migrations/1709405917920-UpdateGameWithSkipCount.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/app/adapter/typeorm/migrations/1709405917920-UpdateGameWithSkipCount.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateGameWithSkipCount1709405917920
+  implements MigrationInterface
+{
+  public readonly name: string = 'UpdateGameWithSkipCount1709405917920';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "Game" ADD "skip_count" smallint`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "Game" DROP COLUMN "skip_count"`);
+  }
+}

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameFromGameDbBuilder.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameFromGameDbBuilder.spec.ts
@@ -347,6 +347,7 @@ describe(GameFromGameDbBuilder.name, () => {
             deck: gameCardSpecArrayFixture,
             discardPile: gameCardSpecArrayFixture,
             drawCount: gameDbFixture.drawCount as number,
+            skipCount: gameDbFixture.skipCount as number,
             slots: [gameSlotFixture],
             status: GameStatus.active,
             turn: gameDbFixture.turn as number,

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameFromGameDbBuilder.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameFromGameDbBuilder.ts
@@ -121,6 +121,7 @@ export class GameFromGameDbBuilder implements Builder<Game, [GameDb]> {
       gameDb.currentTurnCardsPlayed === null ||
       gameDb.deck === null ||
       gameDb.drawCount === null ||
+      gameDb.skipCount === null ||
       gameDb.turn === null
     ) {
       throw new AppError(AppErrorKind.unknown, 'Unexpected card spec db entry');
@@ -145,6 +146,7 @@ export class GameFromGameDbBuilder implements Builder<Game, [GameDb]> {
             gameDb.discardPile,
           ),
         drawCount: gameDb.drawCount,
+        skipCount: gameDb.skipCount,
         slots: gameSlots,
         status: GameStatus.active,
         turn: gameDb.turn,

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSetQueryTypeOrmFromGameUpdateQueryBuilder.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSetQueryTypeOrmFromGameUpdateQueryBuilder.spec.ts
@@ -345,6 +345,38 @@ describe(GameSetQueryTypeOrmFromGameUpdateQueryBuilder.name, () => {
       });
     });
 
+    describe('having a GameUpdateQuery with skipCount', () => {
+      let gameUpdateQueryFixture: GameUpdateQuery;
+
+      beforeAll(() => {
+        gameUpdateQueryFixture = GameUpdateQueryFixtures.withSkipCount;
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = gameSetQueryTypeOrmFromGameUpdateQueryBuilder.build(
+            gameUpdateQueryFixture,
+          );
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should return a QueryDeepPartialEntity<GameDb>', () => {
+          const expectedProperties: Partial<QueryDeepPartialEntity<GameDb>> = {
+            skipCount: gameUpdateQueryFixture.skipCount as number,
+          };
+
+          expect(result).toStrictEqual(
+            expect.objectContaining(expectedProperties),
+          );
+        });
+      });
+    });
+
     describe('having a GameUpdateQuery with status', () => {
       let gameUpdateQueryFixture: GameUpdateQuery;
 

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSetQueryTypeOrmFromGameUpdateQueryBuilder.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSetQueryTypeOrmFromGameUpdateQueryBuilder.ts
@@ -128,6 +128,10 @@ export class GameSetQueryTypeOrmFromGameUpdateQueryBuilder
       gameSetQueryTypeOrm.turn = gameUpdateQuery.turn;
     }
 
+    if (gameUpdateQuery.skipCount !== undefined) {
+      gameSetQueryTypeOrm.skipCount = gameUpdateQuery.skipCount;
+    }
+
     return gameSetQueryTypeOrm;
   }
 }

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/fixtures/GameDbFixtures.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/fixtures/GameDbFixtures.ts
@@ -83,6 +83,7 @@ export class GameDbFixtures {
     fixture.gameSlotsDb = [GameSlotDbFixtures.activeWithOneCard];
     fixture.gameSpecDb = GameSpecDbFixtures.any;
     fixture.id = '6fbcdb6c-b03c-4754-94c1-9f664f036cde';
+    fixture.skipCount = 0;
     fixture.status = GameStatusDb.active;
     fixture.turn = 1;
 

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/models/GameDb.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/models/GameDb.ts
@@ -117,6 +117,14 @@ export class GameDb {
   public readonly name!: string | null;
 
   @Column({
+    name: 'skip_count',
+    nullable: true,
+    type: 'smallint',
+    width: 4,
+  })
+  public readonly skipCount!: number | null;
+
+  @Column({
     name: 'status',
     type: 'smallint',
     width: 2,

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/ActiveGameFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/ActiveGameFixtures.ts
@@ -26,6 +26,7 @@ export class ActiveGameFixtures {
         deck: [],
         discardPile: [],
         drawCount: 0,
+        skipCount: 0,
         slots: [ActiveGameSlotFixtures.withPositionZero],
         status: GameStatus.active,
         turn: 1,

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameUpdateQueryFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameUpdateQueryFixtures.ts
@@ -105,6 +105,15 @@ export class GameUpdateQueryFixtures {
     };
   }
 
+  public static get withSkipCount(): GameUpdateQuery {
+    const fixture: GameUpdateQuery = {
+      ...GameUpdateQueryFixtures.any,
+      skipCount: 0,
+    };
+
+    return fixture;
+  }
+
   public static get withStatusActive(): GameUpdateQuery {
     const fixture: GameUpdateQuery = {
       ...GameUpdateQueryFixtures.any,

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/query/GameUpdateQuery.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/query/GameUpdateQuery.ts
@@ -18,6 +18,7 @@ export interface GameUpdateQuery {
   discardPile?: GameCardSpec[];
   drawCount?: number;
   gameSlotUpdateQueries?: GameSlotUpdateQuery[];
+  skipCount?: number;
   status?: GameStatus;
   turn?: number;
 }

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/services/GameService.spec.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/services/GameService.spec.ts
@@ -746,6 +746,7 @@ describe(GameService.name, () => {
                 },
               },
             ],
+            skipCount: 0,
             status: GameStatus.active,
             turn: 1,
           };

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/services/GameService.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/services/GameService.ts
@@ -166,6 +166,7 @@ export class GameService {
         id: game.id,
       },
       gameSlotUpdateQueries,
+      skipCount: 0,
       status: GameStatus.active,
       turn: UNO_ORIGINAL_FIRST_TURN,
     };

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/valueObjects/ActiveGameState.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/valueObjects/ActiveGameState.ts
@@ -14,6 +14,7 @@ export interface ActiveGameState {
   readonly deck: GameCardSpec[];
   readonly discardPile: GameCardSpec[];
   readonly drawCount: number;
+  readonly skipCount: number;
   readonly slots: ActiveGameSlot[];
   readonly status: GameStatus.active;
   readonly turn: number;

--- a/packages/backend/tools/backend-test-e2e/src/game/utils/actions/setActiveGameCards.ts
+++ b/packages/backend/tools/backend-test-e2e/src/game/utils/actions/setActiveGameCards.ts
@@ -48,6 +48,7 @@ export async function setActiveGameCards(
         },
       }),
     ),
+    skipCount: 0,
   };
 
   const colorProperty: keyof ColoredCard = 'color';


### PR DESCRIPTION
### Added
- Added `GameDb` migration.

### Changed
- Updated `ActiveGameState` with `skipCount`.
- Updated `GameDb` with `skipCount`.

### Additional context
This allow us to fix in further PR #1011.