### PR TITLE
Add use user info hook

### DIFF
--- a/packages/frontend/libraries/frontend-api-rtk-query/src/index.ts
+++ b/packages/frontend/libraries/frontend-api-rtk-query/src/index.ts
@@ -26,7 +26,12 @@ import { UpdateUsersV1MeArgs } from './users/models/UpdateUsersV1MeArgs';
 import { updateUsersV1Me } from './users/mutations/updateUsersV1Me';
 import { getUsersV1Me } from './users/queries/getUsersV1Me';
 
-export type { CreateAuthV2Args, SerializableAppError };
+export type {
+  CreateAuthV2Args,
+  GetUsersV1MeArgs,
+  SerializableAppError,
+  UpdateUsersV1MeArgs,
+};
 
 export { ApiTag };
 

--- a/packages/frontend/web-ui/src/common/helpers/mapUseQueryHookResult.spec.ts
+++ b/packages/frontend/web-ui/src/common/helpers/mapUseQueryHookResult.spec.ts
@@ -1,0 +1,79 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { Either } from '../models/Either';
+import {
+  UseQueryStateResult,
+  mapUseQueryHookResult,
+} from './mapUseQueryHookResult';
+
+describe(mapUseQueryHookResult.name, () => {
+  describe.each<
+    [string, UseQueryStateResult<unknown>, Either<string, unknown> | null]
+  >([
+    [
+      'with isLoading true',
+      {
+        error: undefined,
+        isLoading: true,
+      },
+      null,
+    ],
+    [
+      'with isLoading false and result.data undefined and error undefined',
+      {
+        data: undefined,
+        error: undefined,
+        isLoading: false,
+      },
+      {
+        isRight: false,
+        value: '',
+      },
+    ],
+    [
+      'with isLoading false and result.data undefined and error with string',
+      {
+        data: undefined,
+        error: {
+          message: 'message-fixture',
+        },
+        isLoading: false,
+      },
+      {
+        isRight: false,
+        value: 'message-fixture',
+      },
+    ],
+    [
+      'with isLoading false and result.data not undefined',
+      {
+        data: { foo: 'bar' },
+        error: undefined,
+        isLoading: false,
+      },
+      {
+        isRight: true,
+        value: { foo: 'bar' },
+      },
+    ],
+  ])(
+    'having a UseQueryStateResult %s',
+    (
+      _: string,
+      useQueryStateResultFixture: UseQueryStateResult<unknown>,
+      expectedResult: Either<string, unknown> | null,
+    ) => {
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = mapUseQueryHookResult(useQueryStateResultFixture);
+        });
+
+        it('should return expected result', () => {
+          expect(result).toStrictEqual(expectedResult);
+        });
+      });
+    },
+  );
+});

--- a/packages/frontend/web-ui/src/common/helpers/mapUseQueryHookResult.ts
+++ b/packages/frontend/web-ui/src/common/helpers/mapUseQueryHookResult.ts
@@ -1,0 +1,26 @@
+import { SerializableAppError } from '@cornie-js/frontend-api-rtk-query';
+import { SerializedError } from '@reduxjs/toolkit';
+
+import { Either } from '../models/Either';
+
+export interface UseQueryStateResult<TResult> {
+  data?: TResult;
+  error?: SerializableAppError | SerializedError | undefined;
+  isLoading: boolean;
+}
+
+export function mapUseQueryHookResult<TResult>(
+  result: UseQueryStateResult<TResult | undefined>,
+): Either<string, TResult> | null {
+  return result.isLoading
+    ? null
+    : result.data === undefined
+      ? {
+          isRight: false,
+          value: result.error?.message ?? '',
+        }
+      : {
+          isRight: true,
+          value: result.data,
+        };
+}

--- a/packages/frontend/web-ui/src/common/http/services/__mocks__/cornieApi.ts
+++ b/packages/frontend/web-ui/src/common/http/services/__mocks__/cornieApi.ts
@@ -8,6 +8,7 @@ export const cornieApi: jest.Mocked<typeof originalCornieApi> = {
   useCreateGamesV1SlotsMutation: jest.fn(),
   useGetGamesV1MineQuery: jest.fn(),
   useGetUsersV1MeQuery: jest.fn(),
+  useUpdateUsersV1MeMutation: jest.fn(),
 } as Partial<jest.Mocked<typeof originalCornieApi>> as jest.Mocked<
   typeof originalCornieApi
 >;

--- a/packages/frontend/web-ui/src/user/hooks/useUserInfo.spec.ts
+++ b/packages/frontend/web-ui/src/user/hooks/useUserInfo.spec.ts
@@ -1,0 +1,459 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('../../common/helpers/mapUseQueryHookResult');
+jest.mock('../../common/http/services/cornieApi');
+
+import { models as apiModels } from '@cornie-js/api-models';
+import { UpdateUsersV1MeArgs } from '@cornie-js/frontend-api-rtk-query';
+import { QueryStatus } from '@reduxjs/toolkit/query';
+import { RenderHookResult, renderHook, waitFor } from '@testing-library/react';
+import { act } from 'react';
+
+import { mapUseQueryHookResult } from '../../common/helpers/mapUseQueryHookResult';
+import { cornieApi } from '../../common/http/services/cornieApi';
+import { Either } from '../../common/models/Either';
+import { UserInfoStatus } from '../models/UserInfoStatus';
+import { UseUserInfoResult, useUserInfo } from './useUserInfo';
+
+describe(useUserInfo.name, () => {
+  describe('when called', () => {
+    let useGetUsersV1MeQueryResultMock: jest.Mocked<
+      ReturnType<typeof cornieApi.useGetUsersV1MeQuery>
+    >;
+    let useUpdateUsersV1MeMutationResultMock: jest.Mocked<
+      ReturnType<typeof cornieApi.useUpdateUsersV1MeMutation>
+    >;
+    let usersV1MeResultFixture: Either<string, apiModels.UserV1> | null;
+
+    let renderResult: RenderHookResult<UseUserInfoResult, unknown>;
+
+    beforeAll(() => {
+      useGetUsersV1MeQueryResultMock = {
+        data: undefined,
+        error: undefined,
+        isLoading: false,
+        refetch: jest.fn(),
+      };
+
+      useUpdateUsersV1MeMutationResultMock = [
+        jest.fn(),
+        {
+          reset: jest.fn(),
+          status: QueryStatus.uninitialized,
+        },
+      ];
+
+      usersV1MeResultFixture = null;
+
+      (
+        mapUseQueryHookResult as jest.Mock<typeof mapUseQueryHookResult>
+      ).mockReturnValueOnce(usersV1MeResultFixture);
+
+      (
+        cornieApi.useGetUsersV1MeQuery as jest.Mock<
+          typeof cornieApi.useGetUsersV1MeQuery
+        >
+      ).mockReturnValue(useGetUsersV1MeQueryResultMock);
+
+      (
+        cornieApi.useUpdateUsersV1MeMutation as jest.Mock<
+          typeof cornieApi.useUpdateUsersV1MeMutation
+        >
+      ).mockReturnValueOnce(useUpdateUsersV1MeMutationResultMock);
+
+      renderResult = renderHook(() => useUserInfo());
+
+      jest.clearAllMocks();
+    });
+
+    describe('when updateUser is called', () => {
+      let userMeUpdateQueryV1Fixture: apiModels.UserMeUpdateQueryV1;
+
+      beforeAll(async () => {
+        (
+          mapUseQueryHookResult as jest.Mock<typeof mapUseQueryHookResult>
+        ).mockReturnValueOnce(usersV1MeResultFixture);
+
+        (
+          cornieApi.useGetUsersV1MeQuery as jest.Mock<
+            typeof cornieApi.useGetUsersV1MeQuery
+          >
+        ).mockReturnValue(useGetUsersV1MeQueryResultMock);
+
+        (
+          cornieApi.useUpdateUsersV1MeMutation as jest.Mock<
+            typeof cornieApi.useUpdateUsersV1MeMutation
+          >
+        ).mockReturnValueOnce(useUpdateUsersV1MeMutationResultMock);
+
+        userMeUpdateQueryV1Fixture = {
+          name: 'name-fixture',
+        };
+
+        const updateUser: (
+          userMeUpdateQueryV1: apiModels.UserMeUpdateQueryV1,
+        ) => void = renderResult.result.current.updateUser;
+
+        act(() => {
+          updateUser(userMeUpdateQueryV1Fixture);
+        });
+
+        await waitFor(() => {
+          // eslint-disable-next-line jest/no-standalone-expect
+          expect(renderResult.result.current.status).toBe(
+            UserInfoStatus.updatingUser,
+          );
+        });
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call cornieApi.useGetUsersV1MeQuery()', () => {
+        const expectedParams: Parameters<
+          typeof cornieApi.useGetUsersV1MeQuery
+        > = [
+          {
+            params: [],
+          },
+        ];
+
+        expect(cornieApi.useGetUsersV1MeQuery).toHaveBeenCalledTimes(1);
+        expect(cornieApi.useGetUsersV1MeQuery).toHaveBeenCalledWith(
+          ...expectedParams,
+        );
+      });
+
+      it('should call cornieApi.useUpdateUsersV1MeMutation', () => {
+        expect(cornieApi.useUpdateUsersV1MeMutation).toHaveBeenCalledTimes(1);
+        expect(cornieApi.useUpdateUsersV1MeMutation).toHaveBeenCalledWith();
+      });
+
+      it('should call mapUseQueryHookResult()', () => {
+        expect(mapUseQueryHookResult).toHaveBeenCalledTimes(1);
+        expect(mapUseQueryHookResult).toHaveBeenCalledWith(
+          useGetUsersV1MeQueryResultMock,
+        );
+      });
+
+      it('should call triggerUpdateUser()', () => {
+        const expected: UpdateUsersV1MeArgs = {
+          params: [userMeUpdateQueryV1Fixture],
+        };
+
+        const [triggerUpdateUserMock] = useUpdateUsersV1MeMutationResultMock;
+
+        expect(triggerUpdateUserMock).toHaveBeenCalledTimes(1);
+        expect(triggerUpdateUserMock).toHaveBeenCalledWith(expected);
+      });
+
+      it('should return expected result', () => {
+        const expected: UseUserInfoResult = {
+          status: UserInfoStatus.updatingUser,
+          updateUser: expect.any(Function) as unknown as (
+            userMeUpdateQueryV1: apiModels.UserMeUpdateQueryV1,
+          ) => void,
+          usersV1MeResult: usersV1MeResultFixture,
+        };
+
+        expect(renderResult.result.current).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('when called, and mapUseQueryHookResult() returns null', () => {
+    let useGetUsersV1MeQueryResultMock: jest.Mocked<
+      ReturnType<typeof cornieApi.useGetUsersV1MeQuery>
+    >;
+    let useUpdateUsersV1MeMutationResultMock: jest.Mocked<
+      ReturnType<typeof cornieApi.useUpdateUsersV1MeMutation>
+    >;
+    let usersV1MeResultFixture: Either<string, apiModels.UserV1> | null;
+
+    let renderResult: RenderHookResult<UseUserInfoResult, unknown>;
+
+    beforeAll(() => {
+      useGetUsersV1MeQueryResultMock = {
+        data: undefined,
+        error: undefined,
+        isLoading: false,
+        refetch: jest.fn(),
+      };
+
+      useUpdateUsersV1MeMutationResultMock = [
+        jest.fn(),
+        {
+          reset: jest.fn(),
+          status: QueryStatus.uninitialized,
+        },
+      ];
+
+      usersV1MeResultFixture = null;
+
+      (
+        mapUseQueryHookResult as jest.Mock<typeof mapUseQueryHookResult>
+      ).mockReturnValueOnce(usersV1MeResultFixture);
+
+      (
+        cornieApi.useGetUsersV1MeQuery as jest.Mock<
+          typeof cornieApi.useGetUsersV1MeQuery
+        >
+      ).mockReturnValue(useGetUsersV1MeQueryResultMock);
+
+      (
+        cornieApi.useUpdateUsersV1MeMutation as jest.Mock<
+          typeof cornieApi.useUpdateUsersV1MeMutation
+        >
+      ).mockReturnValueOnce(useUpdateUsersV1MeMutationResultMock);
+
+      renderResult = renderHook(() => useUserInfo());
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call cornieApi.useGetUsersV1MeQuery()', () => {
+      const expectedParams: Parameters<typeof cornieApi.useGetUsersV1MeQuery> =
+        [
+          {
+            params: [],
+          },
+        ];
+
+      expect(cornieApi.useGetUsersV1MeQuery).toHaveBeenCalledTimes(1);
+      expect(cornieApi.useGetUsersV1MeQuery).toHaveBeenCalledWith(
+        ...expectedParams,
+      );
+    });
+
+    it('should call cornieApi.useUpdateUsersV1MeMutation', () => {
+      expect(cornieApi.useUpdateUsersV1MeMutation).toHaveBeenCalledTimes(1);
+      expect(cornieApi.useUpdateUsersV1MeMutation).toHaveBeenCalledWith();
+    });
+
+    it('should call mapUseQueryHookResult()', () => {
+      expect(mapUseQueryHookResult).toHaveBeenCalledTimes(1);
+      expect(mapUseQueryHookResult).toHaveBeenCalledWith(
+        useGetUsersV1MeQueryResultMock,
+      );
+    });
+
+    it('should return expected result', () => {
+      const expected: UseUserInfoResult = {
+        status: UserInfoStatus.fetchingUser,
+        updateUser: expect.any(Function) as unknown as (
+          userMeUpdateQueryV1: apiModels.UserMeUpdateQueryV1,
+        ) => void,
+        usersV1MeResult: usersV1MeResultFixture,
+      };
+
+      expect(renderResult.result.current).toStrictEqual(expected);
+    });
+  });
+
+  describe('when called, and mapUseQueryHookResult() returns Left', () => {
+    let useGetUsersV1MeQueryResultMock: jest.Mocked<
+      ReturnType<typeof cornieApi.useGetUsersV1MeQuery>
+    >;
+    let useUpdateUsersV1MeMutationResultMock: jest.Mocked<
+      ReturnType<typeof cornieApi.useUpdateUsersV1MeMutation>
+    >;
+    let usersV1MeResultFixture: Either<string, apiModels.UserV1> | null;
+
+    let renderResult: RenderHookResult<UseUserInfoResult, unknown>;
+
+    beforeAll(() => {
+      useGetUsersV1MeQueryResultMock = {
+        data: undefined,
+        error: undefined,
+        isLoading: false,
+        refetch: jest.fn(),
+      };
+
+      useUpdateUsersV1MeMutationResultMock = [
+        jest.fn(),
+        {
+          reset: jest.fn(),
+          status: QueryStatus.uninitialized,
+        },
+      ];
+
+      usersV1MeResultFixture = {
+        isRight: false,
+        value: 'error-message-fixture',
+      };
+
+      (mapUseQueryHookResult as jest.Mock<typeof mapUseQueryHookResult>)
+        .mockReturnValueOnce(usersV1MeResultFixture)
+        .mockReturnValueOnce(usersV1MeResultFixture);
+
+      (
+        cornieApi.useGetUsersV1MeQuery as jest.Mock<
+          typeof cornieApi.useGetUsersV1MeQuery
+        >
+      )
+        .mockReturnValue(useGetUsersV1MeQueryResultMock)
+        .mockReturnValue(useGetUsersV1MeQueryResultMock);
+
+      (
+        cornieApi.useUpdateUsersV1MeMutation as jest.Mock<
+          typeof cornieApi.useUpdateUsersV1MeMutation
+        >
+      )
+        .mockReturnValueOnce(useUpdateUsersV1MeMutationResultMock)
+        .mockReturnValueOnce(useUpdateUsersV1MeMutationResultMock);
+
+      act(() => {
+        renderResult = renderHook(() => useUserInfo());
+      });
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call cornieApi.useGetUsersV1MeQuery()', () => {
+      const expectedParams: Parameters<typeof cornieApi.useGetUsersV1MeQuery> =
+        [
+          {
+            params: [],
+          },
+        ];
+
+      expect(cornieApi.useGetUsersV1MeQuery).toHaveBeenCalledTimes(2);
+      expect(cornieApi.useGetUsersV1MeQuery).toHaveBeenCalledWith(
+        ...expectedParams,
+      );
+    });
+
+    it('should call cornieApi.useUpdateUsersV1MeMutation', () => {
+      expect(cornieApi.useUpdateUsersV1MeMutation).toHaveBeenCalledTimes(2);
+      expect(cornieApi.useUpdateUsersV1MeMutation).toHaveBeenCalledWith();
+    });
+
+    it('should call mapUseQueryHookResult()', () => {
+      expect(mapUseQueryHookResult).toHaveBeenCalledTimes(2);
+      expect(mapUseQueryHookResult).toHaveBeenCalledWith(
+        useGetUsersV1MeQueryResultMock,
+      );
+    });
+
+    it('should return expected result', () => {
+      const expected: UseUserInfoResult = {
+        status: UserInfoStatus.userFetchError,
+        updateUser: expect.any(Function) as unknown as (
+          userMeUpdateQueryV1: apiModels.UserMeUpdateQueryV1,
+        ) => void,
+        usersV1MeResult: usersV1MeResultFixture,
+      };
+
+      expect(renderResult.result.current).toStrictEqual(expected);
+    });
+  });
+
+  describe('when called, and mapUseQueryHookResult() returns Right', () => {
+    let useGetUsersV1MeQueryResultMock: jest.Mocked<
+      ReturnType<typeof cornieApi.useGetUsersV1MeQuery>
+    >;
+    let useUpdateUsersV1MeMutationResultMock: jest.Mocked<
+      ReturnType<typeof cornieApi.useUpdateUsersV1MeMutation>
+    >;
+    let usersV1MeResultFixture: Either<string, apiModels.UserV1> | null;
+
+    let renderResult: RenderHookResult<UseUserInfoResult, unknown>;
+
+    beforeAll(() => {
+      useGetUsersV1MeQueryResultMock = {
+        data: undefined,
+        error: undefined,
+        isLoading: false,
+        refetch: jest.fn(),
+      };
+
+      useUpdateUsersV1MeMutationResultMock = [
+        jest.fn(),
+        {
+          reset: jest.fn(),
+          status: QueryStatus.uninitialized,
+        },
+      ];
+
+      usersV1MeResultFixture = {
+        isRight: true,
+        value: {
+          active: true,
+          id: 'id-fixture',
+          name: 'name-fixture',
+        },
+      };
+
+      (mapUseQueryHookResult as jest.Mock<typeof mapUseQueryHookResult>)
+        .mockReturnValueOnce(usersV1MeResultFixture)
+        .mockReturnValueOnce(usersV1MeResultFixture);
+
+      (
+        cornieApi.useGetUsersV1MeQuery as jest.Mock<
+          typeof cornieApi.useGetUsersV1MeQuery
+        >
+      )
+        .mockReturnValue(useGetUsersV1MeQueryResultMock)
+        .mockReturnValue(useGetUsersV1MeQueryResultMock);
+
+      (
+        cornieApi.useUpdateUsersV1MeMutation as jest.Mock<
+          typeof cornieApi.useUpdateUsersV1MeMutation
+        >
+      )
+        .mockReturnValueOnce(useUpdateUsersV1MeMutationResultMock)
+        .mockReturnValueOnce(useUpdateUsersV1MeMutationResultMock);
+
+      act(() => {
+        renderResult = renderHook(() => useUserInfo());
+      });
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call cornieApi.useGetUsersV1MeQuery()', () => {
+      const expectedParams: Parameters<typeof cornieApi.useGetUsersV1MeQuery> =
+        [
+          {
+            params: [],
+          },
+        ];
+
+      expect(cornieApi.useGetUsersV1MeQuery).toHaveBeenCalledTimes(2);
+      expect(cornieApi.useGetUsersV1MeQuery).toHaveBeenCalledWith(
+        ...expectedParams,
+      );
+    });
+
+    it('should call cornieApi.useUpdateUsersV1MeMutation', () => {
+      expect(cornieApi.useUpdateUsersV1MeMutation).toHaveBeenCalledTimes(2);
+      expect(cornieApi.useUpdateUsersV1MeMutation).toHaveBeenCalledWith();
+    });
+
+    it('should call mapUseQueryHookResult()', () => {
+      expect(mapUseQueryHookResult).toHaveBeenCalledTimes(2);
+      expect(mapUseQueryHookResult).toHaveBeenCalledWith(
+        useGetUsersV1MeQueryResultMock,
+      );
+    });
+
+    it('should return expected result', () => {
+      const expected: UseUserInfoResult = {
+        status: UserInfoStatus.idle,
+        updateUser: expect.any(Function) as unknown as (
+          userMeUpdateQueryV1: apiModels.UserMeUpdateQueryV1,
+        ) => void,
+        usersV1MeResult: usersV1MeResultFixture,
+      };
+
+      expect(renderResult.result.current).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/frontend/web-ui/src/user/hooks/useUserInfo.ts
+++ b/packages/frontend/web-ui/src/user/hooks/useUserInfo.ts
@@ -1,0 +1,54 @@
+import { models as apiModels } from '@cornie-js/api-models';
+import { useEffect, useState } from 'react';
+
+import { mapUseQueryHookResult } from '../../common/helpers/mapUseQueryHookResult';
+import { cornieApi } from '../../common/http/services/cornieApi';
+import { Either } from '../../common/models/Either';
+import { UserInfoStatus } from '../models/UserInfoStatus';
+
+export interface UseUserInfoResult {
+  status: UserInfoStatus;
+  updateUser: (userMeUpdateQueryV1: apiModels.UserMeUpdateQueryV1) => void;
+  usersV1MeResult: Either<string, apiModels.UserV1> | null;
+}
+
+export const useUserInfo = (): UseUserInfoResult => {
+  const [status, setStatus] = useState<UserInfoStatus>(
+    UserInfoStatus.fetchingUser,
+  );
+
+  const [triggerUpdateUser] = cornieApi.useUpdateUsersV1MeMutation();
+
+  const useGetUsersV1MeQueryResult = cornieApi.useGetUsersV1MeQuery({
+    params: [],
+  });
+
+  const usersV1MeResult: Either<string, apiModels.UserV1> | null =
+    mapUseQueryHookResult(useGetUsersV1MeQueryResult);
+
+  function updateUser(
+    userMeUpdateQueryV1: apiModels.UserMeUpdateQueryV1,
+  ): void {
+    setStatus(UserInfoStatus.updatingUser);
+
+    void triggerUpdateUser({
+      params: [userMeUpdateQueryV1],
+    });
+  }
+
+  useEffect(() => {
+    if (usersV1MeResult !== null) {
+      if (usersV1MeResult.isRight) {
+        setStatus(UserInfoStatus.idle);
+      } else {
+        setStatus(UserInfoStatus.userFetchError);
+      }
+    }
+  }, [useGetUsersV1MeQueryResult]);
+
+  return {
+    status,
+    updateUser,
+    usersV1MeResult,
+  };
+};

--- a/packages/frontend/web-ui/src/user/models/UserInfoStatus.ts
+++ b/packages/frontend/web-ui/src/user/models/UserInfoStatus.ts
@@ -1,0 +1,6 @@
+export enum UserInfoStatus {
+  fetchingUser = 'fetchingUser',
+  idle = 'idle',
+  updatingUser = 'pendingUpdate',
+  userFetchError = 'userFetchError',
+}


### PR DESCRIPTION
### Added
- Added `useUserInfo` hook.
- Added `UserInfoStatus`.
- Added `mapUseQueryHookResult`.

### Changed
- Updated `cornieApi` mock with `useUpdateUsersV1MeMutation` mock.