### PR TITLE
Update UserUpdateQuery with passwordHash

### DIFF
--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/nest/modules/UserDbModule.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/nest/modules/UserDbModule.ts
@@ -15,7 +15,7 @@ import { UserCreateQueryTypeOrmFromUserCreateQueryBuilder } from '../../typeorm/
 import { UserFindQueryTypeOrmFromUserFindQueryBuilder } from '../../typeorm/builders/UserFindQueryTypeOrmFromUserFindQueryBuilder';
 import { UserFindQueryTypeOrmFromUserUpdateQueryBuilder } from '../../typeorm/builders/UserFindQueryTypeOrmFromUserUpdateQueryBuilder';
 import { UserFromUserDbBuilder } from '../../typeorm/builders/UserFromUserDbBuilder';
-import { UserUpdateQueryFromUserSetQueryTypeOrmBuilder } from '../../typeorm/builders/UserUpdateQueryFromUserSetQueryTypeOrmBuilder';
+import { UserSetQueryTypeOrmFromUserUpdateQueryBuilder } from '../../typeorm/builders/UserSetQueryTypeOrmFromUserUpdateQueryBuilder';
 import { UserCodeDb } from '../../typeorm/models/UserCodeDb';
 import { UserDb } from '../../typeorm/models/UserDb';
 import { CreateUserCodeTypeOrmService } from '../../typeorm/services/CreateUserCodeTypeOrmService';
@@ -63,7 +63,7 @@ export class UserDbModule {
           provide: userPersistenceOutputPortSymbol,
           useClass: UserPersistenceTypeOrmAdapter,
         },
-        UserUpdateQueryFromUserSetQueryTypeOrmBuilder,
+        UserSetQueryTypeOrmFromUserUpdateQueryBuilder,
       ],
     };
   }

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/builders/UserSetQueryTypeOrmFromUserUpdateQueryBuilder.spec.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/builders/UserSetQueryTypeOrmFromUserUpdateQueryBuilder.spec.ts
@@ -5,14 +5,14 @@ import { UserUpdateQueryFixtures } from '@cornie-js/backend-user-domain/users/fi
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity.js';
 
 import { UserDb } from '../models/UserDb';
-import { UserUpdateQueryFromUserSetQueryTypeOrmBuilder } from './UserUpdateQueryFromUserSetQueryTypeOrmBuilder';
+import { UserSetQueryTypeOrmFromUserUpdateQueryBuilder } from './UserSetQueryTypeOrmFromUserUpdateQueryBuilder';
 
-describe(UserUpdateQueryFromUserSetQueryTypeOrmBuilder.name, () => {
-  let userUpdateQueryToUserSetQueryTypeOrmBuilder: UserUpdateQueryFromUserSetQueryTypeOrmBuilder;
+describe(UserSetQueryTypeOrmFromUserUpdateQueryBuilder.name, () => {
+  let userUpdateQueryToUserSetQueryTypeOrmBuilder: UserSetQueryTypeOrmFromUserUpdateQueryBuilder;
 
   beforeAll(() => {
     userUpdateQueryToUserSetQueryTypeOrmBuilder =
-      new UserUpdateQueryFromUserSetQueryTypeOrmBuilder();
+      new UserSetQueryTypeOrmFromUserUpdateQueryBuilder();
   });
 
   describe('.build', () => {
@@ -61,6 +61,32 @@ describe(UserUpdateQueryFromUserSetQueryTypeOrmBuilder.name, () => {
         it('should return a QueryDeepPartialEntity<UserDb>', () => {
           const expected: QueryDeepPartialEntity<UserDb> = {
             name: userUpdateQueryFixture.name as string,
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a UserUpdateQuery with passwordHash', () => {
+      let userUpdateQueryFixture: UserUpdateQuery;
+
+      beforeAll(() => {
+        userUpdateQueryFixture = UserUpdateQueryFixtures.withPasswordHash;
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = userUpdateQueryToUserSetQueryTypeOrmBuilder.build(
+            userUpdateQueryFixture,
+          );
+        });
+
+        it('should return a QueryDeepPartialEntity<UserDb>', () => {
+          const expected: QueryDeepPartialEntity<UserDb> = {
+            passwordHash: userUpdateQueryFixture.passwordHash as string,
           };
 
           expect(result).toStrictEqual(expected);

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/builders/UserSetQueryTypeOrmFromUserUpdateQueryBuilder.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/builders/UserSetQueryTypeOrmFromUserUpdateQueryBuilder.ts
@@ -6,7 +6,7 @@ import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity
 import { UserDb } from '../models/UserDb';
 
 @Injectable()
-export class UserUpdateQueryFromUserSetQueryTypeOrmBuilder
+export class UserSetQueryTypeOrmFromUserUpdateQueryBuilder
   implements Builder<QueryDeepPartialEntity<UserDb>, [UserUpdateQuery]>
 {
   public build(
@@ -20,6 +20,10 @@ export class UserUpdateQueryFromUserSetQueryTypeOrmBuilder
 
     if (userUpdateQuery.name !== undefined) {
       userSetQueryTypeOrm.name = userUpdateQuery.name;
+    }
+
+    if (userUpdateQuery.passwordHash !== undefined) {
+      userSetQueryTypeOrm.passwordHash = userUpdateQuery.passwordHash;
     }
 
     return userSetQueryTypeOrm;

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/services/UpdateUserTypeOrmService.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/services/UpdateUserTypeOrmService.ts
@@ -10,7 +10,7 @@ import { Repository } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity.js';
 
 import { UserFindQueryTypeOrmFromUserUpdateQueryBuilder } from '../builders/UserFindQueryTypeOrmFromUserUpdateQueryBuilder';
-import { UserUpdateQueryFromUserSetQueryTypeOrmBuilder } from '../builders/UserUpdateQueryFromUserSetQueryTypeOrmBuilder';
+import { UserSetQueryTypeOrmFromUserUpdateQueryBuilder } from '../builders/UserSetQueryTypeOrmFromUserUpdateQueryBuilder';
 import { UserDb } from '../models/UserDb';
 
 @Injectable()
@@ -26,8 +26,8 @@ export class UpdateUserTypeOrmService extends UpdateTypeOrmService<
       UserDb,
       UserUpdateQuery
     >,
-    @Inject(UserUpdateQueryFromUserSetQueryTypeOrmBuilder)
-    userUpdateQueryFromUserSetQueryTypeOrmBuilder: Builder<
+    @Inject(UserSetQueryTypeOrmFromUserUpdateQueryBuilder)
+    userSetQueryTypeOrmFromUserUpdateQueryBuilder: Builder<
       QueryDeepPartialEntity<UserDb>,
       [UserUpdateQuery]
     >,
@@ -35,7 +35,7 @@ export class UpdateUserTypeOrmService extends UpdateTypeOrmService<
     super(
       repository,
       userFindQueryTypeOrmFromUserUpdateQueryBuilder,
-      userUpdateQueryFromUserSetQueryTypeOrmBuilder,
+      userSetQueryTypeOrmFromUserUpdateQueryBuilder,
     );
   }
 }

--- a/packages/backend/apps/user/backend-user-domain/src/users/domain/fixtures/UserUpdateQueryFixtures.ts
+++ b/packages/backend/apps/user/backend-user-domain/src/users/domain/fixtures/UserUpdateQueryFixtures.ts
@@ -38,4 +38,11 @@ export class UserUpdateQueryFixtures {
       name: '',
     };
   }
+
+  public static get withPasswordHash(): UserUpdateQuery {
+    return {
+      ...UserUpdateQueryFixtures.any,
+      passwordHash: 'hash',
+    };
+  }
 }

--- a/packages/backend/apps/user/backend-user-domain/src/users/domain/query/UserUpdateQuery.ts
+++ b/packages/backend/apps/user/backend-user-domain/src/users/domain/query/UserUpdateQuery.ts
@@ -5,4 +5,5 @@ export interface UserUpdateQuery {
 
   readonly active?: true;
   readonly name?: string;
+  readonly passwordHash?: string;
 }


### PR DESCRIPTION
### Changed
- Updated `UserUpdateQuery` with `passwordHash`.
- Updated `UserSetQueryTypeOrmFromUserUpdateQueryBuilder` to handle `passwordHash`.