### PR TITLE
Fix GamePassTurnUpdateQueryFromGameBuilder

### DIFF
--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/builders/GamePassTurnUpdateQueryFromGameBuilder.spec.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/builders/GamePassTurnUpdateQueryFromGameBuilder.spec.ts
@@ -33,16 +33,15 @@ describe(GamePassTurnUpdateQueryFromGameBuilder.name, () => {
 
       beforeAll(() => {
         activeGameFixture = {
-          ...ActiveGameFixtures.withSlotsTwoAndCurrentPlayingSlotZero,
+          ...ActiveGameFixtures.withSlotsThreeAndCurrentPlayingSlotZero,
           state: {
-            ...ActiveGameFixtures.withSlotsTwoAndCurrentPlayingSlotZero.state,
+            ...ActiveGameFixtures.withSlotsThreeAndCurrentPlayingSlotZero.state,
             currentDirection: GameDirection.antiClockwise,
-            currentPlayingSlotIndex: 0,
             skipCount: 0,
           },
         };
 
-        gameSpecFixtures = GameSpecFixtures.withGameSlotsAmountTwo;
+        gameSpecFixtures = GameSpecFixtures.withGameSlotsAmountThree;
       });
 
       describe('when called, and isGameFinishedSpec.isSatisfiedBy() returns false', () => {
@@ -141,16 +140,15 @@ describe(GamePassTurnUpdateQueryFromGameBuilder.name, () => {
 
       beforeAll(() => {
         activeGameFixture = {
-          ...ActiveGameFixtures.withSlotsTwoAndCurrentPlayingSlotZero,
+          ...ActiveGameFixtures.withSlotsThreeAndCurrentPlayingSlotZero,
           state: {
-            ...ActiveGameFixtures.withSlotsTwoAndCurrentPlayingSlotZero.state,
+            ...ActiveGameFixtures.withSlotsThreeAndCurrentPlayingSlotZero.state,
             currentDirection: GameDirection.antiClockwise,
-            currentPlayingSlotIndex: 0,
             skipCount: 1,
           },
         };
 
-        gameSpecFixtures = GameSpecFixtures.withGameSlotsAmountTwo;
+        gameSpecFixtures = GameSpecFixtures.withGameSlotsAmountThree;
       });
 
       describe('when called, and isGameFinishedSpec.isSatisfiedBy() returns false', () => {
@@ -249,16 +247,15 @@ describe(GamePassTurnUpdateQueryFromGameBuilder.name, () => {
 
       beforeAll(() => {
         activeGameFixture = {
-          ...ActiveGameFixtures.withSlotsTwoAndCurrentPlayingSlotZero,
+          ...ActiveGameFixtures.withSlotsThreeAndCurrentPlayingSlotZero,
           state: {
-            ...ActiveGameFixtures.withSlotsTwoAndCurrentPlayingSlotZero.state,
+            ...ActiveGameFixtures.withSlotsThreeAndCurrentPlayingSlotZero.state,
             currentDirection: GameDirection.clockwise,
-            currentPlayingSlotIndex: 0,
             skipCount: 0,
           },
         };
 
-        gameSpecFixtures = GameSpecFixtures.withGameSlotsAmountTwo;
+        gameSpecFixtures = GameSpecFixtures.withGameSlotsAmountThree;
       });
 
       describe('when called, and isGameFinishedSpec.isSatisfiedBy() returns false', () => {
@@ -357,16 +354,15 @@ describe(GamePassTurnUpdateQueryFromGameBuilder.name, () => {
 
       beforeAll(() => {
         activeGameFixture = {
-          ...ActiveGameFixtures.withSlotsTwoAndCurrentPlayingSlotZero,
+          ...ActiveGameFixtures.withSlotsThreeAndCurrentPlayingSlotZero,
           state: {
-            ...ActiveGameFixtures.withSlotsTwoAndCurrentPlayingSlotZero.state,
+            ...ActiveGameFixtures.withSlotsThreeAndCurrentPlayingSlotZero.state,
             currentDirection: GameDirection.clockwise,
-            currentPlayingSlotIndex: 0,
             skipCount: 1,
           },
         };
 
-        gameSpecFixtures = GameSpecFixtures.withGameSlotsAmountTwo;
+        gameSpecFixtures = GameSpecFixtures.withGameSlotsAmountThree;
       });
 
       describe('when called, and isGameFinishedSpec.isSatisfiedBy() returns false', () => {

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/builders/GamePassTurnUpdateQueryFromGameBuilder.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/builders/GamePassTurnUpdateQueryFromGameBuilder.ts
@@ -46,7 +46,6 @@ export class GamePassTurnUpdateQueryFromGameBuilder
 
   #getNextTurnPlayerIndex(game: ActiveGame, gameSpec: GameSpec): number {
     const players: number = gameSpec.gameSlotsAmount;
-    const modulus: number = players + 1;
     const direction: GameDirection = game.state.currentDirection;
 
     let nextTurnPlayerIndex: number;
@@ -56,12 +55,12 @@ export class GamePassTurnUpdateQueryFromGameBuilder
         game.state.currentPlayingSlotIndex - (1 + game.state.skipCount);
 
       if (nextTurnPlayerIndex < 0) {
-        nextTurnPlayerIndex = (nextTurnPlayerIndex % modulus) + modulus;
+        nextTurnPlayerIndex = (nextTurnPlayerIndex % players) + players;
       }
     } else {
       nextTurnPlayerIndex =
         (game.state.currentPlayingSlotIndex + (1 + game.state.skipCount)) %
-        modulus;
+        players;
     }
 
     return nextTurnPlayerIndex;

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/ActiveGameFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/ActiveGameFixtures.ts
@@ -216,4 +216,21 @@ export class ActiveGameFixtures {
       },
     };
   }
+
+  public static get withSlotsThreeAndCurrentPlayingSlotZero(): ActiveGame {
+    const anyActiveGameFixture: ActiveGame = ActiveGameFixtures.any;
+
+    return {
+      ...anyActiveGameFixture,
+      state: {
+        ...anyActiveGameFixture.state,
+        currentPlayingSlotIndex: 0,
+        slots: [
+          ActiveGameSlotFixtures.withPositionZero,
+          ActiveGameSlotFixtures.withPositionOne,
+          ActiveGameSlotFixtures.withPositionTwo,
+        ],
+      },
+    };
+  }
 }

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/ActiveGameSlotFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/ActiveGameSlotFixtures.ts
@@ -31,6 +31,13 @@ export class ActiveGameSlotFixtures {
     };
   }
 
+  public static get withPositionTwo(): ActiveGameSlot {
+    return {
+      ...ActiveGameSlotFixtures.any,
+      position: 2,
+    };
+  }
+
   public static get withPositionZero(): ActiveGameSlot {
     return {
       ...ActiveGameSlotFixtures.any,

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameSpecFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameSpecFixtures.ts
@@ -26,6 +26,13 @@ export class GameSpecFixtures {
     };
   }
 
+  public static get withGameSlotsAmountThree(): GameSpec {
+    return {
+      ...GameSpecFixtures.any,
+      gameSlotsAmount: 3,
+    };
+  }
+
   public static get withGameSlotsAmountTwo(): GameSpec {
     return {
       ...GameSpecFixtures.any,

--- a/turbo.json
+++ b/turbo.json
@@ -6,9 +6,7 @@
       "inputs": ["src/**/*.{cts,mts,ts}"],
       "outputs": [
         "dist/**",
-        "!dist/**/.spec.js",
-        "lib/**",
-        "!lib/**/.spec.js"
+        "lib/**"
       ]
     },
     "@cornie-js/api-graphql-schemas#build": {


### PR DESCRIPTION
### Changed
- Updated `GamePassTurnUpdateQueryFromGameBuilder` to properly set `currentPlayingSlotIndex`.