### PR TITLE
Add get games events e2e test

### DIFF
--- a/packages/backend/tools/backend-test-e2e/features/games/getGameEvents.feature
+++ b/packages/backend/tools/backend-test-e2e/features/games/getGameEvents.feature
@@ -1,0 +1,19 @@
+Feature: Get game events
+
+  Players can get game events with their user credentials as long as the game is active.
+
+  Rule: The active player can get game events
+
+    Scenario: User subscribes to game and observes its own play
+      Given a user "Bob"
+      And a user auth for "Bob"
+      And a user "Alice"
+      And a user auth for "Alice"
+      And game options with non mandatory card play
+      And a list of cards "( 7y )" as "Bob cards"
+      And a started game with current card "7y" for "Bob" with "Bob cards" and "Alice" created with "Bob" credentials
+      And a game event subscription for game with "Bob" credentials
+      And a game play first card request for game for "Bob"
+      When the update game request is sent
+      And a message event for game is received
+      Then the message event matches the game play first card request

--- a/packages/backend/tools/backend-test-e2e/features/games/updateGame.feature
+++ b/packages/backend/tools/backend-test-e2e/features/games/updateGame.feature
@@ -24,7 +24,7 @@ Feature: Update game
       And game options with non mandatory card play
       And a list of cards "( 7y )" as "Bob cards"
       And a started game with current card "7y" for "Bob" with "Bob cards" and "Alice" created with "Bob" credentials
-      And a game pass play first card request for game for "Bob"
+      And a game play first card request for game for "Bob"
       When the update game request is sent
       Then the update game response should be successful
 

--- a/packages/backend/tools/backend-test-e2e/package.json
+++ b/packages/backend/tools/backend-test-e2e/package.json
@@ -12,6 +12,7 @@
     "@cornie-js/backend-game-application": "workspace:*",
     "@cornie-js/backend-env": "workspace:*",
     "@cornie-js/backend-game-domain": "workspace:*",
+    "@cornie-js/eventsource": "workspace:*",
     "@cucumber/cucumber": "10.4.0",
     "@nestjs/common": "10.3.7",
     "@nestjs/core": "10.3.7",

--- a/packages/backend/tools/backend-test-e2e/src/app/adapter/cucumber/hooks/after.ts
+++ b/packages/backend/tools/backend-test-e2e/src/app/adapter/cucumber/hooks/after.ts
@@ -1,0 +1,8 @@
+import { After } from '@cucumber/cucumber';
+
+import { OneGameApiWorld } from '../../../../http/models/OneGameApiWorld';
+import { disposeWorld } from '../../../../http/utils/actions/disposeWorld';
+
+After<OneGameApiWorld>(async function (this: OneGameApiWorld) {
+  await disposeWorld.bind(this)();
+});

--- a/packages/backend/tools/backend-test-e2e/src/game/models/GameEventSubscriptionV2Parameter.ts
+++ b/packages/backend/tools/backend-test-e2e/src/game/models/GameEventSubscriptionV2Parameter.ts
@@ -1,0 +1,7 @@
+import { models as apiModels } from '@cornie-js/api-models';
+import { EventSource } from '@cornie-js/eventsource';
+
+export interface GameEventSubscriptionV2Parameter {
+  eventSource: EventSource;
+  gameEvents: apiModels.GameEventV2[];
+}

--- a/packages/backend/tools/backend-test-e2e/src/game/modules/CustomEventSource.ts
+++ b/packages/backend/tools/backend-test-e2e/src/game/modules/CustomEventSource.ts
@@ -1,0 +1,25 @@
+import { EventSource, EventSourceInit } from '@cornie-js/eventsource';
+
+export class CustomEventSource extends EventSource {
+  readonly #token: string | undefined;
+
+  constructor(
+    url: string,
+    eventSourceInitDict: EventSourceInit & { token?: string } = {},
+  ) {
+    super(url, eventSourceInitDict);
+
+    this.#token = eventSourceInitDict.token;
+  }
+
+  protected override _buildHeaders(): Headers {
+    // Keep other relevant SSE headers in the base class method.
+    const headers: Headers = super._buildHeaders();
+
+    if (this.#token !== undefined) {
+      headers.set('authorization', `Bearer ${this.#token}`);
+    }
+
+    return headers;
+  }
+}

--- a/packages/backend/tools/backend-test-e2e/src/game/utils/actions/setGameEventSubscription.ts
+++ b/packages/backend/tools/backend-test-e2e/src/game/utils/actions/setGameEventSubscription.ts
@@ -1,0 +1,10 @@
+import { OneGameApiWorld } from '../../../http/models/OneGameApiWorld';
+import { GameEventSubscriptionV2Parameter } from '../../models/GameEventSubscriptionV2Parameter';
+
+export function setGameEventSubscription(
+  this: OneGameApiWorld,
+  alias: string,
+  gameEventSubscription: GameEventSubscriptionV2Parameter,
+): void {
+  this.entities.gameEventSubscriptions.set(alias, gameEventSubscription);
+}

--- a/packages/backend/tools/backend-test-e2e/src/game/utils/calculations/getGameEventSubscriptionOrFail.ts
+++ b/packages/backend/tools/backend-test-e2e/src/game/utils/calculations/getGameEventSubscriptionOrFail.ts
@@ -1,0 +1,17 @@
+import { OneGameApiWorld } from '../../../http/models/OneGameApiWorld';
+import { GameEventSubscriptionV2Parameter } from '../../models/GameEventSubscriptionV2Parameter';
+
+export function getGameEventSubscriptionOrFail(
+  this: OneGameApiWorld,
+  alias: string,
+): GameEventSubscriptionV2Parameter {
+  const gameEventSubscriptionV2Parameter:
+    | GameEventSubscriptionV2Parameter
+    | undefined = this.entities.gameEventSubscriptions.get(alias);
+
+  if (gameEventSubscriptionV2Parameter === undefined) {
+    throw new Error(`Expected game event subscription "${alias}" to be found`);
+  }
+
+  return gameEventSubscriptionV2Parameter;
+}

--- a/packages/backend/tools/backend-test-e2e/src/http/models/OneGameApiWorld.ts
+++ b/packages/backend/tools/backend-test-e2e/src/http/models/OneGameApiWorld.ts
@@ -3,6 +3,7 @@ import { IWorld } from '@cucumber/cucumber';
 
 import { AuthV2Parameter } from '../../auth/models/AuthV2Parameter';
 import { CardArrayV1Parameter } from '../../card/models/CardArrayV1Parameter';
+import { GameEventSubscriptionV2Parameter } from '../../game/models/GameEventSubscriptionV2Parameter';
 import { GameOptionsV1Parameter } from '../../game/models/GameOptionsV1Parameter';
 import { GameV1Parameter } from '../../game/models/GameV1Parameter';
 import { UserV1Parameter } from '../../user/models/UserV1Parameter';
@@ -10,9 +11,14 @@ import { UserV1Parameter } from '../../user/models/UserV1Parameter';
 export interface EntitiesMap {
   auth: Map<string, AuthV2Parameter>;
   cardArrays: Map<string, CardArrayV1Parameter>;
+  gameEventSubscriptions: Map<string, GameEventSubscriptionV2Parameter>;
   gameOptions: Map<string, GameOptionsV1Parameter>;
   games: Map<string, GameV1Parameter>;
   users: Map<string, UserV1Parameter>;
+}
+
+export interface Environment {
+  backendBaseUrl: string;
 }
 
 export type RequestMap = {
@@ -28,6 +34,7 @@ export type ResponseMap = {
 
 export interface OneGameApiWorld extends IWorld {
   entities: EntitiesMap;
+  env: Environment;
   httpClient: HttpClient;
   requestParameters: RequestMap;
   responses: ResponseMap;

--- a/packages/backend/tools/backend-test-e2e/src/http/utils/actions/disposeWorld.ts
+++ b/packages/backend/tools/backend-test-e2e/src/http/utils/actions/disposeWorld.ts
@@ -1,0 +1,7 @@
+import { OneGameApiWorld } from '../../models/OneGameApiWorld';
+
+export async function disposeWorld(this: OneGameApiWorld): Promise<void> {
+  for (const gameEventSubscription of this.entities.gameEventSubscriptions.values()) {
+    gameEventSubscription.eventSource.close();
+  }
+}

--- a/packages/backend/tools/backend-test-e2e/src/http/utils/actions/initializeWorld.ts
+++ b/packages/backend/tools/backend-test-e2e/src/http/utils/actions/initializeWorld.ts
@@ -9,9 +9,13 @@ export function initializeWorld(
   this.entities = {
     auth: new Map(),
     cardArrays: new Map(),
+    gameEventSubscriptions: new Map(),
     gameOptions: new Map(),
     games: new Map(),
     users: new Map(),
+  };
+  this.env = {
+    backendBaseUrl: baseUrl,
   };
   this.httpClient = new HttpClient(baseUrl);
   this.requestParameters = {};


### PR DESCRIPTION
### Added
- Added `getGameEventsFeature`.
- Added `setGameEventSubscription`.
- Added `getGameEventSubscriptionOrFail`.
- Added after hook.
- Added `disposeWorld`.
- Added `CustomEventSource`.
- Added `GameEventSubscriptionV2Parameter`.

### Changed
- Update dependencies with `eventsource`.
- Updated `OneGameApiWorld` with `gameEventSubscriptions`.