### PR TITLE
Update start game flow to never start game with wild draw 4 current card

### DIFF
--- a/packages/backend/apps/game/backend-game-domain/src/cards/adapter/nest/CardDomainModule.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/cards/adapter/nest/CardDomainModule.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 
 import { AreCardsEqualsSpec } from '../../domain/specs/AreCardsEqualsSpec';
+import { IsValidInitialCardSpec } from '../../domain/specs/IsValidInitialCardSpec';
 
 @Module({
-  exports: [AreCardsEqualsSpec],
-  providers: [AreCardsEqualsSpec],
+  exports: [AreCardsEqualsSpec, IsValidInitialCardSpec],
+  providers: [AreCardsEqualsSpec, IsValidInitialCardSpec],
 })
 export class CardDomainModule {}

--- a/packages/backend/apps/game/backend-game-domain/src/cards/domain/specs/IsValidInitialCardSpec.spec.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/cards/domain/specs/IsValidInitialCardSpec.spec.ts
@@ -1,0 +1,30 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { CardFixtures } from '../fixtures';
+import { Card } from '../valueObjects/Card';
+import { IsValidInitialCardSpec } from './IsValidInitialCardSpec';
+
+describe(IsValidInitialCardSpec.name, () => {
+  let isValidInitialCardSpec: IsValidInitialCardSpec;
+
+  beforeAll(() => {
+    isValidInitialCardSpec = new IsValidInitialCardSpec();
+  });
+
+  describe.each<[string, Card, boolean]>([
+    ['a wild draw 4 card', CardFixtures.wildDraw4Card, false],
+    ['a non wild draw 4 card', CardFixtures.normalBlueSevenCard, true],
+  ])('having %s', (_: string, cardFixture: Card, expectedResult: boolean) => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = isValidInitialCardSpec.isSatisfiedBy(cardFixture);
+      });
+
+      it('should return boolean', () => {
+        expect(result).toBe(expectedResult);
+      });
+    });
+  });
+});

--- a/packages/backend/apps/game/backend-game-domain/src/cards/domain/specs/IsValidInitialCardSpec.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/cards/domain/specs/IsValidInitialCardSpec.ts
@@ -1,0 +1,12 @@
+import { Spec } from '@cornie-js/backend-common';
+import { Injectable } from '@nestjs/common';
+
+import { Card } from '../valueObjects/Card';
+import { CardKind } from '../valueObjects/CardKind';
+
+@Injectable()
+export class IsValidInitialCardSpec implements Spec<[Card]> {
+  public isSatisfiedBy(card: Card): boolean {
+    return card.kind !== CardKind.wildDraw4;
+  }
+}

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/builders/StartGameUpdateQueryFromGameBuilder.spec.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/builders/StartGameUpdateQueryFromGameBuilder.spec.ts
@@ -1,8 +1,10 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
+import { IsValidInitialCardSpec } from '../../../cards/domain/specs/IsValidInitialCardSpec';
 import { Card } from '../../../cards/domain/valueObjects/Card';
 import { CardColor } from '../../../cards/domain/valueObjects/CardColor';
 import { NonStartedGame } from '../entities/NonStartedGame';
+import { GameDrawMutationFixtures } from '../fixtures/GameDrawMutationFixtures';
 import { GameInitialDrawsMutationFixtures } from '../fixtures/GameInitialDrawsMutationFixtures';
 import { GameSpecFixtures } from '../fixtures/GameSpecFixtures';
 import { NonStartedGameFixtures } from '../fixtures/NonStartedGameFixtures';
@@ -10,6 +12,7 @@ import { GameUpdateQuery } from '../query/GameUpdateQuery';
 import { GameDrawService } from '../services/GameDrawService';
 import { GameService } from '../services/GameService';
 import { GameDirection } from '../valueObjects/GameDirection';
+import { GameDrawMutation } from '../valueObjects/GameDrawMutation';
 import { GameInitialDrawsMutation } from '../valueObjects/GameInitialDrawsMutation';
 import { GameSpec } from '../valueObjects/GameSpec';
 import { GameStatus } from '../valueObjects/GameStatus';
@@ -18,12 +21,15 @@ import { StartGameUpdateQueryFromGameBuilder } from './StartGameUpdateQueryFromG
 describe(StartGameUpdateQueryFromGameBuilder.name, () => {
   let gameDrawServiceMock: jest.Mocked<GameDrawService>;
   let gameServiceMock: jest.Mocked<GameService>;
+  let isValidInitialCardSpecMock: jest.Mocked<IsValidInitialCardSpec>;
 
   let startGameUpdateQueryFromGameBuilder: StartGameUpdateQueryFromGameBuilder;
 
   beforeAll(() => {
     gameDrawServiceMock = {
+      calculateDrawMutation: jest.fn(),
       calculateInitialCardsDrawMutation: jest.fn(),
+      putCards: jest.fn(),
     } as Partial<jest.Mocked<GameDrawService>> as jest.Mocked<GameDrawService>;
 
     gameServiceMock = {
@@ -33,15 +39,20 @@ describe(StartGameUpdateQueryFromGameBuilder.name, () => {
       getInitialTurn: jest.fn(),
     } as Partial<jest.Mocked<GameService>> as jest.Mocked<GameService>;
 
+    isValidInitialCardSpecMock = {
+      isSatisfiedBy: jest.fn(),
+    };
+
     startGameUpdateQueryFromGameBuilder =
       new StartGameUpdateQueryFromGameBuilder(
         gameDrawServiceMock,
         gameServiceMock,
+        isValidInitialCardSpecMock,
       );
   });
 
   describe('.build', () => {
-    describe('when called', () => {
+    describe('when called, and isValidInitialCardSpec.isSatisfiedBy() returns true', () => {
       let gameFixture: NonStartedGame;
       let gameSpecFixture: GameSpec;
       let gameInitialDrawsMutationFixture: GameInitialDrawsMutation;
@@ -65,6 +76,7 @@ describe(StartGameUpdateQueryFromGameBuilder.name, () => {
         gameDrawServiceMock.calculateInitialCardsDrawMutation.mockReturnValueOnce(
           gameInitialDrawsMutationFixture,
         );
+        isValidInitialCardSpecMock.isSatisfiedBy.mockReturnValueOnce(true);
         gameServiceMock.getInitialCardColor.mockReturnValueOnce(
           initialColorFixture,
         );
@@ -93,6 +105,15 @@ describe(StartGameUpdateQueryFromGameBuilder.name, () => {
         expect(
           gameDrawServiceMock.calculateInitialCardsDrawMutation,
         ).toHaveBeenCalledWith(gameSpecFixture);
+      });
+
+      it('should call isValidInitialCardSpec.isSatisfiedBy()', () => {
+        expect(isValidInitialCardSpecMock.isSatisfiedBy).toHaveBeenCalledTimes(
+          1,
+        );
+        expect(isValidInitialCardSpecMock.isSatisfiedBy).toHaveBeenCalledWith(
+          gameInitialDrawsMutationFixture.currentCard,
+        );
       });
 
       it('should call gameService.getInitialCardColor()', () => {
@@ -130,6 +151,161 @@ describe(StartGameUpdateQueryFromGameBuilder.name, () => {
           currentTurnCardsDrawn: false,
           currentTurnCardsPlayed: false,
           deck: gameInitialDrawsMutationFixture.deck,
+          discardPile: [],
+          drawCount: 0,
+          gameFindQuery: {
+            id: gameFixture.id,
+          },
+          gameSlotUpdateQueries: [
+            {
+              cards: gameInitialDrawsMutationFixture.cards[0] as Card[],
+              gameSlotFindQuery: {
+                gameId: gameFixture.id,
+                position: 0,
+              },
+            },
+          ],
+          skipCount: 0,
+          status: GameStatus.active,
+          turn: initialTurnFixture,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+
+    describe('when called, and isValidInitialCardSpec.isSatisfiedBy() returns false and, later, true', () => {
+      let gameFixture: NonStartedGame;
+      let gameSpecFixture: GameSpec;
+      let gameInitialDrawsMutationFixture: GameInitialDrawsMutation;
+      let gameDrawMutationFixture: GameDrawMutation;
+      let initialColorFixture: CardColor;
+      let initialDirectionFixture: GameDirection;
+      let initialPlayingSlotIndexFixture: number;
+      let initialTurnFixture: number;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        gameFixture = NonStartedGameFixtures.any;
+        gameSpecFixture = GameSpecFixtures.any;
+        gameInitialDrawsMutationFixture =
+          GameInitialDrawsMutationFixtures.withCardsOneCardArray;
+        gameDrawMutationFixture = GameDrawMutationFixtures.withCardsOne;
+        initialColorFixture = CardColor.blue;
+        initialDirectionFixture = GameDirection.antiClockwise;
+        initialPlayingSlotIndexFixture = 0;
+        initialTurnFixture = 1;
+
+        gameDrawServiceMock.calculateInitialCardsDrawMutation.mockReturnValueOnce(
+          gameInitialDrawsMutationFixture,
+        );
+        isValidInitialCardSpecMock.isSatisfiedBy
+          .mockReturnValueOnce(false)
+          .mockReturnValueOnce(true);
+        gameDrawServiceMock.calculateDrawMutation.mockReturnValueOnce(
+          gameDrawMutationFixture,
+        );
+        gameServiceMock.getInitialCardColor.mockReturnValueOnce(
+          initialColorFixture,
+        );
+        gameServiceMock.getInitialDirection.mockReturnValueOnce(
+          initialDirectionFixture,
+        );
+        gameServiceMock.getInitialPlayingSlotIndex.mockReturnValueOnce(
+          initialPlayingSlotIndexFixture,
+        );
+        gameServiceMock.getInitialTurn.mockReturnValueOnce(initialTurnFixture);
+
+        result = startGameUpdateQueryFromGameBuilder.build(
+          gameFixture,
+          gameSpecFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call gameDrawServiceMock.calculateInitialCardsDrawMutation()', () => {
+        expect(
+          gameDrawServiceMock.calculateInitialCardsDrawMutation,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          gameDrawServiceMock.calculateInitialCardsDrawMutation,
+        ).toHaveBeenCalledWith(gameSpecFixture);
+      });
+
+      it('should call isValidInitialCardSpec.isSatisfiedBy()', () => {
+        expect(isValidInitialCardSpecMock.isSatisfiedBy).toHaveBeenCalledTimes(
+          2,
+        );
+        expect(
+          isValidInitialCardSpecMock.isSatisfiedBy,
+        ).toHaveBeenNthCalledWith(
+          1,
+          gameInitialDrawsMutationFixture.currentCard,
+        );
+        expect(
+          isValidInitialCardSpecMock.isSatisfiedBy,
+        ).toHaveBeenNthCalledWith(2, gameDrawMutationFixture.cards[0]);
+      });
+
+      it('should call gameDrawService.putCards()', () => {
+        expect(gameDrawServiceMock.putCards).toHaveBeenCalledTimes(1);
+        expect(gameDrawServiceMock.putCards).toHaveBeenCalledWith(
+          [],
+          [gameInitialDrawsMutationFixture.currentCard],
+        );
+      });
+
+      it('should call gameDrawService.calculateDrawMutation()', () => {
+        expect(gameDrawServiceMock.calculateDrawMutation).toHaveBeenCalledTimes(
+          1,
+        );
+        expect(gameDrawServiceMock.calculateDrawMutation).toHaveBeenCalledWith(
+          gameInitialDrawsMutationFixture.deck,
+          [],
+          1,
+        );
+      });
+
+      it('should call gameService.getInitialCardColor()', () => {
+        expect(gameServiceMock.getInitialCardColor).toHaveBeenCalledTimes(1);
+        expect(gameServiceMock.getInitialCardColor).toHaveBeenCalledWith(
+          gameInitialDrawsMutationFixture.currentCard,
+        );
+      });
+
+      it('should call gameService.getInitialDirection()', () => {
+        expect(gameServiceMock.getInitialDirection).toHaveBeenCalledTimes(1);
+        expect(gameServiceMock.getInitialDirection).toHaveBeenCalledWith();
+      });
+
+      it('should call gameService.getInitialPlayingSlotIndex()', () => {
+        expect(
+          gameServiceMock.getInitialPlayingSlotIndex,
+        ).toHaveBeenCalledTimes(1);
+        expect(gameServiceMock.getInitialPlayingSlotIndex).toHaveBeenCalledWith(
+          gameSpecFixture,
+        );
+      });
+
+      it('should call gameService.getInitialTurn()', () => {
+        expect(gameServiceMock.getInitialTurn).toHaveBeenCalledTimes(1);
+        expect(gameServiceMock.getInitialTurn).toHaveBeenCalledWith();
+      });
+
+      it('should return a GameUpdateQuery', () => {
+        const expected: GameUpdateQuery = {
+          currentCard: gameInitialDrawsMutationFixture.currentCard,
+          currentColor: initialColorFixture,
+          currentDirection: initialDirectionFixture,
+          currentPlayingSlotIndex: initialPlayingSlotIndexFixture,
+          currentTurnCardsDrawn: false,
+          currentTurnCardsPlayed: false,
+          deck: gameInitialDrawsMutationFixture.deck,
+          discardPile: [],
           drawCount: 0,
           gameFindQuery: {
             id: gameFixture.id,

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/builders/StartGameUpdateQueryFromGameBuilder.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/builders/StartGameUpdateQueryFromGameBuilder.ts
@@ -1,12 +1,15 @@
-import { Builder } from '@cornie-js/backend-common';
+import { AppError, AppErrorKind, Builder } from '@cornie-js/backend-common';
 import { Inject, Injectable } from '@nestjs/common';
 
+import { IsValidInitialCardSpec } from '../../../cards/domain/specs/IsValidInitialCardSpec';
 import { Card } from '../../../cards/domain/valueObjects/Card';
 import { NonStartedGame } from '../entities/NonStartedGame';
 import { GameSlotUpdateQuery } from '../query/GameSlotUpdateQuery';
 import { GameUpdateQuery } from '../query/GameUpdateQuery';
 import { GameDrawService } from '../services/GameDrawService';
 import { GameService } from '../services/GameService';
+import { GameCardSpec } from '../valueObjects/GameCardSpec';
+import { GameDrawMutation } from '../valueObjects/GameDrawMutation';
 import { GameInitialDrawsMutation } from '../valueObjects/GameInitialDrawsMutation';
 import { GameSpec } from '../valueObjects/GameSpec';
 import { GameStatus } from '../valueObjects/GameStatus';
@@ -17,15 +20,19 @@ export class StartGameUpdateQueryFromGameBuilder
 {
   readonly #gameDrawService: GameDrawService;
   readonly #gameService: GameService;
+  readonly #isValidInitialCardSpec: IsValidInitialCardSpec;
 
   constructor(
     @Inject(GameDrawService)
     gameDrawService: GameDrawService,
     @Inject(GameService)
     gameService: GameService,
+    @Inject(IsValidInitialCardSpec)
+    isValidInitialCardSpec: IsValidInitialCardSpec,
   ) {
     this.#gameDrawService = gameDrawService;
     this.#gameService = gameService;
+    this.#isValidInitialCardSpec = isValidInitialCardSpec;
   }
 
   public build(game: NonStartedGame, gameSpec: GameSpec): GameUpdateQuery {
@@ -33,18 +40,13 @@ export class StartGameUpdateQueryFromGameBuilder
       this.#gameDrawService.calculateInitialCardsDrawMutation(gameSpec);
 
     const gameSlotUpdateQueries: GameSlotUpdateQuery[] =
-      gameInitialDraws.cards.map(
-        (cards: Card[], index: number): GameSlotUpdateQuery => ({
-          cards: cards,
-          gameSlotFindQuery: {
-            gameId: game.id,
-            position: index,
-          },
-        }),
-      );
+      this.#buildGameSlotUpdateQueries(game, gameInitialDraws);
+
+    const [currentCard, discardPile]: [Card, GameCardSpec[]] =
+      this.#getCurrentCardAndDiscardPile(gameInitialDraws);
 
     const gameUpdateQuery: GameUpdateQuery = {
-      currentCard: gameInitialDraws.currentCard,
+      currentCard,
       currentColor: this.#gameService.getInitialCardColor(
         gameInitialDraws.currentCard,
       ),
@@ -54,6 +56,7 @@ export class StartGameUpdateQueryFromGameBuilder
       currentTurnCardsDrawn: false,
       currentTurnCardsPlayed: false,
       deck: gameInitialDraws.deck,
+      discardPile,
       drawCount: 0,
       gameFindQuery: {
         id: game.id,
@@ -65,5 +68,50 @@ export class StartGameUpdateQueryFromGameBuilder
     };
 
     return gameUpdateQuery;
+  }
+
+  #buildGameSlotUpdateQueries(
+    game: NonStartedGame,
+    gameInitialDraws: GameInitialDrawsMutation,
+  ): GameSlotUpdateQuery[] {
+    return gameInitialDraws.cards.map(
+      (cards: Card[], index: number): GameSlotUpdateQuery => ({
+        cards: cards,
+        gameSlotFindQuery: {
+          gameId: game.id,
+          position: index,
+        },
+      }),
+    );
+  }
+
+  #getCurrentCardAndDiscardPile(
+    gameInitialDraws: GameInitialDrawsMutation,
+  ): [Card, GameCardSpec[]] {
+    let card: Card = gameInitialDraws.currentCard;
+    let deck: GameCardSpec[] = gameInitialDraws.deck;
+    let discardPile: GameCardSpec[] = [];
+
+    while (!this.#isValidInitialCardSpec.isSatisfiedBy(card)) {
+      this.#gameDrawService.putCards(discardPile, [card]);
+
+      const drawMutation: GameDrawMutation =
+        this.#gameDrawService.calculateDrawMutation(deck, discardPile, 1);
+
+      const [firstDraw]: Card[] = drawMutation.cards;
+
+      if (firstDraw === undefined) {
+        throw new AppError(AppErrorKind.unknown, 'Unexpected card draw');
+      }
+
+      card = firstDraw;
+      deck = drawMutation.deck;
+
+      if (drawMutation.isDiscardPileEmptied) {
+        discardPile = [];
+      }
+    }
+
+    return [card, discardPile];
   }
 }

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameDrawMutationFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/fixtures/GameDrawMutationFixtures.ts
@@ -11,6 +11,13 @@ export class GameDrawMutationFixtures {
     };
   }
 
+  public static get withCardsOne(): GameDrawMutation {
+    return {
+      ...GameDrawMutationFixtures.any,
+      cards: [CardFixtures.any],
+    };
+  }
+
   public static get withIsDiscardPileEmptiedFalse(): GameDrawMutation {
     return {
       ...GameDrawMutationFixtures.any,


### PR DESCRIPTION
### Added
- Added `IsValidInitialCardSpec`.

### Changed
- Updated `StartGameUpdateQueryFromGameBuilder` to draw cards until a valid initial one is the current one.

### Additional context
- Fixes #1012.