### PR TITLE
Adopt react hook conventions

### DIFF
--- a/packages/frontend/web-ui/src/app/store/features/authSlice.ts
+++ b/packages/frontend/web-ui/src/app/store/features/authSlice.ts
@@ -95,6 +95,10 @@ export const authSlice = createSlice({
   reducers: {},
 });
 
+export const selectAuth = (state: RootState): AuthState => {
+  return state.auth;
+};
+
 export const selectAuthToken = (state: RootState): string | null => {
   return state.auth.status === AuthStateStatus.authenticated
     ? state.auth.accessToken

--- a/packages/frontend/web-ui/src/common/helpers/useSingleApiCall.int.spec.ts
+++ b/packages/frontend/web-ui/src/common/helpers/useSingleApiCall.int.spec.ts
@@ -3,22 +3,18 @@ jest.mock('../http/services/HttpService');
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 import { HttpClient } from '@cornie-js/api-http-client';
-import {
-  RenderHookResult,
-  act,
-  renderHook,
-  waitFor,
-} from '@testing-library/react';
+import { RenderHookResult, renderHook, waitFor } from '@testing-library/react';
+import { act } from 'react';
 
 import { HttpApiParams } from '../http/models/HttpApiParams';
 import { HttpApiResult } from '../http/models/HttpApiResult';
 import { httpClient } from '../http/services/HttpService';
 import { Either } from '../models/Either';
 import {
-  BuildSingleApiCallHookParams,
-  SingleApiCallHookResult,
-  buildSingleApiCallHook,
-} from './buildSingleApiCallHook';
+  UseSingleApiCallParams,
+  SingleApiCallResult,
+  useSingleApiCall,
+} from './useSingleApiCall';
 
 type TestContext = void;
 type TestParams = void;
@@ -28,23 +24,18 @@ interface TestResult {
   foo: string;
 }
 
-describe(buildSingleApiCallHook.name, () => {
+describe(useSingleApiCall.name, () => {
   let buildSingleApiCallHookParamsMock: jest.Mocked<
-    BuildSingleApiCallHookParams<
-      TestContext,
-      TestParams,
-      TestEndpoint,
-      TestResult
-    >
+    UseSingleApiCallParams<TestContext, TestParams, TestEndpoint, TestResult>
   >;
 
   beforeAll(() => {
     buildSingleApiCallHookParamsMock = {
-      buildContext: jest.fn(),
       buildErrorMessage: jest.fn(),
       buildRequestParams: jest.fn(),
       buildResult: jest.fn(),
       endpoint: 'createAuth',
+      useContext: jest.fn(),
     };
   });
 
@@ -55,7 +46,7 @@ describe(buildSingleApiCallHook.name, () => {
     let resultFixture: Either<string, TestResult>;
 
     let renderHookResult: RenderHookResult<
-      SingleApiCallHookResult<TestParams, TestResult>,
+      SingleApiCallResult<TestParams, TestResult>,
       unknown
     >;
 
@@ -72,9 +63,9 @@ describe(buildSingleApiCallHook.name, () => {
         },
       };
 
-      buildSingleApiCallHookParamsMock.buildContext.mockReturnValueOnce(
-        contextFixture,
-      );
+      buildSingleApiCallHookParamsMock.useContext.mockReturnValue({
+        context: contextFixture,
+      });
       buildSingleApiCallHookParamsMock.buildRequestParams.mockReturnValueOnce(
         httpApiParamsFixture,
       );
@@ -87,7 +78,7 @@ describe(buildSingleApiCallHook.name, () => {
       ].mockResolvedValueOnce(httpApiResultFixture);
 
       renderHookResult = renderHook(() =>
-        buildSingleApiCallHook(buildSingleApiCallHookParamsMock),
+        useSingleApiCall(buildSingleApiCallHookParamsMock),
       );
 
       act(() => {
@@ -102,6 +93,8 @@ describe(buildSingleApiCallHook.name, () => {
 
     afterAll(() => {
       jest.clearAllMocks();
+
+      buildSingleApiCallHookParamsMock.useContext.mockReset();
     });
 
     it('should return a result', () => {

--- a/packages/frontend/web-ui/src/game/hooks/useCreateGame/index.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useCreateGame/index.ts
@@ -1,14 +1,14 @@
-import { buildSingleApiCallHook } from '../../../common/helpers/buildSingleApiCallHook';
-import { buildContext } from './utils/buildContext';
+import { useSingleApiCall } from '../../../common/helpers/useSingleApiCall';
 import { buildErrorMessage } from './utils/buildErrorMessage';
 import { buildRequestParams } from './utils/buildRequestParams';
 import { buildResult } from './utils/buildResult';
+import { useContext } from './utils/useContext';
 
 export const useCreateGame = () =>
-  buildSingleApiCallHook({
-    buildContext,
+  useSingleApiCall({
     buildErrorMessage,
     buildRequestParams,
     buildResult,
     endpoint: 'createGame',
+    useContext,
   });

--- a/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/useContext.spec.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/useContext.spec.ts
@@ -4,9 +4,9 @@ jest.mock('../../../../app/store/hooks');
 
 import { useAppSelector } from '../../../../app/store/hooks';
 import { UseCreateGameContext } from '../models/UseCreateGameContext';
-import { buildContext } from './buildContext';
+import { useContext } from './useContext';
 
-describe(buildContext.name, () => {
+describe(useContext.name, () => {
   describe('when called, and useAppSelector returns an authenticated AuthState', () => {
     let tokenFixture: string;
 
@@ -19,7 +19,7 @@ describe(buildContext.name, () => {
         tokenFixture,
       );
 
-      result = buildContext();
+      result = useContext();
     });
 
     afterAll(() => {
@@ -32,8 +32,8 @@ describe(buildContext.name, () => {
     });
 
     it('should return token', () => {
-      const expected: UseCreateGameContext = {
-        token: tokenFixture,
+      const expected: { context: UseCreateGameContext } = {
+        context: { token: tokenFixture },
       };
 
       expect(result).toStrictEqual(expected);
@@ -48,7 +48,7 @@ describe(buildContext.name, () => {
         null,
       );
 
-      result = buildContext();
+      result = useContext();
     });
 
     afterAll(() => {
@@ -61,8 +61,8 @@ describe(buildContext.name, () => {
     });
 
     it('should return null', () => {
-      const expected: UseCreateGameContext = {
-        token: null,
+      const expected: { context: UseCreateGameContext } = {
+        context: { token: null },
       };
 
       expect(result).toStrictEqual(expected);

--- a/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/useContext.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useCreateGame/utils/useContext.ts
@@ -1,11 +1,11 @@
 import { selectAuthToken } from '../../../../app/store/features/authSlice';
 import { useAppSelector } from '../../../../app/store/hooks';
-import { UseGetGamesContext } from '../models/UseGetGamesContext';
+import { UseCreateGameContext } from '../models/UseCreateGameContext';
 
-export function buildContext(): UseGetGamesContext {
+export function useContext(): { context: UseCreateGameContext } {
   const token: string | null = useAppSelector(selectAuthToken);
 
   return {
-    token,
+    context: { token },
   };
 }

--- a/packages/frontend/web-ui/src/game/hooks/useCreateNewGame.spec.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useCreateNewGame.spec.ts
@@ -16,6 +16,7 @@ import { AuthStateStatus } from '../../app/store/helpers/models/AuthStateStatus'
 import { useAppSelector } from '../../app/store/hooks';
 import { getUserMeId } from '../../common/helpers/getUserMeId';
 import { joinGame } from '../../common/helpers/joinGame';
+import { SingleApiCallResult } from '../../common/helpers/useSingleApiCall';
 import { JoinGameSerializedResponse } from '../../common/http/models/JoinGameSerializedResponse';
 import { UserMeSerializedResponse } from '../../common/http/models/UserMeSerializedResponse';
 import { Either } from '../../common/models/Either';
@@ -24,7 +25,6 @@ import { CreateNewGameResult } from '../models/CreateNewGameResult';
 import { CreateNewGameStatus } from '../models/CreateNewGameStatus';
 import { FormFieldsNewGame } from '../models/FormFieldsNewGame';
 import { GameOptions } from '../models/GameOptions';
-import { SingleApiCallHookResult } from './../../common/helpers/buildSingleApiCallHook';
 import { FormNewGameValidationErrorResult } from './../models/FormNewGameValidationErrorResult';
 import { useCreateGame } from './useCreateGame';
 import { HTTP_BAD_REQUEST_ERROR_MESSAGE } from './useCreateGame/utils/unexpectedErrorMessage';
@@ -37,7 +37,7 @@ describe(useCreateNewGame.name, () => {
   let serializableUserIdFixture: UserMeSerializedResponse;
   let serializableJoinGameFixture: JoinGameSerializedResponse;
   let callNewGameMock: jest.Mock<(params: FormFieldsNewGame) => void>;
-  let singleApiCallHookResultFixture: SingleApiCallHookResult<
+  let singleApiCallHookResultFixture: SingleApiCallResult<
     FormFieldsNewGame,
     apiModels.NonStartedGameV1
   >;
@@ -202,7 +202,7 @@ describe(useCreateNewGame.name, () => {
   describe('when called, and API returns an OK response', () => {
     let renderResult: RenderHookResult<CreateNewGameResult, unknown>;
     let status: CreateNewGameStatus;
-    let singleApiCallHookFixture: SingleApiCallHookResult<
+    let singleApiCallHookFixture: SingleApiCallResult<
       FormFieldsNewGame,
       apiModels.NonStartedGameV1
     >;
@@ -295,7 +295,7 @@ describe(useCreateNewGame.name, () => {
     let renderResult: RenderHookResult<CreateNewGameResult, unknown>;
     let backendError: string | null;
     let status: CreateNewGameStatus;
-    let singleApiCallHookFixture: SingleApiCallHookResult<
+    let singleApiCallHookFixture: SingleApiCallResult<
       FormFieldsNewGame,
       apiModels.NonStartedGameV1
     >;

--- a/packages/frontend/web-ui/src/home/hooks/useGetGames/index.ts
+++ b/packages/frontend/web-ui/src/home/hooks/useGetGames/index.ts
@@ -1,14 +1,14 @@
-import { buildSingleApiCallHook } from '../../../common/helpers/buildSingleApiCallHook';
-import { buildContext } from './utils/buildContext';
+import { useSingleApiCall } from '../../../common/helpers/useSingleApiCall';
 import { buildErrorMessage } from './utils/buildErrorMessage';
 import { buildRequestParams } from './utils/buildRequestParams';
 import { buildResult } from './utils/buildResult';
+import { useContext } from './utils/useContext';
 
 export const useGetGames = () =>
-  buildSingleApiCallHook({
-    buildContext,
+  useSingleApiCall({
     buildErrorMessage,
     buildRequestParams,
     buildResult,
     endpoint: 'getGamesMine',
+    useContext,
   });

--- a/packages/frontend/web-ui/src/home/hooks/useGetGames/utils/useContext.spec.ts
+++ b/packages/frontend/web-ui/src/home/hooks/useGetGames/utils/useContext.spec.ts
@@ -4,9 +4,9 @@ jest.mock('../../../../app/store/hooks');
 
 import { useAppSelector } from '../../../../app/store/hooks';
 import { UseGetGamesContext } from '../models/UseGetGamesContext';
-import { buildContext } from './buildContext';
+import { useContext } from './useContext';
 
-describe(buildContext.name, () => {
+describe(useContext.name, () => {
   describe('when called, and useAppSelector returns an authenticated AuthState', () => {
     let tokenFixture: string;
 
@@ -19,7 +19,7 @@ describe(buildContext.name, () => {
         tokenFixture,
       );
 
-      result = buildContext();
+      result = useContext();
     });
 
     afterAll(() => {
@@ -32,8 +32,10 @@ describe(buildContext.name, () => {
     });
 
     it('should return token', () => {
-      const expected: UseGetGamesContext = {
-        token: tokenFixture,
+      const expected: { context: UseGetGamesContext } = {
+        context: {
+          token: tokenFixture,
+        },
       };
 
       expect(result).toStrictEqual(expected);
@@ -48,7 +50,7 @@ describe(buildContext.name, () => {
         null,
       );
 
-      result = buildContext();
+      result = useContext();
     });
 
     afterAll(() => {
@@ -61,8 +63,10 @@ describe(buildContext.name, () => {
     });
 
     it('should return null', () => {
-      const expected: UseGetGamesContext = {
-        token: null,
+      const expected: { context: UseGetGamesContext } = {
+        context: {
+          token: null,
+        },
       };
 
       expect(result).toStrictEqual(expected);

--- a/packages/frontend/web-ui/src/home/hooks/useGetGames/utils/useContext.ts
+++ b/packages/frontend/web-ui/src/home/hooks/useGetGames/utils/useContext.ts
@@ -1,11 +1,11 @@
 import { selectAuthToken } from '../../../../app/store/features/authSlice';
 import { useAppSelector } from '../../../../app/store/hooks';
-import { UseCreateGameContext } from '../models/UseCreateGameContext';
+import { UseGetGamesContext } from '../models/UseGetGamesContext';
 
-export function buildContext(): UseCreateGameContext {
+export function useContext(): { context: UseGetGamesContext } {
   const token: string | null = useAppSelector(selectAuthToken);
 
   return {
-    token,
+    context: { token },
   };
 }

--- a/packages/frontend/web-ui/src/home/pages/CornieHome.spec.tsx
+++ b/packages/frontend/web-ui/src/home/pages/CornieHome.spec.tsx
@@ -1,11 +1,21 @@
 jest.mock('../../app/store/hooks');
+jest.mock('../components/Home', () => ({
+  Home: () => {
+    return <div id="home-page">Home fixture</div>;
+  },
+}));
+jest.mock('../components/HomeWithAuth', () => ({
+  HomeWithAuth: () => {
+    return <div id="home-page-with-auth">Home with auth fixture</div>;
+  },
+}));
 
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 import { RenderResult, render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
-import { AuthenticatedAuthState } from '../../app/store/helpers/models/AuthState';
+import { AuthState } from '../../app/store/helpers/models/AuthState';
 import { AuthStateStatus } from '../../app/store/helpers/models/AuthStateStatus';
 import { useAppSelector } from '../../app/store/hooks';
 import { CornieHome } from './CornieHome';
@@ -14,19 +24,19 @@ const HOME_PAGE = '#home-page';
 const HOME_PAGE_WITH_AUTH = '#home-page-with-auth';
 
 describe(CornieHome.name, () => {
-  let authenticateAuthStateFixture: AuthenticatedAuthState | null;
+  describe('when called, and useSelector() returns a not authenticated state', () => {
+    let authStateFixture: AuthState;
 
-  beforeAll(() => {
-    authenticateAuthStateFixture = null;
-  });
-
-  describe('when called, and useSelector() returns a null accessToken', () => {
     let shownPage: Element | null;
 
     beforeAll(() => {
+      authStateFixture = {
+        status: AuthStateStatus.nonAuthenticated,
+      };
+
       (
         useAppSelector as unknown as jest.Mock<typeof useAppSelector>
-      ).mockReturnValueOnce(authenticateAuthStateFixture);
+      ).mockReturnValueOnce(authStateFixture);
 
       const renderResult: RenderResult = render(
         <MemoryRouter>
@@ -43,15 +53,17 @@ describe(CornieHome.name, () => {
     });
 
     it('should return a <Home /> page', () => {
-      expect(shownPage).not.toBe(undefined);
+      expect(shownPage).not.toBeNull();
+      expect((shownPage as Element).innerHTML).toBe('Home fixture');
     });
   });
 
   describe('when called, and useSelector() returns a valid accessToken', () => {
+    let authStateFixture: AuthState;
     let shownPage: Element | null;
 
     beforeAll(() => {
-      authenticateAuthStateFixture = {
+      authStateFixture = {
         accessToken: 'accessToken-fixture',
         refreshToken: 'refreshToken-fixture',
         status: AuthStateStatus.authenticated,
@@ -59,7 +71,7 @@ describe(CornieHome.name, () => {
 
       (
         useAppSelector as unknown as jest.Mock<typeof useAppSelector>
-      ).mockReturnValueOnce(authenticateAuthStateFixture);
+      ).mockReturnValueOnce(authStateFixture);
 
       const renderResult: RenderResult = render(
         <MemoryRouter>
@@ -76,7 +88,8 @@ describe(CornieHome.name, () => {
     });
 
     it('should return a <HomeWithAuth /> page', () => {
-      expect(shownPage).not.toBe(undefined);
+      expect(shownPage).not.toBeNull();
+      expect((shownPage as Element).innerHTML).toBe('Home with auth fixture');
     });
   });
 });

--- a/packages/frontend/web-ui/src/home/pages/CornieHome.tsx
+++ b/packages/frontend/web-ui/src/home/pages/CornieHome.tsx
@@ -1,17 +1,16 @@
 import React from 'react';
 
-import { selectAuthenticatedAuth } from '../../app/store/features/authSlice';
-import { AuthenticatedAuthState } from '../../app/store/helpers/models/AuthState';
+import { selectAuth } from '../../app/store/features/authSlice';
+import { AuthState } from '../../app/store/helpers/models/AuthState';
+import { AuthStateStatus } from '../../app/store/helpers/models/AuthStateStatus';
 import { useAppSelector } from '../../app/store/hooks';
 import { Home } from '../components/Home';
 import { HomeWithAuth } from '../components/HomeWithAuth';
 
 export const CornieHome = (): React.JSX.Element => {
-  const auth: AuthenticatedAuthState | null = useAppSelector(
-    selectAuthenticatedAuth,
-  );
+  const auth: AuthState = useAppSelector(selectAuth);
 
-  if (auth === null) {
+  if (auth.status === AuthStateStatus.nonAuthenticated) {
     return <Home />;
   } else {
     return <HomeWithAuth />;


### PR DESCRIPTION
### Changed
- Update `CornieHome` to rely on auth state status.
- Rename `buildSingleApiHook` and related interfaces and modules to adopt react conventions.