### PR TITLE
Update getTestMatch() to return an array

### DIFF
--- a/packages/backend/tools/backend-jest-config/lib/config/getJestJsProjectConfig.js
+++ b/packages/backend/tools/backend-jest-config/lib/config/getJestJsProjectConfig.js
@@ -12,7 +12,7 @@ function getJestJsProjectConfig(
   testPathIgnorePatterns,
   extension,
 ) {
-  const testMatch = [getTestMatch(extension, false)];
+  const testMatch = getTestMatch(extension, false);
 
   return getJestProjectConfig(projectName, testMatch, testPathIgnorePatterns);
 }

--- a/packages/backend/tools/backend-jest-config/lib/config/getJestTsProjectConfig.js
+++ b/packages/backend/tools/backend-jest-config/lib/config/getJestTsProjectConfig.js
@@ -12,7 +12,7 @@ function getJestTsProjectConfig(
   testPathIgnorePatterns,
   extension,
 ) {
-  const testMatch = [getTestMatch(extension, true)];
+  const testMatch = getTestMatch(extension, true);
 
   return {
     ...getJestProjectConfig(projectName, testMatch, testPathIgnorePatterns),

--- a/packages/backend/tools/backend-jest-config/lib/config/getTestMatch.js
+++ b/packages/backend/tools/backend-jest-config/lib/config/getTestMatch.js
@@ -3,15 +3,18 @@ import projectRoot from './projectRoot.js';
 /**
  * @param { !string } testExtension Test extension files
  * @param { !boolean } isTargetingSource True if test are under the source folder
- * @returns { !string }
+ * @returns { !Array.<string> }
  */
 function getTestMatch(testExtension, isTargetingSource) {
   let testMatch;
 
   if (isTargetingSource) {
-    testMatch = `${projectRoot}/src/**/*${testExtension}`;
+    testMatch = [`${projectRoot}/src/**/*${testExtension}`];
   } else {
-    testMatch = `${projectRoot}/{dist,lib}/**/*${testExtension}`;
+    testMatch = [
+      `${projectRoot}/{dist,lib}/*${testExtension}`,
+      `${projectRoot}/{dist,lib}/!(esm)/**/*${testExtension}`,
+    ];
   }
 
   return testMatch;


### PR DESCRIPTION
### Changed
- Updated `getTestMatch()` to return an array ignoring esm js files.