### PR TITLE
Update events games endpoint to refure request if game is not active

### DIFF
--- a/packages/backend/apps/game/backend-game-application/src/games/application/controllers/GetGameGameIdEventsV2SseController.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/controllers/GetGameGameIdEventsV2SseController.ts
@@ -87,7 +87,7 @@ export class GetGameGameIdEventsV2SseController extends HttpSseRequestController
         statusCode: HttpStatus.OK,
       },
       previousMessageEvents,
-      await this.#gameEventsManagementInputPort.subscribeV2(game.id, publisher),
+      await this.#gameEventsManagementInputPort.subscribeV2(game, publisher),
     ];
   }
 

--- a/packages/backend/apps/game/backend-game-domain/src/games/adapter/nest/GameDomainModule.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/adapter/nest/GameDomainModule.ts
@@ -14,6 +14,7 @@ import { CardCanBePlayedSpec } from '../../domain/specs/CardCanBePlayedSpec';
 import { CurrentPlayerCanPlayCardsSpec } from '../../domain/specs/CurrentPlayerCanPlayCardsSpec';
 import { GameCanHoldMoreGameSlotsSpec } from '../../domain/specs/GameCanHoldMoreGameSlotsSpec';
 import { GameCanHoldOnlyOneMoreGameSlotSpec } from '../../domain/specs/GameCanHoldOnlyOneMoreGameSlotSpec';
+import { GameEventsCanBeObservedSpec } from '../../domain/specs/GameEventsCanBeObservedSpec';
 import { IsGameFinishedSpec } from '../../domain/specs/IsGameFinishedSpec';
 import { IsValidGameCreateQuerySpec } from '../../domain/specs/IsValidGameCreateQuerySpec';
 import { PlayerCanDrawCardsSpec } from '../../domain/specs/PlayerCanDrawCardsSpec';
@@ -30,6 +31,7 @@ import { PlayerCanUpdateGameSpec } from '../../domain/specs/PlayerCanUpdateGameS
     GameCardsEffectUpdateQueryFromGameBuilder,
     GameDrawCardsUpdateQueryFromGameBuilder,
     GameDrawService,
+    GameEventsCanBeObservedSpec,
     GameService,
     GamePassTurnUpdateQueryFromGameBuilder,
     GamePlayCardsUpdateQueryFromGameBuilder,
@@ -50,6 +52,7 @@ import { PlayerCanUpdateGameSpec } from '../../domain/specs/PlayerCanUpdateGameS
     GameCardsEffectUpdateQueryFromGameBuilder,
     GameDrawCardsUpdateQueryFromGameBuilder,
     GameDrawService,
+    GameEventsCanBeObservedSpec,
     GamePassTurnUpdateQueryFromGameBuilder,
     GamePlayCardsUpdateQueryFromGameBuilder,
     GameService,

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/index.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/index.ts
@@ -25,6 +25,7 @@ import { GameService } from './services/GameService';
 import { CurrentPlayerCanPlayCardsSpec } from './specs/CurrentPlayerCanPlayCardsSpec';
 import { GameCanHoldMoreGameSlotsSpec } from './specs/GameCanHoldMoreGameSlotsSpec';
 import { GameCanHoldOnlyOneMoreGameSlotSpec } from './specs/GameCanHoldOnlyOneMoreGameSlotSpec';
+import { GameEventsCanBeObservedSpec } from './specs/GameEventsCanBeObservedSpec';
 import { IsGameFinishedSpec } from './specs/IsGameFinishedSpec';
 import { IsValidGameCreateQuerySpec } from './specs/IsValidGameCreateQuerySpec';
 import { PlayerCanDrawCardsSpec } from './specs/PlayerCanDrawCardsSpec';
@@ -77,6 +78,7 @@ export {
   GameDirection,
   GameDrawCardsUpdateQueryFromGameBuilder,
   GameDrawService,
+  GameEventsCanBeObservedSpec,
   GamePassTurnUpdateQueryFromGameBuilder,
   GamePlayCardsUpdateQueryFromGameBuilder,
   GameService,

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/specs/GameEventsCanBeObservedSpec.spec.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/specs/GameEventsCanBeObservedSpec.spec.ts
@@ -1,0 +1,56 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { Game } from '../entities/Game';
+import { ActiveGameFixtures } from '../fixtures/ActiveGameFixtures';
+import { NonStartedGameFixtures } from '../fixtures/NonStartedGameFixtures';
+import { GameEventsCanBeObservedSpec } from './GameEventsCanBeObservedSpec';
+
+describe(GameEventsCanBeObservedSpec.name, () => {
+  let gameEventsCanBeObservedSpec: GameEventsCanBeObservedSpec;
+
+  beforeAll(() => {
+    gameEventsCanBeObservedSpec = new GameEventsCanBeObservedSpec();
+  });
+
+  describe('.isSatisfiedBy', () => {
+    describe('having an ActiveGame', () => {
+      let gameFixture: Game;
+
+      beforeAll(() => {
+        gameFixture = ActiveGameFixtures.any;
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = gameEventsCanBeObservedSpec.isSatisfiedBy(gameFixture);
+        });
+
+        it('should return true', () => {
+          expect(result).toBe(true);
+        });
+      });
+    });
+
+    describe('having a non ActiveGame', () => {
+      let gameFixture: Game;
+
+      beforeAll(() => {
+        gameFixture = NonStartedGameFixtures.any;
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = gameEventsCanBeObservedSpec.isSatisfiedBy(gameFixture);
+        });
+
+        it('should return false', () => {
+          expect(result).toBe(false);
+        });
+      });
+    });
+  });
+});

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/specs/GameEventsCanBeObservedSpec.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/specs/GameEventsCanBeObservedSpec.ts
@@ -1,0 +1,12 @@
+import { Spec } from '@cornie-js/backend-common';
+import { Injectable } from '@nestjs/common';
+
+import { Game } from '../entities/Game';
+import { GameStatus } from '../valueObjects/GameStatus';
+
+@Injectable()
+export class GameEventsCanBeObservedSpec implements Spec<[Game]> {
+  public isSatisfiedBy(game: Game): boolean {
+    return game.state.status === GameStatus.active;
+  }
+}


### PR DESCRIPTION
### Added
- Added `GameEventsCanBeObservedSpec`.

### Changed
- Updated `GameEventsManagementInputPort.subscribeV2` with `Game` argument.
- Updated `GameEventsManagementInputPort.subscribeV2` to rely on `GameEventsCanBeObservedSpec`.
