### PR TITLE
Update concurrency to rely on docker image

### DIFF
--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -1,6 +1,6 @@
 name: publish-docker-image
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{github.event.inputs.image}}-${{ github.ref }}
   cancel-in-progress: true
 on:
   workflow_dispatch:


### PR DESCRIPTION
### Changed
- Updated gh action concurrency to rely on docker image.