### PR TITLE
Create createGame using buildSingleApiCallHook

### DIFF
--- a/packages/frontend/web-ui/src/game/hooks/useCreateGame/index.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useCreateGame/index.ts
@@ -1,0 +1,14 @@
+import { buildSingleApiCallHook } from '../../../common/helpers/buildSingleApiCallHook';
+import { buildContext } from './utils/buildContext';
+import { buildRequestParams } from './utils/buildRequestParams';
+import { buildErrorMessage } from './utils/buildErrorMessage';
+import { buildResult } from './utils/buildResult';
+
+export const useCreateGame = () =>
+  buildSingleApiCallHook({
+    buildContext,
+    buildErrorMessage,
+    buildRequestParams,
+    buildResult,
+    endpoint: 'createGame',
+  });

--- a/packages/frontend/web-ui/src/game/hooks/useCreateGame/models/UseCreateGameContext.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useCreateGame/models/UseCreateGameContext.ts
@@ -1,0 +1,3 @@
+export interface UseCreateGameContext {
+  token: string | null;
+}

--- a/packages/frontend/web-ui/src/game/hooks/useCreateGame/models/UseCreateGameParams.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useCreateGame/models/UseCreateGameParams.ts
@@ -1,0 +1,5 @@
+import { models as apiModels } from '@cornie-js/api-models';
+
+export interface UseCreateGameParams {
+  body: apiModels.GameCreateQueryV1;
+}

--- a/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/buildContext.spec.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/buildContext.spec.ts
@@ -1,0 +1,71 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('../../../../app/store/hooks');
+
+import { buildContext } from './buildContext';
+import { useAppSelector } from '../../../../app/store/hooks';
+import { UseCreateGameContext } from '../models/UseCreateGameContext';
+
+describe(buildContext.name, () => {
+  describe('when called, and useAppSelector returns an authenticated AuthState', () => {
+    let tokenFixture: string;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      tokenFixture = 'token-fixture';
+
+      (useAppSelector as jest.Mock<typeof useAppSelector>).mockReturnValueOnce(
+        tokenFixture,
+      );
+
+      result = buildContext();
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call useAppSelector()', () => {
+      expect(useAppSelector).toHaveBeenCalledTimes(1);
+      expect(useAppSelector).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('should return token', () => {
+      const expected: UseCreateGameContext = {
+        token: tokenFixture,
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+
+  describe('when called, and useAppSelector returns a non authenticated AuthState', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      (useAppSelector as jest.Mock<typeof useAppSelector>).mockReturnValueOnce(
+        null,
+      );
+
+      result = buildContext();
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call useAppSelector()', () => {
+      expect(useAppSelector).toHaveBeenCalledTimes(1);
+      expect(useAppSelector).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('should return null', () => {
+      const expected: UseCreateGameContext = {
+        token: null,
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/buildContext.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/buildContext.ts
@@ -1,0 +1,11 @@
+import { selectAuthToken } from '../../../../app/store/features/authSlice';
+import { useAppSelector } from '../../../../app/store/hooks';
+import { UseCreateGameContext } from '../models/UseCreateGameContext';
+
+export function buildContext(): UseCreateGameContext {
+  const token: string | null = useAppSelector(selectAuthToken);
+
+  return {
+    token,
+  };
+}

--- a/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/buildErrorMessage.spec.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/buildErrorMessage.spec.ts
@@ -1,0 +1,17 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+import { buildErrorMessage } from './buildErrorMessage';
+import { UNEXPECTED_ERROR_MESSAGE } from './unexpectedErrorMessage';
+
+describe(buildErrorMessage.name, () => {
+  describe('when called', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      result = buildErrorMessage();
+    });
+
+    it('should return string', () => {
+      expect(result).toBe(UNEXPECTED_ERROR_MESSAGE);
+    });
+  });
+});

--- a/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/buildErrorMessage.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/buildErrorMessage.ts
@@ -1,0 +1,5 @@
+import { UNEXPECTED_ERROR_MESSAGE } from './unexpectedErrorMessage';
+
+export function buildErrorMessage(): string {
+  return UNEXPECTED_ERROR_MESSAGE;
+}

--- a/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/buildRequestParams.spec.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/buildRequestParams.spec.ts
@@ -1,0 +1,100 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+import { buildRequestParams } from './buildRequestParams';
+import { UseCreateGameContext } from '../models/UseCreateGameContext';
+import { HttpApiParams } from '../../../../common/http/models/HttpApiParams';
+import { FormFieldsNewGame } from '../../../models/FormFieldsNewGame';
+
+describe(buildRequestParams.name, () => {
+  let contextFixture: UseCreateGameContext;
+
+  beforeAll(() => {
+    contextFixture = {
+      token: 'token-fixture',
+    };
+  });
+
+  describe('having params with name', () => {
+    let paramsFixture: FormFieldsNewGame;
+
+    beforeAll(() => {
+      paramsFixture = {
+        name: 'name-fixture',
+        players: 2,
+        options: {
+          chainDraw2Draw2Cards: false,
+          chainDraw2Draw4Cards: false,
+          chainDraw4Draw4Cards: false,
+          chainDraw4Draw2Cards: false,
+          playCardIsMandatory: false,
+          playMultipleSameCards: false,
+          playWildDraw4IfNoOtherAlternative: true,
+        },
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildRequestParams(contextFixture, paramsFixture);
+      });
+
+      it('should return request params', () => {
+        const expected: HttpApiParams<'createGame'> = [
+          {
+            authorization: `Bearer ${contextFixture.token}`,
+          },
+          {
+            gameSlotsAmount: paramsFixture.players,
+            name: paramsFixture.name as string,
+            options: paramsFixture.options,
+          },
+        ];
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having params without name', () => {
+    let paramsFixture: FormFieldsNewGame;
+
+    beforeAll(() => {
+      paramsFixture = {
+        name: undefined,
+        players: 2,
+        options: {
+          chainDraw2Draw2Cards: false,
+          chainDraw2Draw4Cards: false,
+          chainDraw4Draw4Cards: false,
+          chainDraw4Draw2Cards: false,
+          playCardIsMandatory: false,
+          playMultipleSameCards: false,
+          playWildDraw4IfNoOtherAlternative: true,
+        },
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildRequestParams(contextFixture, paramsFixture);
+      });
+
+      it('should return request params', () => {
+        const expected: HttpApiParams<'createGame'> = [
+          {
+            authorization: `Bearer ${contextFixture.token}`,
+          },
+          {
+            gameSlotsAmount: paramsFixture.players,
+            options: paramsFixture.options,
+          },
+        ];
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+});

--- a/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/buildRequestParams.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/buildRequestParams.ts
@@ -1,0 +1,38 @@
+import { HttpApiParams } from '../../../../common/http/models/HttpApiParams';
+import { UseCreateGameContext } from '../models/UseCreateGameContext';
+import { UseCreateGameParams } from '../models/UseCreateGameParams';
+import { FormFieldsNewGame } from '../../../models/FormFieldsNewGame';
+
+export function buildRequestParams(
+  context: UseCreateGameContext,
+  params: FormFieldsNewGame,
+): HttpApiParams<'createGame'> {
+  return [
+    {
+      authorization: `Bearer ${context.token}`,
+    },
+    buildQuery(params).body,
+  ];
+}
+
+function buildQuery(params: FormFieldsNewGame): UseCreateGameParams {
+  let bodyQuery: UseCreateGameParams;
+
+  if (params.name !== undefined) {
+    bodyQuery = {
+      body: {
+        gameSlotsAmount: params.players,
+        options: params.options,
+        name: params.name,
+      },
+    };
+  } else {
+    bodyQuery = {
+      body: {
+        gameSlotsAmount: params.players,
+        options: params.options,
+      },
+    };
+  }
+  return bodyQuery;
+}

--- a/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/buildResult.spec.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/buildResult.spec.ts
@@ -1,0 +1,80 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { models as apiModels } from '@cornie-js/api-models';
+import { buildResult } from './buildResult';
+import { HttpApiResult } from '../../../../common/http/models/HttpApiResult';
+import { Left, Right } from '../../../../common/models/Either';
+import { HTTP_BAD_REQUEST_ERROR_MESSAGE } from './unexpectedErrorMessage';
+import { HttpSpecificResponse } from '../../../../common/http/models/HttpSpecificResponse';
+
+type CreateGameBadRequestResponse = HttpSpecificResponse<
+  HttpApiResult<'createGame'>,
+  400
+>;
+
+type CreateGameOkResponse = HttpSpecificResponse<
+  HttpApiResult<'createGame'>,
+  200
+>;
+
+describe(buildResult.name, () => {
+  describe('having a response with status code 200', () => {
+    let responseFixture: CreateGameOkResponse;
+
+    beforeAll(() => {
+      responseFixture = {
+        body: Symbol() as unknown as apiModels.NonStartedGameV1,
+        headers: {},
+        statusCode: 200,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildResult(responseFixture);
+      });
+
+      it('should return Right', () => {
+        const expected: Right<apiModels.NonStartedGameV1> = {
+          isRight: true,
+          value: responseFixture.body,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having a response with status code different than 200', () => {
+    let responseFixture: CreateGameBadRequestResponse;
+
+    beforeAll(() => {
+      responseFixture = {
+        body: {
+          description: 'sample-description',
+        },
+        headers: {},
+        statusCode: 400,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildResult(responseFixture);
+      });
+
+      it('should return Left', () => {
+        const expected: Left<string> = {
+          isRight: false,
+          value: HTTP_BAD_REQUEST_ERROR_MESSAGE,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+});

--- a/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/buildResult.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/buildResult.ts
@@ -1,0 +1,41 @@
+import { models as apiModels } from '@cornie-js/api-models';
+import { HttpApiResult } from '../../../../common/http/models/HttpApiResult';
+import { Either } from '../../../../common/models/Either';
+import {
+  FORBIDDEN_ERROR_MESSAGE,
+  HTTP_BAD_REQUEST_ERROR_MESSAGE,
+  UNAUTHORIZED_ERROR_MESSAGE,
+  UNEXPECTED_ERROR_MESSAGE,
+} from './unexpectedErrorMessage';
+
+export function buildResult(
+  response: HttpApiResult<'createGame'>,
+): Either<string, apiModels.NonStartedGameV1> {
+  switch (response.statusCode) {
+    case 200:
+      return {
+        isRight: true,
+        value: response.body,
+      };
+    case 400:
+      return {
+        isRight: false,
+        value: HTTP_BAD_REQUEST_ERROR_MESSAGE,
+      };
+    case 401:
+      return {
+        isRight: false,
+        value: UNAUTHORIZED_ERROR_MESSAGE,
+      };
+    case 403:
+      return {
+        isRight: false,
+        value: FORBIDDEN_ERROR_MESSAGE,
+      };
+    default:
+      return {
+        isRight: false,
+        value: UNEXPECTED_ERROR_MESSAGE,
+      };
+  }
+}

--- a/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/unexpectedErrorMessage.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/unexpectedErrorMessage.ts
@@ -1,0 +1,6 @@
+export const UNEXPECTED_ERROR_MESSAGE: string =
+  'Unexpected error when fetching user games';
+export const UNAUTHORIZED_ERROR_MESSAGE: string = 'Unauthorized error.';
+export const HTTP_BAD_REQUEST_ERROR_MESSAGE: string =
+  'Unexpected error occurred while processing the request.';
+export const FORBIDDEN_ERROR_MESSAGE: string = `Forbidden error.`;

--- a/packages/frontend/web-ui/src/game/models/FormFieldsNewGame.ts
+++ b/packages/frontend/web-ui/src/game/models/FormFieldsNewGame.ts
@@ -1,7 +1,7 @@
-import { models as apiModels } from '@cornie-js/api-models';
+import { GameOptions } from './GameOptions';
 
 export interface FormFieldsNewGame {
-  name?: string;
-  players: string;
-  options: apiModels.GameOptionsV1;
+  name: string | undefined;
+  players: number;
+  options: GameOptions;
 }

--- a/packages/frontend/web-ui/src/game/models/GameOptions.ts
+++ b/packages/frontend/web-ui/src/game/models/GameOptions.ts
@@ -1,0 +1,9 @@
+export interface GameOptions {
+  chainDraw2Draw2Cards: boolean;
+  chainDraw2Draw4Cards: boolean;
+  chainDraw4Draw2Cards: boolean;
+  chainDraw4Draw4Cards: boolean;
+  playCardIsMandatory: boolean;
+  playMultipleSameCards: boolean;
+  playWildDraw4IfNoOtherAlternative: boolean;
+}


### PR DESCRIPTION
### Changed:

- Modify `FormFIeldsNewGame.ts` to properties `name` and `players`.
- Added new type `GameOptions`.
- Added new hook `useCreateGame` with their `models` and `utils`, and their tests.