### PR TITLE
Update game with draw flag

### DIFF
--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/app/adapter/typeorm/migrations/1709670322300-UpdateGameWithCardsDrawnFlag.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/app/adapter/typeorm/migrations/1709670322300-UpdateGameWithCardsDrawnFlag.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateGameWithCardsDrawnFlag1709670322300
+  implements MigrationInterface
+{
+  public readonly name: string = 'UpdateGameWithCardsDrawnFlag1709670322300';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "Game" ADD "current_turn_cards_drawn" smallint`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "Game" ADD "current_card_single_card_draw" bit(16)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "Game" DROP COLUMN "current_card_single_card_draw"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "Game" DROP COLUMN "current_turn_cards_drawn"`,
+    );
+  }
+}

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameFromGameDbBuilder.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameFromGameDbBuilder.spec.ts
@@ -251,13 +251,14 @@ describe(GameFromGameDbBuilder.name, () => {
     });
   });
 
-  describe('having a started GameDb', () => {
+  describe('having a started GameDb with null currentTurnSingleCardDraw', () => {
     let gameCardSpecArrayFixture: GameCardSpec[];
     let gameDbFixture: GameDb;
 
     beforeAll(() => {
       gameCardSpecArrayFixture = [GameCardSpecFixtures.any];
-      gameDbFixture = GameDbFixtures.withStatusActiveAndGameSlotsOne;
+      gameDbFixture =
+        GameDbFixtures.withStatusActiveAndGameSlotsOneAndCurrentTurnSingleCardDrawNull;
     });
 
     describe('when called', () => {
@@ -342,8 +343,123 @@ describe(GameFromGameDbBuilder.name, () => {
             currentDirection: gameDirectionFixture,
             currentPlayingSlotIndex:
               gameDbFixture.currentPlayingSlotIndex as number,
+            currentTurnCardsDrawn:
+              gameDbFixture.currentTurnCardsDrawn as boolean,
             currentTurnCardsPlayed:
               gameDbFixture.currentTurnCardsPlayed as boolean,
+            currentTurnSingleCardDraw: undefined,
+            deck: gameCardSpecArrayFixture,
+            discardPile: gameCardSpecArrayFixture,
+            drawCount: gameDbFixture.drawCount as number,
+            skipCount: gameDbFixture.skipCount as number,
+            slots: [gameSlotFixture],
+            status: GameStatus.active,
+            turn: gameDbFixture.turn as number,
+          },
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having a started GameDb with currentTurnSingleCardDraw', () => {
+    let gameCardSpecArrayFixture: GameCardSpec[];
+    let gameDbFixture: GameDb;
+
+    beforeAll(() => {
+      gameCardSpecArrayFixture = [GameCardSpecFixtures.any];
+      gameDbFixture =
+        GameDbFixtures.withStatusActiveAndGameSlotsOneAndCurrentTurnSingleCardDraw;
+    });
+
+    describe('when called', () => {
+      let cardColorFixture: CardColor;
+      let cardFixture: Card;
+      let gameDirectionFixture: GameDirection;
+      let gameSlotFixture: ActiveGameSlot;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        cardColorFixture = CardColor.blue;
+        cardFixture = CardFixtures.any;
+        gameDirectionFixture = GameDirection.clockwise;
+        gameSlotFixture = ActiveGameSlotFixtures.withPositionZero;
+
+        cardBuilderMock.build.mockReturnValue(cardFixture);
+        cardColorBuilderMock.build.mockReturnValue(cardColorFixture);
+        gameCardSpecArrayFromGameCardSpecArrayDbBuilderMock.build
+          .mockReturnValueOnce(gameCardSpecArrayFixture)
+          .mockReturnValueOnce(gameCardSpecArrayFixture);
+        gameDirectionFromGameDirectionDbBuilderMock.build.mockReturnValueOnce(
+          gameDirectionFixture,
+        );
+        gameSlotFromGameSlotDbBuilderMock.build.mockReturnValue(
+          gameSlotFixture,
+        );
+
+        result = gameFromGameDbBuilder.build(gameDbFixture);
+      });
+
+      afterAll(() => {
+        cardBuilderMock.build.mockReset();
+        cardColorBuilderMock.build.mockReset();
+        gameSlotFromGameSlotDbBuilderMock.build.mockReset();
+
+        jest.clearAllMocks();
+      });
+
+      it('should call gameSlotFromGameSlotDbBuilderMock.build()', () => {
+        expect(gameSlotFromGameSlotDbBuilderMock.build).toHaveBeenCalledTimes(
+          gameDbFixture.gameSlotsDb.length,
+        );
+
+        for (const [i, gameSlotDb] of gameDbFixture.gameSlotsDb.entries()) {
+          expect(
+            gameSlotFromGameSlotDbBuilderMock.build,
+          ).toHaveBeenNthCalledWith(i + 1, gameSlotDb);
+        }
+      });
+
+      it('should call cardBuilder.build()', () => {
+        expect(cardBuilderMock.build).toHaveBeenCalled();
+      });
+
+      it('should call cardColorBuilder.build()', () => {
+        expect(cardColorBuilderMock.build).toHaveBeenCalledTimes(1);
+        expect(cardColorBuilderMock.build).toHaveBeenCalledWith(
+          gameDbFixture.currentColor,
+        );
+      });
+
+      it('should call gameCardSpecArrayFromGameCardSpecArrayDbBuilder.build()', () => {
+        expect(
+          gameCardSpecArrayFromGameCardSpecArrayDbBuilderMock.build,
+        ).toHaveBeenCalledTimes(2);
+        expect(
+          gameCardSpecArrayFromGameCardSpecArrayDbBuilderMock.build,
+        ).toHaveBeenNthCalledWith(1, gameDbFixture.deck);
+        expect(
+          gameCardSpecArrayFromGameCardSpecArrayDbBuilderMock.build,
+        ).toHaveBeenNthCalledWith(2, gameDbFixture.discardPile);
+      });
+
+      it('should return an ActiveGame', () => {
+        const expected: ActiveGame = {
+          id: gameDbFixture.id,
+          name: gameDbFixture.name,
+          state: {
+            currentCard: cardFixture,
+            currentColor: cardColorFixture,
+            currentDirection: gameDirectionFixture,
+            currentPlayingSlotIndex:
+              gameDbFixture.currentPlayingSlotIndex as number,
+            currentTurnCardsDrawn:
+              gameDbFixture.currentTurnCardsDrawn as boolean,
+            currentTurnCardsPlayed:
+              gameDbFixture.currentTurnCardsPlayed as boolean,
+            currentTurnSingleCardDraw: cardFixture,
             deck: gameCardSpecArrayFixture,
             discardPile: gameCardSpecArrayFixture,
             drawCount: gameDbFixture.drawCount as number,

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameFromGameDbBuilder.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameFromGameDbBuilder.ts
@@ -118,6 +118,7 @@ export class GameFromGameDbBuilder implements Builder<Game, [GameDb]> {
       gameDb.currentColor === null ||
       gameDb.currentDirection === null ||
       gameDb.currentPlayingSlotIndex === null ||
+      gameDb.currentTurnCardsDrawn === null ||
       gameDb.currentTurnCardsPlayed === null ||
       gameDb.deck === null ||
       gameDb.drawCount === null ||
@@ -137,7 +138,12 @@ export class GameFromGameDbBuilder implements Builder<Game, [GameDb]> {
           gameDb.currentDirection,
         ),
         currentPlayingSlotIndex: gameDb.currentPlayingSlotIndex,
+        currentTurnCardsDrawn: gameDb.currentTurnCardsDrawn,
         currentTurnCardsPlayed: gameDb.currentTurnCardsPlayed,
+        currentTurnSingleCardDraw:
+          gameDb.currentTurnSingleCardDraw === null
+            ? undefined
+            : this.#cardBuilder.build(gameDb.currentTurnSingleCardDraw),
         deck: this.#gameCardSpecArrayFromGameCardSpecArrayDbBuilder.build(
           gameDb.deck,
         ),

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSetQueryTypeOrmFromGameUpdateQueryBuilder.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSetQueryTypeOrmFromGameUpdateQueryBuilder.spec.ts
@@ -185,6 +185,40 @@ describe(GameSetQueryTypeOrmFromGameUpdateQueryBuilder.name, () => {
       });
     });
 
+    describe('having a GameUpdateQuery with currentTurnCardsDrawn', () => {
+      let gameUpdateQueryFixture: GameUpdateQuery;
+
+      beforeAll(() => {
+        gameUpdateQueryFixture =
+          GameUpdateQueryFixtures.withCurrentTurnCardsDrawn;
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = gameSetQueryTypeOrmFromGameUpdateQueryBuilder.build(
+            gameUpdateQueryFixture,
+          );
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should return a QueryDeepPartialEntity<GameDb>', () => {
+          const expectedProperties: Partial<QueryDeepPartialEntity<GameDb>> = {
+            currentTurnCardsDrawn:
+              gameUpdateQueryFixture.currentTurnCardsDrawn as boolean,
+          };
+
+          expect(result).toStrictEqual(
+            expect.objectContaining(expectedProperties),
+          );
+        });
+      });
+    });
+
     describe('having a GameUpdateQuery with currentTurnCardsPlayed', () => {
       let gameUpdateQueryFixture: GameUpdateQuery;
 
@@ -210,6 +244,89 @@ describe(GameSetQueryTypeOrmFromGameUpdateQueryBuilder.name, () => {
           const expectedProperties: Partial<QueryDeepPartialEntity<GameDb>> = {
             currentTurnCardsPlayed:
               gameUpdateQueryFixture.currentTurnCardsPlayed as boolean,
+          };
+
+          expect(result).toStrictEqual(
+            expect.objectContaining(expectedProperties),
+          );
+        });
+      });
+    });
+
+    describe('having a GameUpdateQuery with currentTurnSingleCardDraw', () => {
+      let gameUpdateQueryFixture: GameUpdateQuery;
+
+      beforeAll(() => {
+        gameUpdateQueryFixture =
+          GameUpdateQueryFixtures.currentTurnSingleCardDraw;
+      });
+
+      describe('when called', () => {
+        let cardDbFixture: CardDb;
+
+        let result: unknown;
+
+        beforeAll(() => {
+          cardDbFixture = 0x0039;
+
+          cardDbBuilderMock.build.mockReturnValueOnce(cardDbFixture);
+
+          result = gameSetQueryTypeOrmFromGameUpdateQueryBuilder.build(
+            gameUpdateQueryFixture,
+          );
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call cardDbBuilder.build()', () => {
+          expect(cardDbBuilderMock.build).toHaveBeenCalledTimes(1);
+          expect(cardDbBuilderMock.build).toHaveBeenCalledWith(
+            gameUpdateQueryFixture.currentTurnSingleCardDraw,
+          );
+        });
+
+        it('should return a QueryDeepPartialEntity<GameDb>', () => {
+          const expectedProperties: Partial<QueryDeepPartialEntity<GameDb>> = {
+            currentTurnSingleCardDraw: cardDbFixture,
+          };
+
+          expect(result).toStrictEqual(
+            expect.objectContaining(expectedProperties),
+          );
+        });
+      });
+    });
+
+    describe('having a GameUpdateQuery with currentTurnSingleCardDraw null', () => {
+      let gameUpdateQueryFixture: GameUpdateQuery;
+
+      beforeAll(() => {
+        gameUpdateQueryFixture =
+          GameUpdateQueryFixtures.currentTurnSingleCardDrawNull;
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = gameSetQueryTypeOrmFromGameUpdateQueryBuilder.build(
+            gameUpdateQueryFixture,
+          );
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should not call cardDbBuilder.build()', () => {
+          expect(cardDbBuilderMock.build).not.toHaveBeenCalled();
+        });
+
+        it('should return a QueryDeepPartialEntity<GameDb>', () => {
+          const expectedProperties: Partial<QueryDeepPartialEntity<GameDb>> = {
+            currentTurnSingleCardDraw: null,
           };
 
           expect(result).toStrictEqual(

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSetQueryTypeOrmFromGameUpdateQueryBuilder.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/builders/GameSetQueryTypeOrmFromGameUpdateQueryBuilder.ts
@@ -101,6 +101,20 @@ export class GameSetQueryTypeOrmFromGameUpdateQueryBuilder
         gameUpdateQuery.currentPlayingSlotIndex;
     }
 
+    if (gameUpdateQuery.currentTurnCardsDrawn !== undefined) {
+      gameSetQueryTypeOrm.currentTurnCardsDrawn =
+        gameUpdateQuery.currentTurnCardsDrawn;
+    }
+
+    if (gameUpdateQuery.currentTurnSingleCardDraw !== undefined) {
+      gameSetQueryTypeOrm.currentTurnSingleCardDraw =
+        gameUpdateQuery.currentTurnSingleCardDraw === null
+          ? null
+          : this.#cardDbBuilder.build(
+              gameUpdateQuery.currentTurnSingleCardDraw,
+            );
+    }
+
     if (gameUpdateQuery.currentTurnCardsPlayed !== undefined) {
       gameSetQueryTypeOrm.currentTurnCardsPlayed =
         gameUpdateQuery.currentTurnCardsPlayed;

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/fixtures/GameDbFixtures.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/fixtures/GameDbFixtures.ts
@@ -76,7 +76,9 @@ export class GameDbFixtures {
     fixture.currentColor = 32;
     fixture.currentDirection = GameDirectionDb.clockwise;
     fixture.currentPlayingSlotIndex = 0;
+    fixture.currentTurnCardsDrawn = false;
     fixture.currentTurnCardsPlayed = false;
+    fixture.currentTurnSingleCardDraw = null;
     fixture.deck = '[{ "amount": 1, "card": 39 }]';
     fixture.discardPile = '[]';
     fixture.drawCount = 0;
@@ -86,6 +88,24 @@ export class GameDbFixtures {
     fixture.skipCount = 0;
     fixture.status = GameStatusDb.active;
     fixture.turn = 1;
+
+    return fixture;
+  }
+
+  public static get withStatusActiveAndGameSlotsOneAndCurrentTurnSingleCardDraw(): GameDb {
+    const fixture: Writable<GameDb> =
+      GameDbFixtures.withStatusActiveAndGameSlotsOne;
+
+    fixture.currentTurnSingleCardDraw = 39;
+
+    return fixture;
+  }
+
+  public static get withStatusActiveAndGameSlotsOneAndCurrentTurnSingleCardDrawNull(): GameDb {
+    const fixture: Writable<GameDb> =
+      GameDbFixtures.withStatusActiveAndGameSlotsOne;
+
+    fixture.currentTurnSingleCardDraw = null;
 
     return fixture;
   }

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/models/GameDb.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/games/adapter/typeorm/models/GameDb.ts
@@ -47,6 +47,15 @@ export class GameDb {
   public readonly currentPlayingSlotIndex!: number | null;
 
   @Column({
+    name: 'current_turn_cards_drawn',
+    nullable: true,
+    transformer: new NumberToBooleanTransformer(),
+    type: 'smallint',
+    width: 1,
+  })
+  public readonly currentTurnCardsDrawn!: boolean | null;
+
+  @Column({
     name: 'current_turn_cards_played',
     nullable: true,
     transformer: new NumberToBooleanTransformer(),
@@ -54,6 +63,16 @@ export class GameDb {
     width: 1,
   })
   public readonly currentTurnCardsPlayed!: boolean | null;
+
+  @Column({
+    length: 16,
+    name: 'current_card_single_card_draw',
+    nullable: true,
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+    transformer: new BinaryToNumberTransformer(16),
+    type: 'bit',
+  })
+  public readonly currentTurnSingleCardDraw!: number | null;
 
   @Column({
     name: 'deck',

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/ActiveGameFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/ActiveGameFixtures.ts
@@ -22,7 +22,9 @@ export class ActiveGameFixtures {
         currentColor: CardColor.blue,
         currentDirection: GameDirection.antiClockwise,
         currentPlayingSlotIndex: 0,
+        currentTurnCardsDrawn: false,
         currentTurnCardsPlayed: false,
+        currentTurnSingleCardDraw: undefined,
         deck: [],
         discardPile: [],
         drawCount: 0,
@@ -30,6 +32,30 @@ export class ActiveGameFixtures {
         slots: [ActiveGameSlotFixtures.withPositionZero],
         status: GameStatus.active,
         turn: 1,
+      },
+    };
+  }
+
+  public static get withCurrentTurnCardsPlayedFalse(): ActiveGame {
+    const anyFixture: ActiveGame = ActiveGameFixtures.any;
+
+    return {
+      ...anyFixture,
+      state: {
+        ...anyFixture.state,
+        currentTurnCardsPlayed: false,
+      },
+    };
+  }
+
+  public static get withCurrentTurnCardsPlayedTrue(): ActiveGame {
+    const anyFixture: ActiveGame = ActiveGameFixtures.any;
+
+    return {
+      ...anyFixture,
+      state: {
+        ...anyFixture.state,
+        currentTurnCardsPlayed: true,
       },
     };
   }

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameUpdateQueryFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameUpdateQueryFixtures.ts
@@ -34,10 +34,37 @@ export class GameUpdateQueryFixtures {
     return fixture;
   }
 
+  public static get withCurrentTurnCardsDrawn(): GameUpdateQuery {
+    const fixture: GameUpdateQuery = {
+      ...GameUpdateQueryFixtures.any,
+      currentTurnCardsDrawn: true,
+    };
+
+    return fixture;
+  }
+
   public static get withCurrentTurnCardsPlayed(): GameUpdateQuery {
     const fixture: GameUpdateQuery = {
       ...GameUpdateQueryFixtures.any,
       currentTurnCardsPlayed: true,
+    };
+
+    return fixture;
+  }
+
+  public static get currentTurnSingleCardDraw(): GameUpdateQuery {
+    const fixture: GameUpdateQuery = {
+      ...GameUpdateQueryFixtures.any,
+      currentTurnSingleCardDraw: CardFixtures.any,
+    };
+
+    return fixture;
+  }
+
+  public static get currentTurnSingleCardDrawNull(): GameUpdateQuery {
+    const fixture: GameUpdateQuery = {
+      ...GameUpdateQueryFixtures.any,
+      currentTurnSingleCardDraw: null,
     };
 
     return fixture;

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/query/GameUpdateQuery.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/query/GameUpdateQuery.ts
@@ -13,6 +13,8 @@ export interface GameUpdateQuery {
   currentColor?: CardColor;
   currentDirection?: GameDirection;
   currentPlayingSlotIndex?: number;
+  currentTurnCardsDrawn?: boolean | null;
+  currentTurnSingleCardDraw?: Card | null;
   currentTurnCardsPlayed?: boolean | null;
   deck?: GameCardSpec[];
   discardPile?: GameCardSpec[];

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/valueObjects/ActiveGameState.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/valueObjects/ActiveGameState.ts
@@ -10,7 +10,9 @@ export interface ActiveGameState {
   readonly currentColor: CardColor;
   readonly currentDirection: GameDirection;
   readonly currentPlayingSlotIndex: number;
+  readonly currentTurnCardsDrawn: boolean;
   readonly currentTurnCardsPlayed: boolean;
+  readonly currentTurnSingleCardDraw: Card | undefined;
   readonly deck: GameCardSpec[];
   readonly discardPile: GameCardSpec[];
   readonly drawCount: number;


### PR DESCRIPTION
### Changed
- Updated `GameDb` with `currentTurnCardsDrawn` and `currentTurnSingleCardDraw`.
- Updated `ActiveGameState` with `currentTurnCardsDrawn` and `currentTurnSingleCardDraw`.
- Updated `GameUpdateQuery` with `currentTurnCardsDrawn` and `currentTurnSingleCardDraw`.