### PR TITLE
Update GameAction with additional fields

### DIFF
--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/builders/GameActionCreateQueryTypeOrmFromGameActionCreateQueryBuilder.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/builders/GameActionCreateQueryTypeOrmFromGameActionCreateQueryBuilder.spec.ts
@@ -239,6 +239,8 @@ describe(
           it('should call insertQueryBuilder.values()', () => {
             const expectedPayload: PassTurnGameActionDbPayloadV1 = {
               kind: GameActionDbPayloadV1Kind.passTurn,
+              nextPlayingSlotIndex:
+                passTurnGameActionCreateQueryFixture.nextPlayingSlotIndex,
               version: GameActionDbVersion.v1,
             };
 
@@ -362,7 +364,9 @@ describe(
           beforeAll(() => {
             cardDbFixture = 0x0039;
 
-            cardDbBuilderMock.build.mockReturnValueOnce(cardDbFixture);
+            cardDbBuilderMock.build
+              .mockReturnValueOnce(cardDbFixture)
+              .mockReturnValueOnce(cardDbFixture);
 
             result =
               gameActionCreateQueryTypeOrmFromGameActionCreateQueryBuilder.build(
@@ -378,6 +382,7 @@ describe(
           it('should call insertQueryBuilder.values()', () => {
             const expectedPayload: PlayCardsGameActionDbPayloadV1 = {
               cards: [cardDbFixture],
+              currentCard: cardDbFixture,
               kind: GameActionDbPayloadV1Kind.playCards,
               version: GameActionDbVersion.v1,
             };

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/builders/GameActionCreateQueryTypeOrmFromGameActionCreateQueryBuilder.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/builders/GameActionCreateQueryTypeOrmFromGameActionCreateQueryBuilder.ts
@@ -77,6 +77,7 @@ export class GameActionCreateQueryTypeOrmFromGameActionCreateQueryBuilder
       case GameActionKind.passTurn:
         return {
           kind: GameActionDbPayloadV1Kind.passTurn,
+          nextPlayingSlotIndex: gameActionCreateQuery.nextPlayingSlotIndex,
           version: GameActionDbVersion.v1,
         };
       case GameActionKind.playCards:
@@ -84,6 +85,10 @@ export class GameActionCreateQueryTypeOrmFromGameActionCreateQueryBuilder
           cards: gameActionCreateQuery.cards.map((card: Card) =>
             this.#cardDbBuilder.build(card),
           ),
+          currentCard:
+            gameActionCreateQuery.currentCard === null
+              ? null
+              : this.#cardDbBuilder.build(gameActionCreateQuery.currentCard),
           kind: GameActionDbPayloadV1Kind.playCards,
           version: GameActionDbVersion.v1,
         };

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/builders/GameActionFromGameActionDbBuilder.spec.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/builders/GameActionFromGameActionDbBuilder.spec.ts
@@ -64,6 +64,7 @@ describe(GameActionFromGameActionDbBuilder.name, () => {
             gameId: gameActionDbFixture.gameId,
             id: gameActionDbFixture.id,
             kind: GameActionKind.passTurn,
+            nextPlayingSlotIndex: 1,
             position: gameActionDbFixture.position,
             turn: gameActionDbFixture.turn,
           };
@@ -78,6 +79,7 @@ describe(GameActionFromGameActionDbBuilder.name, () => {
 
           return {
             cards: [CardFixtures.any],
+            currentCard: CardFixtures.any,
             currentPlayingSlotIndex:
               gameActionDbFixture.currentPlayingSlotIndex,
             gameId: gameActionDbFixture.gameId,

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/builders/GameActionFromGameActionDbBuilder.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/builders/GameActionFromGameActionDbBuilder.ts
@@ -61,6 +61,7 @@ export class GameActionFromGameActionDbBuilder
           gameId: gameActionDb.gameId,
           id: gameActionDb.id,
           kind: GameActionKind.passTurn,
+          nextPlayingSlotIndex: payload.nextPlayingSlotIndex,
           position: gameActionDb.position,
           turn: gameActionDb.turn,
         };
@@ -69,6 +70,10 @@ export class GameActionFromGameActionDbBuilder
           cards: payload.cards.map((cardDb: CardDb) =>
             this.#cardBuilder.build(cardDb),
           ),
+          currentCard:
+            payload.currentCard === null
+              ? null
+              : this.#cardBuilder.build(payload.currentCard),
           currentPlayingSlotIndex: gameActionDb.currentPlayingSlotIndex,
           gameId: gameActionDb.gameId,
           id: gameActionDb.id,

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/fixtures/GameActionDbPayloadV1Fixtures.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/fixtures/GameActionDbPayloadV1Fixtures.ts
@@ -10,6 +10,7 @@ export class GameActionDbPayloadV1Fixtures {
   public static get any(): GameActionDbPayloadV1 {
     return {
       kind: GameActionDbPayloadV1Kind.passTurn,
+      nextPlayingSlotIndex: 1,
       version: GameActionDbVersion.v1,
     };
   }
@@ -25,6 +26,7 @@ export class GameActionDbPayloadV1Fixtures {
   public static get withKindPassTurn(): PassTurnGameActionDbPayloadV1 {
     return {
       kind: GameActionDbPayloadV1Kind.passTurn,
+      nextPlayingSlotIndex: 1,
       version: GameActionDbVersion.v1,
     };
   }
@@ -32,6 +34,7 @@ export class GameActionDbPayloadV1Fixtures {
   public static get withKindPlayCardsAndCardsOne(): PlayCardsGameActionDbPayloadV1 {
     return {
       cards: [0x0039],
+      currentCard: 0x0039,
       kind: GameActionDbPayloadV1Kind.playCards,
       version: GameActionDbVersion.v1,
     };

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/models/v1/PassTurnGameActionDbPayloadV1.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/models/v1/PassTurnGameActionDbPayloadV1.ts
@@ -1,5 +1,7 @@
 import { BaseGameActionDbPayloadV1 } from './BaseGameActionDbPayloadV1';
 import { GameActionDbPayloadV1Kind } from './GameActionDbPayloadV1Kind';
 
-export type PassTurnGameActionDbPayloadV1 =
-  BaseGameActionDbPayloadV1<GameActionDbPayloadV1Kind.passTurn>;
+export interface PassTurnGameActionDbPayloadV1
+  extends BaseGameActionDbPayloadV1<GameActionDbPayloadV1Kind.passTurn> {
+  nextPlayingSlotIndex: number | null;
+}

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/models/v1/PlayCardsGameActionDbPayloadV1.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/models/v1/PlayCardsGameActionDbPayloadV1.ts
@@ -5,4 +5,5 @@ import { GameActionDbPayloadV1Kind } from './GameActionDbPayloadV1Kind';
 export interface PlayCardsGameActionDbPayloadV1
   extends BaseGameActionDbPayloadV1<GameActionDbPayloadV1Kind.playCards> {
   readonly cards: CardDb[];
+  readonly currentCard: CardDb | null;
 }

--- a/packages/backend/apps/game/backend-game-application/src/games/application/builders/GameActionCreateQueryFromGameUpdateEventBuilder.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/builders/GameActionCreateQueryFromGameUpdateEventBuilder.spec.ts
@@ -4,6 +4,7 @@ import {
   GameActionCreateQuery,
   GameActionKind,
 } from '@cornie-js/backend-game-domain/gameActions';
+import { ActiveGame } from '@cornie-js/backend-game-domain/games';
 
 import { UuidContext } from '../../../foundation/common/application/models/UuidContext';
 import { ActiveGameUpdatedEventFixtures } from '../fixtures/ActiveGameUpdatedEventFixtures';
@@ -62,13 +63,13 @@ describe(GameActionCreateQueryFromGameUpdateEventBuilder.name, () => {
       });
     });
 
-    describe('having an ActiveGameUpdatedCardsPlayEvent', () => {
+    describe('having an ActiveGameUpdatedCardsPlayEvent with an ActiveGame', () => {
       let activeGameUpdatedCardsDrawEventFixture: ActiveGameUpdatedCardsPlayEvent;
       let uuidContextFixture: UuidContext;
 
       beforeAll(() => {
         activeGameUpdatedCardsDrawEventFixture =
-          ActiveGameUpdatedEventFixtures.anyCardsPlayEvent;
+          ActiveGameUpdatedEventFixtures.cardPlayEventWithActiveGame;
 
         uuidContextFixture = {
           uuid: '738e3afd-b015-4385-ad87-378475db4847',
@@ -88,6 +89,9 @@ describe(GameActionCreateQueryFromGameUpdateEventBuilder.name, () => {
         it('should return a GameActionCreateQuery', () => {
           const expected: GameActionCreateQuery = {
             cards: activeGameUpdatedCardsDrawEventFixture.cards,
+            currentCard: (
+              activeGameUpdatedCardsDrawEventFixture.game as ActiveGame
+            ).state.currentCard,
             currentPlayingSlotIndex:
               activeGameUpdatedCardsDrawEventFixture.gameBeforeUpdate.state
                 .currentPlayingSlotIndex,
@@ -103,13 +107,55 @@ describe(GameActionCreateQueryFromGameUpdateEventBuilder.name, () => {
       });
     });
 
-    describe('having an ActiveGameUpdatedTurnPassEvent', () => {
+    describe('having an ActiveGameUpdatedCardsPlayEvent with a FinishedGame', () => {
+      let activeGameUpdatedCardsDrawEventFixture: ActiveGameUpdatedCardsPlayEvent;
+      let uuidContextFixture: UuidContext;
+
+      beforeAll(() => {
+        activeGameUpdatedCardsDrawEventFixture =
+          ActiveGameUpdatedEventFixtures.cardPlayEventWithFinishedGame;
+
+        uuidContextFixture = {
+          uuid: '738e3afd-b015-4385-ad87-378475db4847',
+        };
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = gameActionCreateQueryFromGameUpdateEventBuilder.build(
+            activeGameUpdatedCardsDrawEventFixture,
+            uuidContextFixture,
+          );
+        });
+
+        it('should return a GameActionCreateQuery', () => {
+          const expected: GameActionCreateQuery = {
+            cards: activeGameUpdatedCardsDrawEventFixture.cards,
+            currentCard: null,
+            currentPlayingSlotIndex:
+              activeGameUpdatedCardsDrawEventFixture.gameBeforeUpdate.state
+                .currentPlayingSlotIndex,
+            gameId: activeGameUpdatedCardsDrawEventFixture.gameBeforeUpdate.id,
+            id: uuidContextFixture.uuid,
+            kind: GameActionKind.playCards,
+            turn: activeGameUpdatedCardsDrawEventFixture.gameBeforeUpdate.state
+              .turn,
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having an ActiveGameUpdatedTurnPassEvent with ActiveGame', () => {
       let activeGameUpdatedCardsDrawEventFixture: ActiveGameUpdatedTurnPassEvent;
       let uuidContextFixture: UuidContext;
 
       beforeAll(() => {
         activeGameUpdatedCardsDrawEventFixture =
-          ActiveGameUpdatedEventFixtures.anyTurnPassEvent;
+          ActiveGameUpdatedEventFixtures.turnPassEventWithActiveGame;
 
         uuidContextFixture = {
           uuid: '738e3afd-b015-4385-ad87-378475db4847',
@@ -134,6 +180,50 @@ describe(GameActionCreateQueryFromGameUpdateEventBuilder.name, () => {
             gameId: activeGameUpdatedCardsDrawEventFixture.gameBeforeUpdate.id,
             id: uuidContextFixture.uuid,
             kind: GameActionKind.passTurn,
+            nextPlayingSlotIndex: (
+              activeGameUpdatedCardsDrawEventFixture.game as ActiveGame
+            ).state.currentPlayingSlotIndex,
+            turn: activeGameUpdatedCardsDrawEventFixture.gameBeforeUpdate.state
+              .turn,
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having an ActiveGameUpdatedTurnPassEvent with FinishedGame', () => {
+      let activeGameUpdatedCardsDrawEventFixture: ActiveGameUpdatedTurnPassEvent;
+      let uuidContextFixture: UuidContext;
+
+      beforeAll(() => {
+        activeGameUpdatedCardsDrawEventFixture =
+          ActiveGameUpdatedEventFixtures.turnPassEventWithFinishedGame;
+
+        uuidContextFixture = {
+          uuid: '738e3afd-b015-4385-ad87-378475db4847',
+        };
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = gameActionCreateQueryFromGameUpdateEventBuilder.build(
+            activeGameUpdatedCardsDrawEventFixture,
+            uuidContextFixture,
+          );
+        });
+
+        it('should return a GameActionCreateQuery', () => {
+          const expected: GameActionCreateQuery = {
+            currentPlayingSlotIndex:
+              activeGameUpdatedCardsDrawEventFixture.gameBeforeUpdate.state
+                .currentPlayingSlotIndex,
+            gameId: activeGameUpdatedCardsDrawEventFixture.gameBeforeUpdate.id,
+            id: uuidContextFixture.uuid,
+            kind: GameActionKind.passTurn,
+            nextPlayingSlotIndex: null,
             turn: activeGameUpdatedCardsDrawEventFixture.gameBeforeUpdate.state
               .turn,
           };

--- a/packages/backend/apps/game/backend-game-application/src/games/application/builders/GameActionCreateQueryFromGameUpdateEventBuilder.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/builders/GameActionCreateQueryFromGameUpdateEventBuilder.ts
@@ -1,13 +1,24 @@
 import { Builder } from '@cornie-js/backend-common';
 import {
+  DrawGameActionCreateQuery,
   GameActionCreateQuery,
   GameActionKind,
+  PassTurnGameActionCreateQuery,
+  PlayCardsGameActionCreateQuery,
 } from '@cornie-js/backend-game-domain/gameActions';
+import {
+  ActiveGame,
+  Game,
+  GameStatus,
+} from '@cornie-js/backend-game-domain/games';
 import { Injectable } from '@nestjs/common';
 
 import { UuidContext } from '../../../foundation/common/application/models/UuidContext';
+import { ActiveGameUpdatedCardsDrawEvent } from '../models/ActiveGameUpdatedCardsDrawEvent';
+import { ActiveGameUpdatedCardsPlayEvent } from '../models/ActiveGameUpdatedCardsPlayEvent';
 import { ActiveGameUpdatedEvent } from '../models/ActiveGameUpdatedEvent';
 import { ActiveGameUpdatedEventKind } from '../models/ActiveGameUpdatedEventKind';
+import { ActiveGameUpdatedTurnPassEvent } from '../models/ActiveGameUpdatedTurnPassEvent';
 
 @Injectable()
 export class GameActionCreateQueryFromGameUpdateEventBuilder
@@ -21,39 +32,79 @@ export class GameActionCreateQueryFromGameUpdateEventBuilder
     let gameActionCreateQuery: GameActionCreateQuery;
     switch (event.kind) {
       case ActiveGameUpdatedEventKind.cardsDraw:
-        gameActionCreateQuery = {
-          currentPlayingSlotIndex:
-            event.gameBeforeUpdate.state.currentPlayingSlotIndex,
-          draw: event.draw,
-          gameId: event.gameBeforeUpdate.id,
-          id: context.uuid,
-          kind: GameActionKind.draw,
-          turn: event.gameBeforeUpdate.state.turn,
-        };
+        gameActionCreateQuery = this.#buildDrawGameActionCreateQuery(
+          event,
+          context,
+        );
         break;
       case ActiveGameUpdatedEventKind.cardsPlay:
-        gameActionCreateQuery = {
-          cards: event.cards,
-          currentPlayingSlotIndex:
-            event.gameBeforeUpdate.state.currentPlayingSlotIndex,
-          gameId: event.gameBeforeUpdate.id,
-          id: context.uuid,
-          kind: GameActionKind.playCards,
-          turn: event.gameBeforeUpdate.state.turn,
-        };
+        gameActionCreateQuery = this.#buildPlayCardsGameActionCreateQuery(
+          event,
+          context,
+        );
         break;
       case ActiveGameUpdatedEventKind.turnPass:
-        gameActionCreateQuery = {
-          currentPlayingSlotIndex:
-            event.gameBeforeUpdate.state.currentPlayingSlotIndex,
-          gameId: event.gameBeforeUpdate.id,
-          id: context.uuid,
-          kind: GameActionKind.passTurn,
-          turn: event.gameBeforeUpdate.state.turn,
-        };
+        gameActionCreateQuery = this.#buildPassTurnGameActionCreateQuery(
+          event,
+          context,
+        );
         break;
     }
 
     return gameActionCreateQuery;
+  }
+
+  #buildDrawGameActionCreateQuery(
+    event: ActiveGameUpdatedCardsDrawEvent,
+    context: UuidContext,
+  ): DrawGameActionCreateQuery {
+    return {
+      currentPlayingSlotIndex:
+        event.gameBeforeUpdate.state.currentPlayingSlotIndex,
+      draw: event.draw,
+      gameId: event.gameBeforeUpdate.id,
+      id: context.uuid,
+      kind: GameActionKind.draw,
+      turn: event.gameBeforeUpdate.state.turn,
+    };
+  }
+
+  #buildPassTurnGameActionCreateQuery(
+    event: ActiveGameUpdatedTurnPassEvent,
+    context: UuidContext,
+  ): PassTurnGameActionCreateQuery {
+    return {
+      currentPlayingSlotIndex:
+        event.gameBeforeUpdate.state.currentPlayingSlotIndex,
+      gameId: event.gameBeforeUpdate.id,
+      id: context.uuid,
+      kind: GameActionKind.passTurn,
+      nextPlayingSlotIndex: this.#isActiveGame(event.game)
+        ? event.game.state.currentPlayingSlotIndex
+        : null,
+      turn: event.gameBeforeUpdate.state.turn,
+    };
+  }
+
+  #buildPlayCardsGameActionCreateQuery(
+    event: ActiveGameUpdatedCardsPlayEvent,
+    context: UuidContext,
+  ): PlayCardsGameActionCreateQuery {
+    return {
+      cards: event.cards,
+      currentCard: this.#isActiveGame(event.game)
+        ? event.game.state.currentCard
+        : null,
+      currentPlayingSlotIndex:
+        event.gameBeforeUpdate.state.currentPlayingSlotIndex,
+      gameId: event.gameBeforeUpdate.id,
+      id: context.uuid,
+      kind: GameActionKind.playCards,
+      turn: event.gameBeforeUpdate.state.turn,
+    };
+  }
+
+  #isActiveGame(game: Game): game is ActiveGame {
+    return game.state.status === GameStatus.active;
   }
 }

--- a/packages/backend/apps/game/backend-game-application/src/games/application/builders/GameEventV2FromGameMessageEventBuilder.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/builders/GameEventV2FromGameMessageEventBuilder.spec.ts
@@ -3,8 +3,10 @@ import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { models as apiModels } from '@cornie-js/api-models';
 import { Builder } from '@cornie-js/backend-common';
 import { Card } from '@cornie-js/backend-game-domain/cards';
-import { DrawGameAction } from '@cornie-js/backend-game-domain/gameActions';
-import { ActiveGame } from '@cornie-js/backend-game-domain/games';
+import {
+  DrawGameAction,
+  PassTurnGameAction,
+} from '@cornie-js/backend-game-domain/gameActions';
 
 import { CardV1Fixtures } from '../../../cards/application/fixtures';
 import { GameUpdatedMessageEventFixtures } from '../fixtures/GameUpdatedMessageEventFixtures';
@@ -65,12 +67,12 @@ describe(GameEventV2FromGameMessageEventBuilder.name, () => {
       });
     });
 
-    describe('having a GameMessageEvent with an pass turn game action and game active', () => {
+    describe('having a GameMessageEvent with an pass turn game action', () => {
       let gameMessageEventFixture: GameMessageEvent;
 
       beforeAll(() => {
         gameMessageEventFixture =
-          GameUpdatedMessageEventFixtures.withGameActiveAndPassTurnGameAction;
+          GameUpdatedMessageEventFixtures.withPassTurnGameAction;
       });
 
       describe('when called', () => {
@@ -93,8 +95,9 @@ describe(GameEventV2FromGameMessageEventBuilder.name, () => {
               currentPlayingSlotIndex:
                 gameMessageEventFixture.gameAction.currentPlayingSlotIndex,
               kind: 'turnPassed',
-              nextPlayingSlotIndex: (gameMessageEventFixture.game as ActiveGame)
-                .state.currentPlayingSlotIndex,
+              nextPlayingSlotIndex: (
+                gameMessageEventFixture.gameAction as PassTurnGameAction
+              ).nextPlayingSlotIndex,
               position: gameMessageEventFixture.gameAction.position,
             },
           ];
@@ -104,50 +107,12 @@ describe(GameEventV2FromGameMessageEventBuilder.name, () => {
       });
     });
 
-    describe('having a GameMessageEvent with an pass turn game action and game finished', () => {
+    describe('having a GameMessageEvent with an play cards game action and current card', () => {
       let gameMessageEventFixture: GameMessageEvent;
 
       beforeAll(() => {
         gameMessageEventFixture =
-          GameUpdatedMessageEventFixtures.withGameFinishedAndPassTurnGameAction;
-      });
-
-      describe('when called', () => {
-        let result: unknown;
-
-        beforeAll(() => {
-          result = gameEventV2FromGameMessageEventBuilder.build(
-            gameMessageEventFixture,
-          );
-        });
-
-        afterAll(() => {
-          jest.clearAllMocks();
-        });
-
-        it('should return CardsPlayedGameEventV2', () => {
-          const expected: [string, apiModels.TurnPassedGameEventV2] = [
-            gameMessageEventFixture.gameAction.id,
-            {
-              currentPlayingSlotIndex:
-                gameMessageEventFixture.gameAction.currentPlayingSlotIndex,
-              kind: 'turnPassed',
-              nextPlayingSlotIndex: null,
-              position: gameMessageEventFixture.gameAction.position,
-            },
-          ];
-
-          expect(result).toStrictEqual(expected);
-        });
-      });
-    });
-
-    describe('having a GameMessageEvent with an play cards game action and game active', () => {
-      let gameMessageEventFixture: GameMessageEvent;
-
-      beforeAll(() => {
-        gameMessageEventFixture =
-          GameUpdatedMessageEventFixtures.withGameActiveAndPlayCardsGameActionAndCardsOne;
+          GameUpdatedMessageEventFixtures.withPlayCardsGameActionWithCardsOneAndCurrentCard;
       });
 
       describe('when called', () => {
@@ -176,8 +141,7 @@ describe(GameEventV2FromGameMessageEventBuilder.name, () => {
             gameMessageEventFixture.gameAction.id,
             {
               cards: [cardV1Fixture],
-              currentCard: (gameMessageEventFixture.game as ActiveGame).state
-                .currentCard,
+              currentCard: cardV1Fixture,
               currentPlayingSlotIndex:
                 gameMessageEventFixture.gameAction.currentPlayingSlotIndex,
               kind: 'cardsPlayed',
@@ -195,7 +159,7 @@ describe(GameEventV2FromGameMessageEventBuilder.name, () => {
 
       beforeAll(() => {
         gameMessageEventFixture =
-          GameUpdatedMessageEventFixtures.withGameFinishedAndPlayCardsGameActionAndCardsOne;
+          GameUpdatedMessageEventFixtures.withPlayCardsGameActionWithCardsOneAndCurrentCardNull;
       });
 
       describe('when called', () => {

--- a/packages/backend/apps/game/backend-game-application/src/games/application/fixtures/ActiveGameUpdatedEventFixtures.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/fixtures/ActiveGameUpdatedEventFixtures.ts
@@ -1,6 +1,9 @@
 import { TransactionWrapper } from '@cornie-js/backend-db/application';
 import { CardFixtures } from '@cornie-js/backend-game-domain/cards/fixtures';
-import { ActiveGameFixtures } from '@cornie-js/backend-game-domain/games/fixtures';
+import {
+  ActiveGameFixtures,
+  FinishedGameFixtures,
+} from '@cornie-js/backend-game-domain/games/fixtures';
 
 import { ActiveGameUpdatedCardsDrawEvent } from '../models/ActiveGameUpdatedCardsDrawEvent';
 import { ActiveGameUpdatedCardsPlayEvent } from '../models/ActiveGameUpdatedCardsPlayEvent';
@@ -11,6 +14,7 @@ export class ActiveGameUpdatedEventFixtures {
   public static get anyCardsDrawEvent(): ActiveGameUpdatedCardsDrawEvent {
     return {
       draw: [CardFixtures.any],
+      game: ActiveGameFixtures.any,
       gameBeforeUpdate: ActiveGameFixtures.any,
       kind: ActiveGameUpdatedEventKind.cardsDraw,
       transactionWrapper: Symbol() as unknown as TransactionWrapper,
@@ -20,6 +24,7 @@ export class ActiveGameUpdatedEventFixtures {
   public static get anyCardsPlayEvent(): ActiveGameUpdatedCardsPlayEvent {
     return {
       cards: [CardFixtures.any],
+      game: ActiveGameFixtures.any,
       gameBeforeUpdate: ActiveGameFixtures.any,
       kind: ActiveGameUpdatedEventKind.cardsPlay,
       transactionWrapper: Symbol() as unknown as TransactionWrapper,
@@ -28,9 +33,38 @@ export class ActiveGameUpdatedEventFixtures {
 
   public static get anyTurnPassEvent(): ActiveGameUpdatedTurnPassEvent {
     return {
+      game: ActiveGameFixtures.any,
       gameBeforeUpdate: ActiveGameFixtures.any,
       kind: ActiveGameUpdatedEventKind.turnPass,
       transactionWrapper: Symbol() as unknown as TransactionWrapper,
+    };
+  }
+
+  public static get cardPlayEventWithActiveGame(): ActiveGameUpdatedCardsPlayEvent {
+    return {
+      ...ActiveGameUpdatedEventFixtures.anyCardsPlayEvent,
+      game: ActiveGameFixtures.any,
+    };
+  }
+
+  public static get cardPlayEventWithFinishedGame(): ActiveGameUpdatedCardsPlayEvent {
+    return {
+      ...ActiveGameUpdatedEventFixtures.anyCardsPlayEvent,
+      game: FinishedGameFixtures.any,
+    };
+  }
+
+  public static get turnPassEventWithActiveGame(): ActiveGameUpdatedTurnPassEvent {
+    return {
+      ...ActiveGameUpdatedEventFixtures.anyTurnPassEvent,
+      game: ActiveGameFixtures.any,
+    };
+  }
+
+  public static get turnPassEventWithFinishedGame(): ActiveGameUpdatedTurnPassEvent {
+    return {
+      ...ActiveGameUpdatedEventFixtures.anyTurnPassEvent,
+      game: FinishedGameFixtures.any,
     };
   }
 }

--- a/packages/backend/apps/game/backend-game-application/src/games/application/fixtures/GameUpdatedMessageEventFixtures.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/fixtures/GameUpdatedMessageEventFixtures.ts
@@ -25,10 +25,9 @@ export class GameUpdatedMessageEventFixtures {
     };
   }
 
-  public static get withGameActiveAndPassTurnGameAction(): GameUpdatedMessageEvent {
+  public static get withPassTurnGameAction(): GameUpdatedMessageEvent {
     return {
       ...GameUpdatedMessageEventFixtures.any,
-      game: ActiveGameFixtures.any,
       gameAction: GameActionFixtures.withKindPassTurn,
     };
   }
@@ -41,19 +40,18 @@ export class GameUpdatedMessageEventFixtures {
     };
   }
 
-  public static get withGameActiveAndPlayCardsGameActionAndCardsOne(): GameUpdatedMessageEvent {
+  public static get withPlayCardsGameActionWithCardsOneAndCurrentCard(): GameUpdatedMessageEvent {
     return {
       ...GameUpdatedMessageEventFixtures.any,
-      game: ActiveGameFixtures.any,
-      gameAction: GameActionFixtures.withKindPlayCardsAndCardsOne,
+      gameAction: GameActionFixtures.withKindPlayCardsAndCardsOneAndCurrentCard,
     };
   }
 
-  public static get withGameFinishedAndPlayCardsGameActionAndCardsOne(): GameUpdatedMessageEvent {
+  public static get withPlayCardsGameActionWithCardsOneAndCurrentCardNull(): GameUpdatedMessageEvent {
     return {
       ...GameUpdatedMessageEventFixtures.any,
-      game: FinishedGameFixtures.any,
-      gameAction: GameActionFixtures.withKindPlayCardsAndCardsOne,
+      gameAction:
+        GameActionFixtures.withKindPlayCardsAndCardsOneAndCurrentCardNull,
     };
   }
 }

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdDrawCardsQueryV1Handler.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdDrawCardsQueryV1Handler.spec.ts
@@ -510,9 +510,9 @@ describe(GameIdDrawCardsQueryV1Handler.name, () => {
           jest.Mocked<TransactionWrapper>
         > as jest.Mocked<TransactionWrapper>;
 
-        gamePersistenceOutputPortMock.findOne.mockResolvedValueOnce(
-          activeGameFixture,
-        );
+        gamePersistenceOutputPortMock.findOne
+          .mockResolvedValueOnce(activeGameFixture)
+          .mockResolvedValueOnce(activeGameFixture);
         gameSpecPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
           gameSpecFixture,
         );
@@ -547,13 +547,21 @@ describe(GameIdDrawCardsQueryV1Handler.name, () => {
       });
 
       it('should call gamePersistenceOutputPort.findOne()', () => {
-        const expectedGameFindQuery: GameFindQuery = {
+        const expectedFirstGameFindQuery: GameFindQuery = {
           id: gameIdFixture,
         };
+        const expectedSecondGameFindQuery: GameFindQuery = {
+          id: activeGameFixture.id,
+        };
 
-        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(1);
-        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
-          expectedGameFindQuery,
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(2);
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenNthCalledWith(
+          1,
+          expectedFirstGameFindQuery,
+        );
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenNthCalledWith(
+          2,
+          expectedSecondGameFindQuery,
         );
       });
 
@@ -621,6 +629,7 @@ describe(GameIdDrawCardsQueryV1Handler.name, () => {
       it('should call gameUpdatedEventHandler.handle()', () => {
         const expectedGameUpdatedEvent: ActiveGameUpdatedEvent = {
           draw: gameDrawMutationFixture.cards,
+          game: activeGameFixture,
           gameBeforeUpdate: activeGameFixture,
           kind: ActiveGameUpdatedEventKind.cardsDraw,
           transactionWrapper: transactionWrapperMock,

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdDrawCardsQueryV1Handler.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdDrawCardsQueryV1Handler.ts
@@ -114,6 +114,7 @@ export class GameIdDrawCardsQueryV1Handler extends GameIdUpdateQueryV1Handler<ap
 
     return {
       draw: drawMutation.cards,
+      game: await this._getUpdatedGame(game),
       gameBeforeUpdate: game,
       kind: ActiveGameUpdatedEventKind.cardsDraw,
       transactionWrapper,

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPassTurnQueryV1Handler.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPassTurnQueryV1Handler.spec.ts
@@ -495,9 +495,9 @@ describe(GameIdPassTurnQueryV1Handler.name, () => {
           jest.Mocked<TransactionWrapper>
         > as jest.Mocked<TransactionWrapper>;
 
-        gamePersistenceOutputPortMock.findOne.mockResolvedValueOnce(
-          activeGameFixture,
-        );
+        gamePersistenceOutputPortMock.findOne
+          .mockResolvedValueOnce(activeGameFixture)
+          .mockResolvedValueOnce(activeGameFixture);
         gameSpecPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
           gameSpecFixture,
         );
@@ -528,13 +528,21 @@ describe(GameIdPassTurnQueryV1Handler.name, () => {
       });
 
       it('should call gamePersistenceOutputPort.findOne()', () => {
-        const expectedGameFindQuery: GameFindQuery = {
+        const expectedFirstGameFindQuery: GameFindQuery = {
           id: gameIdFixture,
         };
+        const expectedSecondGameFindQuery: GameFindQuery = {
+          id: activeGameFixture.id,
+        };
 
-        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(1);
-        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
-          expectedGameFindQuery,
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(2);
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenNthCalledWith(
+          1,
+          expectedFirstGameFindQuery,
+        );
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenNthCalledWith(
+          2,
+          expectedSecondGameFindQuery,
         );
       });
 
@@ -601,6 +609,7 @@ describe(GameIdPassTurnQueryV1Handler.name, () => {
 
       it('should call gameUpdatedEventHandler.handle()', () => {
         const expectedGameUpdatedEvent: ActiveGameUpdatedEvent = {
+          game: activeGameFixture,
           gameBeforeUpdate: activeGameFixture,
           kind: ActiveGameUpdatedEventKind.turnPass,
           transactionWrapper: transactionWrapperMock,

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPassTurnQueryV1Handler.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPassTurnQueryV1Handler.ts
@@ -104,6 +104,7 @@ export class GameIdPassTurnQueryV1Handler extends GameIdUpdateQueryV1Handler<api
     );
 
     return {
+      game: await this._getUpdatedGame(game),
       gameBeforeUpdate: game,
       kind: ActiveGameUpdatedEventKind.turnPass,
       transactionWrapper,

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPlayCardsQueryV1Handler.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPlayCardsQueryV1Handler.spec.ts
@@ -528,9 +528,9 @@ describe(GameIdPlayCardsQueryV1Handler.name, () => {
         > as jest.Mocked<TransactionWrapper>;
         gameCardsEffectUpdateQueryFixture = GameUpdateQueryFixtures.any;
 
-        gamePersistenceOutputPortMock.findOne.mockResolvedValueOnce(
-          activeGameFixture,
-        );
+        gamePersistenceOutputPortMock.findOne
+          .mockResolvedValueOnce(activeGameFixture)
+          .mockResolvedValueOnce(activeGameFixture);
         gameSpecPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
           gameSpecFixture,
         );
@@ -570,13 +570,21 @@ describe(GameIdPlayCardsQueryV1Handler.name, () => {
       });
 
       it('should call gamePersistenceOutputPort.findOne()', () => {
-        const expectedGameFindQuery: GameFindQuery = {
+        const expectedFirstGameFindQuery: GameFindQuery = {
           id: gameIdFixture,
         };
+        const expectedSecondGameFindQuery: GameFindQuery = {
+          id: activeGameFixture.id,
+        };
 
-        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(1);
-        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
-          expectedGameFindQuery,
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(2);
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenNthCalledWith(
+          1,
+          expectedFirstGameFindQuery,
+        );
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenNthCalledWith(
+          2,
+          expectedSecondGameFindQuery,
         );
       });
 
@@ -682,6 +690,7 @@ describe(GameIdPlayCardsQueryV1Handler.name, () => {
       it('should call gameUpdatedEventHandler.handle()', () => {
         const expectedGameUpdatedEvent: ActiveGameUpdatedEvent = {
           cards: cardsFixture,
+          game: activeGameFixture,
           gameBeforeUpdate: activeGameFixture,
           kind: ActiveGameUpdatedEventKind.cardsPlay,
           transactionWrapper: transactionWrapperMock,
@@ -766,9 +775,9 @@ describe(GameIdPlayCardsQueryV1Handler.name, () => {
         > as jest.Mocked<TransactionWrapper>;
         gameCardsEffectUpdateQueryFixture = GameUpdateQueryFixtures.any;
 
-        gamePersistenceOutputPortMock.findOne.mockResolvedValueOnce(
-          activeGameFixture,
-        );
+        gamePersistenceOutputPortMock.findOne
+          .mockResolvedValueOnce(activeGameFixture)
+          .mockResolvedValueOnce(activeGameFixture);
         gameSpecPersistenceOutputPortMock.findOne.mockResolvedValueOnce(
           gameSpecFixture,
         );
@@ -811,13 +820,21 @@ describe(GameIdPlayCardsQueryV1Handler.name, () => {
       });
 
       it('should call gamePersistenceOutputPort.findOne()', () => {
-        const expectedGameFindQuery: GameFindQuery = {
+        const expectedFirstGameFindQuery: GameFindQuery = {
           id: gameIdFixture,
         };
+        const expectedSecondGameFindQuery: GameFindQuery = {
+          id: activeGameFixture.id,
+        };
 
-        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(1);
-        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledWith(
-          expectedGameFindQuery,
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenCalledTimes(2);
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenNthCalledWith(
+          1,
+          expectedFirstGameFindQuery,
+        );
+        expect(gamePersistenceOutputPortMock.findOne).toHaveBeenNthCalledWith(
+          2,
+          expectedSecondGameFindQuery,
         );
       });
 
@@ -932,6 +949,7 @@ describe(GameIdPlayCardsQueryV1Handler.name, () => {
       it('should call gameUpdatedEventHandler.handle()', () => {
         const expectedGameUpdatedEvent: ActiveGameUpdatedEvent = {
           cards: cardsFixture,
+          game: activeGameFixture,
           gameBeforeUpdate: activeGameFixture,
           kind: ActiveGameUpdatedEventKind.cardsPlay,
           transactionWrapper: transactionWrapperMock,

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPlayCardsQueryV1Handler.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPlayCardsQueryV1Handler.ts
@@ -146,6 +146,7 @@ export class GameIdPlayCardsQueryV1Handler extends GameIdUpdateQueryV1Handler<ap
 
     return {
       cards,
+      game: await this._getUpdatedGame(game),
       gameBeforeUpdate: game,
       kind: ActiveGameUpdatedEventKind.cardsPlay,
       transactionWrapper,

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameUpdatedEventHandler.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameUpdatedEventHandler.spec.ts
@@ -2,7 +2,6 @@ import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 import { UuidProviderOutputPort } from '@cornie-js/backend-app-uuid';
 import { AppError, AppErrorKind, Builder } from '@cornie-js/backend-common';
-import { TransactionWrapper } from '@cornie-js/backend-db/application';
 import {
   GameAction,
   GameActionCreateQuery,
@@ -16,8 +15,8 @@ import { ActiveGameFixtures } from '@cornie-js/backend-game-domain/games/fixture
 
 import { UuidContext } from '../../../foundation/common/application/models/UuidContext';
 import { GameActionPersistenceOutputPort } from '../../../gameActions/application/ports/output/GameActionPersistenceOutputPort';
+import { ActiveGameUpdatedEventFixtures } from '../fixtures/ActiveGameUpdatedEventFixtures';
 import { ActiveGameUpdatedEvent } from '../models/ActiveGameUpdatedEvent';
-import { ActiveGameUpdatedEventKind } from '../models/ActiveGameUpdatedEventKind';
 import { GameMessageEventKind } from '../models/GameMessageEventKind';
 import { GameUpdatedMessageEvent } from '../models/GameUpdatedMessageEvent';
 import { GameEventsSubscriptionOutputPort } from '../ports/output/GameEventsSubscriptionOutputPort';
@@ -72,11 +71,7 @@ describe(GameUpdatedEventHandler.name, () => {
     let gameUpdatedEventFixture: ActiveGameUpdatedEvent;
 
     beforeAll(() => {
-      gameUpdatedEventFixture = {
-        gameBeforeUpdate: ActiveGameFixtures.any,
-        kind: ActiveGameUpdatedEventKind.turnPass,
-        transactionWrapper: Symbol() as unknown as TransactionWrapper,
-      };
+      gameUpdatedEventFixture = ActiveGameUpdatedEventFixtures.anyTurnPassEvent;
     });
 
     describe('when called, and gamePersistenceOutputPort.findOne() returns undefined', () => {

--- a/packages/backend/apps/game/backend-game-application/src/games/application/models/BaseActiveGameUpdatedEvent.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/models/BaseActiveGameUpdatedEvent.ts
@@ -1,5 +1,5 @@
 import { TransactionWrapper } from '@cornie-js/backend-db/application';
-import { ActiveGame } from '@cornie-js/backend-game-domain/games';
+import { ActiveGame, FinishedGame } from '@cornie-js/backend-game-domain/games';
 
 import { ActiveGameUpdatedEventKind } from './ActiveGameUpdatedEventKind';
 
@@ -7,6 +7,7 @@ export interface BaseActiveGameUpdatedEvent<
   TKind extends ActiveGameUpdatedEventKind,
 > {
   gameBeforeUpdate: ActiveGame;
+  game: ActiveGame | FinishedGame;
   kind: TKind;
   transactionWrapper: TransactionWrapper;
 }

--- a/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/fixtures/GameActionCreateQueryFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/fixtures/GameActionCreateQueryFixtures.ts
@@ -22,6 +22,7 @@ export class GameActionCreateQueryFixtures {
       gameId: 'e6b54159-a4ef-41fc-994a-20709526bdaa',
       id: '20f00a2b-bc9f-47fd-afb2-c2ed1b60e1b3',
       kind: GameActionKind.passTurn,
+      nextPlayingSlotIndex: 1,
       turn: 1,
     };
   }
@@ -29,6 +30,7 @@ export class GameActionCreateQueryFixtures {
   public static get withKindPlayCardsAndCardsOne(): PlayCardsGameActionCreateQuery {
     return {
       cards: [CardFixtures.any],
+      currentCard: CardFixtures.any,
       currentPlayingSlotIndex: 0,
       gameId: 'e6b54159-a4ef-41fc-994a-20709526bdaa',
       id: '20f00a2b-bc9f-47fd-afb2-c2ed1b60e1b3',

--- a/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/fixtures/GameActionFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/fixtures/GameActionFixtures.ts
@@ -12,6 +12,7 @@ export class GameActionFixtures {
       gameId: 'e6b54159-a4ef-41fc-994a-20709526bdaa',
       id: '16b54159-a4ef-41fc-994a-20709526bda0',
       kind: GameActionKind.passTurn,
+      nextPlayingSlotIndex: 1,
       position: 1,
       turn: 1,
     };
@@ -35,20 +36,38 @@ export class GameActionFixtures {
       gameId: 'e6b54159-a4ef-41fc-994a-20709526bdaa',
       id: '16b54159-a4ef-41fc-994a-20709526bda0',
       kind: GameActionKind.passTurn,
+      nextPlayingSlotIndex: 1,
       position: 1,
       turn: 1,
     };
   }
 
-  public static get withKindPlayCardsAndCardsOne(): PlayCardsGameAction {
+  public static get withKindPlayCards(): PlayCardsGameAction {
     return {
-      cards: [CardFixtures.any],
+      cards: [],
+      currentCard: null,
       currentPlayingSlotIndex: 0,
       gameId: 'e6b54159-a4ef-41fc-994a-20709526bdaa',
       id: '16b54159-a4ef-41fc-994a-20709526bda0',
       kind: GameActionKind.playCards,
       position: 1,
       turn: 1,
+    };
+  }
+
+  public static get withKindPlayCardsAndCardsOneAndCurrentCard(): PlayCardsGameAction {
+    return {
+      ...GameActionFixtures.withKindPlayCards,
+      cards: [CardFixtures.any],
+      currentCard: CardFixtures.any,
+    };
+  }
+
+  public static get withKindPlayCardsAndCardsOneAndCurrentCardNull(): PlayCardsGameAction {
+    return {
+      ...GameActionFixtures.withKindPlayCards,
+      cards: [CardFixtures.any],
+      currentCard: null,
     };
   }
 }

--- a/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/query/PassTurnGameActionCreateQuery.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/query/PassTurnGameActionCreateQuery.ts
@@ -1,5 +1,7 @@
 import { GameActionKind } from '../valueObjects/GameActionKind';
 import { BaseGameActionCreateQuery } from './BaseGameActionCreateQuery';
 
-export type PassTurnGameActionCreateQuery =
-  BaseGameActionCreateQuery<GameActionKind.passTurn>;
+export interface PassTurnGameActionCreateQuery
+  extends BaseGameActionCreateQuery<GameActionKind.passTurn> {
+  nextPlayingSlotIndex: number | null;
+}

--- a/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/query/PlayCardsGameActionCreateQuery.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/query/PlayCardsGameActionCreateQuery.ts
@@ -4,5 +4,6 @@ import { BaseGameActionCreateQuery } from './BaseGameActionCreateQuery';
 
 export interface PlayCardsGameActionCreateQuery
   extends BaseGameActionCreateQuery<GameActionKind.playCards> {
-  cards: Card[];
+  readonly cards: Card[];
+  readonly currentCard: Card | null;
 }

--- a/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/valueObjects/PassTurnGameAction.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/valueObjects/PassTurnGameAction.ts
@@ -1,4 +1,7 @@
 import { BaseGameAction } from './BaseGameAction';
 import { GameActionKind } from './GameActionKind';
 
-export type PassTurnGameAction = BaseGameAction<GameActionKind.passTurn>;
+export interface PassTurnGameAction
+  extends BaseGameAction<GameActionKind.passTurn> {
+  nextPlayingSlotIndex: number | null;
+}

--- a/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/valueObjects/PlayCardsGameAction.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/valueObjects/PlayCardsGameAction.ts
@@ -5,4 +5,5 @@ import { GameActionKind } from './GameActionKind';
 export interface PlayCardsGameAction
   extends BaseGameAction<GameActionKind.playCards> {
   readonly cards: Card[];
+  readonly currentCard: Card | null;
 }


### PR DESCRIPTION
### Changed
- Updated GameAction with additional fields.
- Updated `PlayCardsGameActionCreateQuery` with `currentCard`.
- Updated `PassTurnGameActionCreateQuery` with `nextPlayingSlotIndex`.
- Updated `BaseActiveGameUpdatedEvent` with game.