### PR TITLE
Update rtk query with user and user code mutations

### DIFF
--- a/packages/api/libraries/api-http-client/src/httpClient/generated/HttpClientEndpoints.ts
+++ b/packages/api/libraries/api-http-client/src/httpClient/generated/HttpClientEndpoints.ts
@@ -272,6 +272,7 @@ export class HttpClientEndpoints {
   ): Promise<
     | Response<Record<string, string>, undefined, 201>
     | Response<Record<string, string>, apiModels.ErrorV1, 409>
+    | Response<Record<string, string>, apiModels.ErrorV1, 422>
   > {
     return this.#internalHttpClient.callEndpoint({
       body: body,

--- a/packages/api/libraries/api-openapi-schema/schemas/src/one-game.yaml
+++ b/packages/api/libraries/api-openapi-schema/schemas/src/one-game.yaml
@@ -514,6 +514,12 @@ paths:
             application/json:
               schema:
                 $ref: 'https://onegame.schemas/api/v1/errors/error.json'
+        '422':
+          description: Unprocessable operation. This is likely to happen if no user with the email address provided is found
+          content:
+            application/json:
+              schema:
+                $ref: 'https://onegame.schemas/api/v1/errors/error.json'
       tags:
         - User
 

--- a/packages/backend/apps/user/backend-user-application/src/users/application/handlers/PostUserV1EmailCodeRequestParamHandler.spec.ts
+++ b/packages/backend/apps/user/backend-user-application/src/users/application/handlers/PostUserV1EmailCodeRequestParamHandler.spec.ts
@@ -144,8 +144,8 @@ describe(PostUserV1EmailCodeRequestParamHandler.name, () => {
 
         it('should throw an Error', () => {
           const expectedErrorProperties: Partial<AppError> = {
-            kind: AppErrorKind.entityNotFound,
-            message: 'User not found',
+            kind: AppErrorKind.unprocessableOperation,
+            message: 'Unable to permorm operation: user not found',
           };
 
           expect(result).toStrictEqual(

--- a/packages/frontend/libraries/frontend-api-rtk-query/src/foundation/http/models/httpCodes.ts
+++ b/packages/frontend/libraries/frontend-api-rtk-query/src/foundation/http/models/httpCodes.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/typedef */
 
 export const OK = 200;
+export const CREATED = 201;
 export const BAD_REQUEST = 400;
 export const UNAUTHORIZED = 401;
 export const FORBIDDEN = 403;

--- a/packages/frontend/libraries/frontend-api-rtk-query/src/index.ts
+++ b/packages/frontend/libraries/frontend-api-rtk-query/src/index.ts
@@ -21,14 +21,20 @@ import { GetGamesV1MineArgs } from './games/models/GetGamesV1MineArgs';
 import { createGamesV1 } from './games/mutations/createGamesV1';
 import { createGamesV1Slots } from './games/mutations/createGamesV1Slots';
 import { getGamesV1Mine } from './games/queries/getGamesV1Mine';
+import { CreateUsersV1Args } from './users/models/CreateUsersV1Args';
+import { CreateUsersV1EmailCodeArgs } from './users/models/CreateUsersV1EmailCodeArgs';
 import { GetUsersV1MeArgs } from './users/models/GetUsersV1MeArgs';
 import { UpdateUsersV1MeArgs } from './users/models/UpdateUsersV1MeArgs';
+import { createUsersV1 } from './users/mutations/createUsersV1';
+import { createUsersV1EmailCode } from './users/mutations/createUsersV1EmailCode';
 import { updateUsersV1Me } from './users/mutations/updateUsersV1Me';
 import { getUsersV1Me } from './users/queries/getUsersV1Me';
 import { getUsersV1MeDetail } from './users/queries/getUsersV1MeDetail';
 
 export type {
   CreateAuthV2Args,
+  CreateUsersV1Args,
+  CreateUsersV1EmailCodeArgs,
   GetUsersV1MeArgs,
   SerializableAppError,
   UpdateUsersV1MeArgs,
@@ -98,6 +104,15 @@ export function buildApi<TState>(options: BuildApiOptions<TState>) {
           createGamesV1Slots(options.httpClient),
           authorizedEndpointsOptions,
         ),
+      }),
+      createUsersV1: build.mutation<apiModels.UserV1, CreateUsersV1Args>({
+        queryFn: createUsersV1(options.httpClient),
+      }),
+      createUsersV1EmailCode: build.mutation<
+        undefined,
+        CreateUsersV1EmailCodeArgs
+      >({
+        queryFn: createUsersV1EmailCode(options.httpClient),
       }),
       getGamesV1Mine: build.query<apiModels.GameArrayV1, GetGamesV1MineArgs>({
         queryFn: authorizedApiCall(

--- a/packages/frontend/libraries/frontend-api-rtk-query/src/users/models/CreateUsersV1Args.ts
+++ b/packages/frontend/libraries/frontend-api-rtk-query/src/users/models/CreateUsersV1Args.ts
@@ -1,0 +1,5 @@
+import { HttpApiParamsWithNoHeaders } from '../../foundation/http/models/HttpApiParamsWithNoHeaders';
+
+export interface CreateUsersV1Args {
+  params: HttpApiParamsWithNoHeaders<'createUser'>;
+}

--- a/packages/frontend/libraries/frontend-api-rtk-query/src/users/models/CreateUsersV1EmailCodeArgs.ts
+++ b/packages/frontend/libraries/frontend-api-rtk-query/src/users/models/CreateUsersV1EmailCodeArgs.ts
@@ -1,0 +1,5 @@
+import { HttpApiParamsWithNoHeaders } from '../../foundation/http/models/HttpApiParamsWithNoHeaders';
+
+export interface CreateUsersV1EmailCodeArgs {
+  params: HttpApiParamsWithNoHeaders<'createUserByEmailCode'>;
+}

--- a/packages/frontend/libraries/frontend-api-rtk-query/src/users/mutations/createUsersV1.spec.ts
+++ b/packages/frontend/libraries/frontend-api-rtk-query/src/users/mutations/createUsersV1.spec.ts
@@ -1,0 +1,199 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import {
+  HttpClient,
+  HttpClientEndpoints,
+  Response,
+} from '@cornie-js/api-http-client';
+import { models as apiModels } from '@cornie-js/api-models';
+import { AppErrorKind } from '@cornie-js/frontend-common';
+import { BaseQueryApi } from '@reduxjs/toolkit/query';
+
+import { SerializableAppError } from '../../foundation/error/SerializableAppError';
+import { HttpApiResult } from '../../foundation/http/models/HttpApiResult';
+import {
+  BAD_REQUEST,
+  CONFLICT,
+  OK,
+} from '../../foundation/http/models/httpCodes';
+import { QueryReturnValue } from '../../foundation/http/models/QueryReturnValue';
+import { CreateUsersV1Args } from '../models/CreateUsersV1Args';
+import { createUsersV1 } from './createUsersV1';
+
+describe(createUsersV1.name, () => {
+  describe('having an httpClient', () => {
+    let httpClientMock: jest.Mocked<HttpClient>;
+
+    let createUsersV1Function: (
+      args: CreateUsersV1Args,
+      api: BaseQueryApi,
+    ) => Promise<
+      QueryReturnValue<apiModels.UserV1, SerializableAppError, never>
+    >;
+
+    beforeAll(() => {
+      httpClientMock = {
+        endpoints: {
+          createUser: jest.fn(),
+        } as Partial<
+          jest.Mocked<HttpClientEndpoints>
+        > as jest.Mocked<HttpClientEndpoints>,
+      } as Partial<jest.Mocked<HttpClient>> as jest.Mocked<HttpClient>;
+
+      createUsersV1Function = createUsersV1(httpClientMock);
+    });
+
+    describe('having args and api', () => {
+      let argsFixture: CreateUsersV1Args;
+      let apiFixture: BaseQueryApi;
+
+      beforeAll(() => {
+        argsFixture = {
+          params: [Symbol() as unknown as apiModels.UserCreateQueryV1],
+        };
+        apiFixture = Symbol() as unknown as BaseQueryApi;
+      });
+
+      describe('when called, and httpClient.endpoints.createUser() returns a CreateGamesV1Result with 200 http status code', () => {
+        let resultFixture: HttpApiResult<'createUser'> &
+          Response<Record<string, string>, unknown, typeof OK>;
+
+        let result: unknown;
+
+        beforeAll(async () => {
+          resultFixture = {
+            body: Symbol() as unknown as apiModels.UserV1,
+            headers: {},
+            statusCode: OK,
+          };
+
+          httpClientMock.endpoints.createUser.mockResolvedValueOnce(
+            resultFixture,
+          );
+
+          result = await createUsersV1Function(argsFixture, apiFixture);
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call httpClient.endpoints.createUser()', () => {
+          expect(httpClientMock.endpoints.createUser).toHaveBeenCalledTimes(1);
+          expect(httpClientMock.endpoints.createUser).toHaveBeenCalledWith(
+            {},
+            ...argsFixture.params,
+          );
+        });
+
+        it('should return QueryReturnValue', () => {
+          const expected: QueryReturnValue<
+            apiModels.UserV1,
+            SerializableAppError,
+            never
+          > = {
+            data: resultFixture.body,
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+
+      describe('when called, and httpClient.endpoints.createUser() returns a CreateGamesV1Result with 400 http status code', () => {
+        let resultFixture: HttpApiResult<'createUser'> &
+          Response<Record<string, string>, unknown, typeof BAD_REQUEST>;
+
+        let result: unknown;
+
+        beforeAll(async () => {
+          resultFixture = {
+            body: Symbol() as unknown as apiModels.ErrorV1,
+            headers: {},
+            statusCode: BAD_REQUEST,
+          };
+
+          httpClientMock.endpoints.createUser.mockResolvedValueOnce(
+            resultFixture,
+          );
+
+          result = await createUsersV1Function(argsFixture, apiFixture);
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call httpClient.endpoints.createUser()', () => {
+          expect(httpClientMock.endpoints.createUser).toHaveBeenCalledTimes(1);
+          expect(httpClientMock.endpoints.createUser).toHaveBeenCalledWith(
+            {},
+            ...argsFixture.params,
+          );
+        });
+
+        it('should return QueryReturnValue', () => {
+          const expected: QueryReturnValue<
+            apiModels.UserV1,
+            SerializableAppError,
+            never
+          > = {
+            error: {
+              kind: AppErrorKind.contractViolation,
+              message: resultFixture.body.description,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+
+      describe('when called, and httpClient.endpoints.createUser() returns a CreateGamesV1Result with 409 http status code', () => {
+        let resultFixture: HttpApiResult<'createUser'> &
+          Response<Record<string, string>, unknown, typeof CONFLICT>;
+
+        let result: unknown;
+
+        beforeAll(async () => {
+          resultFixture = {
+            body: Symbol() as unknown as apiModels.ErrorV1,
+            headers: {},
+            statusCode: CONFLICT,
+          };
+
+          httpClientMock.endpoints.createUser.mockResolvedValueOnce(
+            resultFixture,
+          );
+
+          result = await createUsersV1Function(argsFixture, apiFixture);
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call httpClient.endpoints.createUser()', () => {
+          expect(httpClientMock.endpoints.createUser).toHaveBeenCalledTimes(1);
+          expect(httpClientMock.endpoints.createUser).toHaveBeenCalledWith(
+            {},
+            ...argsFixture.params,
+          );
+        });
+
+        it('should return QueryReturnValue', () => {
+          const expected: QueryReturnValue<
+            apiModels.UserV1,
+            SerializableAppError,
+            never
+          > = {
+            error: {
+              kind: AppErrorKind.entityConflict,
+              message: resultFixture.body.description,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+  });
+});

--- a/packages/frontend/libraries/frontend-api-rtk-query/src/users/mutations/createUsersV1.ts
+++ b/packages/frontend/libraries/frontend-api-rtk-query/src/users/mutations/createUsersV1.ts
@@ -1,0 +1,57 @@
+import { HttpClient } from '@cornie-js/api-http-client';
+import { models as apiModels } from '@cornie-js/api-models';
+import { AppError, AppErrorKind } from '@cornie-js/frontend-common';
+import { BaseQueryApi } from '@reduxjs/toolkit/query';
+
+import { SerializableAppError } from '../../foundation/error/SerializableAppError';
+import { HttpApiResult } from '../../foundation/http/models/HttpApiResult';
+import {
+  BAD_REQUEST,
+  CONFLICT,
+  OK,
+} from '../../foundation/http/models/httpCodes';
+import { QueryReturnValue } from '../../foundation/http/models/QueryReturnValue';
+import { CreateUsersV1Args } from '../models/CreateUsersV1Args';
+
+type CreateUsersV1Result = HttpApiResult<'createUser'>;
+
+export function createUsersV1(
+  httpClient: HttpClient,
+): (
+  args: CreateUsersV1Args,
+  api: BaseQueryApi,
+) => Promise<QueryReturnValue<apiModels.UserV1, SerializableAppError, never>> {
+  return async (
+    args: CreateUsersV1Args,
+  ): Promise<
+    QueryReturnValue<apiModels.UserV1, SerializableAppError, never>
+  > => {
+    const httpResponse: CreateUsersV1Result =
+      await httpClient.endpoints.createUser({}, ...args.params);
+
+    switch (httpResponse.statusCode) {
+      case OK:
+        return {
+          data: httpResponse.body,
+        };
+      case BAD_REQUEST:
+        return {
+          error: {
+            kind: AppErrorKind.contractViolation,
+            message: httpResponse.body.description,
+          },
+        };
+      case CONFLICT:
+        return {
+          error: {
+            kind: AppErrorKind.entityConflict,
+            message: httpResponse.body.description,
+          },
+        };
+      default:
+        return {
+          error: new AppError(AppErrorKind.unknown),
+        };
+    }
+  };
+}

--- a/packages/frontend/libraries/frontend-api-rtk-query/src/users/mutations/createUsersV1EmailCode.spec.ts
+++ b/packages/frontend/libraries/frontend-api-rtk-query/src/users/mutations/createUsersV1EmailCode.spec.ts
@@ -1,0 +1,218 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import {
+  HttpClient,
+  HttpClientEndpoints,
+  Response,
+} from '@cornie-js/api-http-client';
+import { models as apiModels } from '@cornie-js/api-models';
+import { AppErrorKind } from '@cornie-js/frontend-common';
+import { BaseQueryApi } from '@reduxjs/toolkit/query';
+
+import { SerializableAppError } from '../../foundation/error/SerializableAppError';
+import { HttpApiResult } from '../../foundation/http/models/HttpApiResult';
+import {
+  CONFLICT,
+  CREATED,
+  UNPROCESSABLE_CONTENT,
+} from '../../foundation/http/models/httpCodes';
+import { QueryReturnValue } from '../../foundation/http/models/QueryReturnValue';
+import { CreateUsersV1EmailCodeArgs } from '../models/CreateUsersV1EmailCodeArgs';
+import { createUsersV1EmailCode } from './createUsersV1EmailCode';
+
+describe(createUsersV1EmailCode.name, () => {
+  describe('having an httpClient', () => {
+    let httpClientMock: jest.Mocked<HttpClient>;
+
+    let createUsersV1EmailCodeFunction: (
+      args: CreateUsersV1EmailCodeArgs,
+      api: BaseQueryApi,
+    ) => Promise<QueryReturnValue<undefined, SerializableAppError, never>>;
+
+    beforeAll(() => {
+      httpClientMock = {
+        endpoints: {
+          createUserByEmailCode: jest.fn(),
+        } as Partial<
+          jest.Mocked<HttpClientEndpoints>
+        > as jest.Mocked<HttpClientEndpoints>,
+      } as Partial<jest.Mocked<HttpClient>> as jest.Mocked<HttpClient>;
+
+      createUsersV1EmailCodeFunction = createUsersV1EmailCode(httpClientMock);
+    });
+
+    describe('having args and api', () => {
+      let argsFixture: CreateUsersV1EmailCodeArgs;
+      let apiFixture: BaseQueryApi;
+
+      beforeAll(() => {
+        argsFixture = {
+          params: [
+            {
+              email: 'mail@sample.com',
+            },
+            Symbol() as unknown as apiModels.UserCodeCreateQueryV1,
+          ],
+        };
+        apiFixture = Symbol() as unknown as BaseQueryApi;
+      });
+
+      describe('when called, and httpClient.endpoints.createUserByEmailCode() returns a CreateGamesV1Result with 201 http status code', () => {
+        let resultFixture: HttpApiResult<'createUserByEmailCode'> &
+          Response<Record<string, string>, unknown, typeof CREATED>;
+
+        let result: unknown;
+
+        beforeAll(async () => {
+          resultFixture = {
+            body: undefined,
+            headers: {},
+            statusCode: CREATED,
+          };
+
+          httpClientMock.endpoints.createUserByEmailCode.mockResolvedValueOnce(
+            resultFixture,
+          );
+
+          result = await createUsersV1EmailCodeFunction(
+            argsFixture,
+            apiFixture,
+          );
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call httpClient.endpoints.createUserByEmailCode()', () => {
+          expect(
+            httpClientMock.endpoints.createUserByEmailCode,
+          ).toHaveBeenCalledTimes(1);
+          expect(
+            httpClientMock.endpoints.createUserByEmailCode,
+          ).toHaveBeenCalledWith({}, ...argsFixture.params);
+        });
+
+        it('should return QueryReturnValue', () => {
+          const expected: QueryReturnValue<
+            undefined,
+            SerializableAppError,
+            never
+          > = {
+            data: resultFixture.body,
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+
+      describe('when called, and httpClient.endpoints.createUserByEmailCode() returns a CreateGamesV1Result with 409 http status code', () => {
+        let resultFixture: HttpApiResult<'createUserByEmailCode'> &
+          Response<Record<string, string>, unknown, typeof CONFLICT>;
+
+        let result: unknown;
+
+        beforeAll(async () => {
+          resultFixture = {
+            body: Symbol() as unknown as apiModels.ErrorV1,
+            headers: {},
+            statusCode: CONFLICT,
+          };
+
+          httpClientMock.endpoints.createUserByEmailCode.mockResolvedValueOnce(
+            resultFixture,
+          );
+
+          result = await createUsersV1EmailCodeFunction(
+            argsFixture,
+            apiFixture,
+          );
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call httpClient.endpoints.createUserByEmailCode()', () => {
+          expect(
+            httpClientMock.endpoints.createUserByEmailCode,
+          ).toHaveBeenCalledTimes(1);
+          expect(
+            httpClientMock.endpoints.createUserByEmailCode,
+          ).toHaveBeenCalledWith({}, ...argsFixture.params);
+        });
+
+        it('should return QueryReturnValue', () => {
+          const expected: QueryReturnValue<
+            undefined,
+            SerializableAppError,
+            never
+          > = {
+            error: {
+              kind: AppErrorKind.entityConflict,
+              message: resultFixture.body.description,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+
+      describe('when called, and httpClient.endpoints.createUserByEmailCode() returns a CreateGamesV1Result with 422 http status code', () => {
+        let resultFixture: HttpApiResult<'createUserByEmailCode'> &
+          Response<
+            Record<string, string>,
+            unknown,
+            typeof UNPROCESSABLE_CONTENT
+          >;
+
+        let result: unknown;
+
+        beforeAll(async () => {
+          resultFixture = {
+            body: Symbol() as unknown as apiModels.ErrorV1,
+            headers: {},
+            statusCode: UNPROCESSABLE_CONTENT,
+          };
+
+          httpClientMock.endpoints.createUserByEmailCode.mockResolvedValueOnce(
+            resultFixture,
+          );
+
+          result = await createUsersV1EmailCodeFunction(
+            argsFixture,
+            apiFixture,
+          );
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call httpClient.endpoints.createUserByEmailCode()', () => {
+          expect(
+            httpClientMock.endpoints.createUserByEmailCode,
+          ).toHaveBeenCalledTimes(1);
+          expect(
+            httpClientMock.endpoints.createUserByEmailCode,
+          ).toHaveBeenCalledWith({}, ...argsFixture.params);
+        });
+
+        it('should return QueryReturnValue', () => {
+          const expected: QueryReturnValue<
+            undefined,
+            SerializableAppError,
+            never
+          > = {
+            error: {
+              kind: AppErrorKind.unprocessableOperation,
+              message: resultFixture.body.description,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+  });
+});

--- a/packages/frontend/libraries/frontend-api-rtk-query/src/users/mutations/createUsersV1EmailCode.ts
+++ b/packages/frontend/libraries/frontend-api-rtk-query/src/users/mutations/createUsersV1EmailCode.ts
@@ -1,0 +1,54 @@
+import { HttpClient } from '@cornie-js/api-http-client';
+import { AppError, AppErrorKind } from '@cornie-js/frontend-common';
+import { BaseQueryApi } from '@reduxjs/toolkit/query';
+
+import { SerializableAppError } from '../../foundation/error/SerializableAppError';
+import { HttpApiResult } from '../../foundation/http/models/HttpApiResult';
+import {
+  CONFLICT,
+  CREATED,
+  UNPROCESSABLE_CONTENT,
+} from '../../foundation/http/models/httpCodes';
+import { QueryReturnValue } from '../../foundation/http/models/QueryReturnValue';
+import { CreateUsersV1EmailCodeArgs } from '../models/CreateUsersV1EmailCodeArgs';
+
+type CreateUsersV1EmailCodeResult = HttpApiResult<'createUserByEmailCode'>;
+
+export function createUsersV1EmailCode(
+  httpClient: HttpClient,
+): (
+  args: CreateUsersV1EmailCodeArgs,
+  api: BaseQueryApi,
+) => Promise<QueryReturnValue<undefined, SerializableAppError, never>> {
+  return async (
+    args: CreateUsersV1EmailCodeArgs,
+  ): Promise<QueryReturnValue<undefined, SerializableAppError, never>> => {
+    const httpResponse: CreateUsersV1EmailCodeResult =
+      await httpClient.endpoints.createUserByEmailCode({}, ...args.params);
+
+    switch (httpResponse.statusCode) {
+      case CREATED:
+        return {
+          data: httpResponse.body,
+        };
+      case CONFLICT:
+        return {
+          error: {
+            kind: AppErrorKind.entityConflict,
+            message: httpResponse.body.description,
+          },
+        };
+      case UNPROCESSABLE_CONTENT:
+        return {
+          error: {
+            kind: AppErrorKind.unprocessableOperation,
+            message: httpResponse.body.description,
+          },
+        };
+      default:
+        return {
+          error: new AppError(AppErrorKind.unknown),
+        };
+    }
+  };
+}


### PR DESCRIPTION
### Added
- Added `createUsersV1` mutation.
- Added `createUsersV1EmailCode` mutation.

### Changed
- Updated `CreateUserCodeRequestParamHandler` to thrown an `unprocessableOperation` error.
- Updated API docs.
