### PR TITLE
Update getSlug to be generic

### DIFF
--- a/packages/frontend/web-ui/src/auth/pages/Login.spec.tsx
+++ b/packages/frontend/web-ui/src/auth/pages/Login.spec.tsx
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 jest.mock('../hooks/useLoginForm');
+jest.mock('../../common/helpers/getSlug');
 jest.mock('../../common/hooks/useShowPassword');
 jest.mock('../../app/store/hooks');
 
@@ -16,7 +17,9 @@ import { MemoryRouter, useNavigate } from 'react-router-dom';
 import { AuthenticatedAuthState } from '../../app/store/helpers/models/AuthState';
 import { AuthStateStatus } from '../../app/store/helpers/models/AuthStateStatus';
 import { useAppSelector } from '../../app/store/hooks';
+import { getSlug } from '../../common/helpers/getSlug';
 import { useShowPassword } from '../../common/hooks/useShowPassword';
+import { PageName } from '../../common/models/PageName';
 import { useLoginForm } from '../hooks/useLoginForm';
 import { LoginStatus } from '../models/LoginStatus';
 import { UseLoginFormParams } from '../models/UseLoginFormResult';
@@ -236,7 +239,11 @@ describe(Login.name, () => {
   });
 
   describe('when called, and user exists and navigate to the next page', () => {
+    let slugFixture: string;
+
     beforeAll(() => {
+      slugFixture = '/slug-fixture';
+
       authenticatedAuthStateFixture = {
         accessToken: 'accessToken-fixture',
         refreshToken: 'refreshToken-fixture',
@@ -268,6 +275,8 @@ describe(Login.name, () => {
         useAppSelector as unknown as jest.Mock<typeof useAppSelector>
       ).mockReturnValueOnce(authenticatedAuthStateFixture);
 
+      (getSlug as jest.Mock<typeof getSlug>).mockReturnValueOnce(slugFixture);
+
       render(
         <MemoryRouter>
           <Login />
@@ -280,8 +289,14 @@ describe(Login.name, () => {
       jest.resetAllMocks();
     });
 
-    it('should navigate to the next page', () => {
-      expect(navigateMock).toHaveBeenCalledWith('/');
+    it('should call getSlug()', () => {
+      expect(getSlug).toHaveBeenCalledTimes(1);
+      expect(getSlug).toHaveBeenCalledWith(PageName.home);
+    });
+
+    it('should call navigate()', () => {
+      expect(navigateMock).toHaveBeenCalledTimes(1);
+      expect(navigateMock).toHaveBeenCalledWith(slugFixture);
     });
 
     it('should save accessToken and refreshToken in Local Storage', () => {

--- a/packages/frontend/web-ui/src/auth/pages/Login.tsx
+++ b/packages/frontend/web-ui/src/auth/pages/Login.tsx
@@ -22,8 +22,10 @@ import { selectAuthenticatedAuth } from '../../app/store/features/authSlice';
 import { AuthenticatedAuthState } from '../../app/store/helpers/models/AuthState';
 import { useAppSelector } from '../../app/store/hooks';
 import { CircularProgressModal } from '../../common/components/CircularProgressModal';
+import { getSlug } from '../../common/helpers/getSlug';
 import { useShowPassword } from '../../common/hooks/useShowPassword';
 import { CornieLayout } from '../../common/layout/CornieLayout';
+import { PageName } from '../../common/models/PageName';
 import { useLoginForm } from '../hooks/useLoginForm';
 import { LoginStatus } from '../models/LoginStatus';
 import { UseLoginFormResult } from '../models/UseLoginFormResult';
@@ -67,7 +69,7 @@ export const Login = (): React.JSX.Element => {
 
       const redirectTo: string | null = getRedirectTo();
       if (redirectTo === null) {
-        navigate('/');
+        navigate(getSlug(PageName.home));
       } else {
         window.location.href = redirectTo;
       }

--- a/packages/frontend/web-ui/src/common/components/Navbar.tsx
+++ b/packages/frontend/web-ui/src/common/components/Navbar.tsx
@@ -7,7 +7,7 @@ import { selectAuthenticatedAuth } from '../../app/store/features/authSlice';
 import { AuthenticatedAuthState } from '../../app/store/helpers/models/AuthState';
 import { useAppDispatch, useAppSelector } from '../../app/store/hooks';
 import { getSlug } from '../helpers/getSlug';
-import { NavbarPageName } from '../models/NavbarPageName';
+import { PageName } from '../models/PageName';
 import { NavbarGamesMenu } from './NavbarGamesMenu';
 import { NavbarOptions } from './NavbarOptions';
 import { NavbarUserMenu } from './NavbarUserMenu';
@@ -30,7 +30,7 @@ export const Navbar = (): React.JSX.Element => {
   const onLogout = (event: React.FormEvent) => {
     event.preventDefault();
     dispatch(logout());
-    navigate(getSlug(NavbarPageName.logout));
+    navigate(getSlug(PageName.home));
   };
 
   return (

--- a/packages/frontend/web-ui/src/common/components/NavbarGamesMenu.tsx
+++ b/packages/frontend/web-ui/src/common/components/NavbarGamesMenu.tsx
@@ -2,7 +2,7 @@ import AddIcon from '@mui/icons-material/Add';
 import { Box, Button, Menu, MenuItem } from '@mui/material';
 
 import { getSlug } from '../helpers/getSlug';
-import { NavbarPageName } from '../models/NavbarPageName';
+import { PageName } from '../models/PageName';
 
 export interface NavbarGamesMenuParams {
   setGamesMenuAnchorNav: React.Dispatch<
@@ -22,16 +22,16 @@ const NavbarGamesMenuItems = (
     <Box>
       <MenuItem
         className="navbar-menu-item"
-        key={NavbarPageName.createGame}
+        key={PageName.createGame}
         onClick={buildCloseMenu(params)}
       >
         <Button
           component="a"
           className="navbar-link"
-          href={getSlug(NavbarPageName.createGame)}
+          href={getSlug(PageName.createGame)}
           startIcon={<AddIcon />}
         >
-          {NavbarPageName.createGame}
+          NEW GAME
         </Button>
       </MenuItem>
     </Box>

--- a/packages/frontend/web-ui/src/common/components/NavbarUserMenu.tsx
+++ b/packages/frontend/web-ui/src/common/components/NavbarUserMenu.tsx
@@ -8,7 +8,7 @@ import { Box, Button, Menu, MenuItem } from '@mui/material';
 
 import { AuthenticatedAuthState } from '../../app/store/helpers/models/AuthState';
 import { getSlug } from '../helpers/getSlug';
-import { NavbarPageName } from '../models/NavbarPageName';
+import { PageName } from '../models/PageName';
 
 export interface NavbarUserMenuParams {
   auth: AuthenticatedAuthState | null;
@@ -31,30 +31,30 @@ const NavbarUserMenuItems = (
       <Box>
         <MenuItem
           className="navbar-menu-item"
-          key={NavbarPageName.login}
+          key={PageName.login}
           onClick={buildCloseUserMenu(params)}
         >
           <Button
             component="a"
             className="navbar-link"
-            href={getSlug(NavbarPageName.login)}
+            href={getSlug(PageName.login)}
             startIcon={<LoginOutlined />}
           >
-            {NavbarPageName.login}
+            LOGIN
           </Button>
         </MenuItem>
         <MenuItem
           className="navbar-menu-item"
-          key={NavbarPageName.register}
+          key={PageName.register}
           onClick={buildCloseUserMenu(params)}
         >
           <Button
             component="a"
             className="navbar-link"
-            href={getSlug(NavbarPageName.register)}
+            href={getSlug(PageName.register)}
             startIcon={<AppRegistrationOutlined />}
           >
-            {NavbarPageName.register}
+            REGISTER
           </Button>
         </MenuItem>
       </Box>
@@ -65,31 +65,31 @@ const NavbarUserMenuItems = (
     <Box>
       <MenuItem
         className="navbar-menu-item"
-        key={NavbarPageName.userMe}
+        key={PageName.userMe}
         onClick={buildCloseUserMenu(params)}
       >
         <Button
           component="a"
           className="navbar-link"
-          href={getSlug(NavbarPageName.userMe)}
+          href={getSlug(PageName.userMe)}
           startIcon={<AccountCircleOutlined />}
         >
-          {NavbarPageName.userMe}
+          PROFILE
         </Button>
       </MenuItem>
       <MenuItem
         className="navbar-menu-item"
-        key={NavbarPageName.logout}
+        key={PageName.home}
         onClick={buildCloseUserMenu(params)}
       >
         <Button
           component="a"
           className="navbar-link"
-          href={getSlug(NavbarPageName.logout)}
+          href={getSlug(PageName.home)}
           onClick={params.onLogout}
           startIcon={<LogoutOutlined />}
         >
-          {NavbarPageName.logout}
+          LOGOUT
         </Button>
       </MenuItem>
     </Box>

--- a/packages/frontend/web-ui/src/common/helpers/getSlug.spec.ts
+++ b/packages/frontend/web-ui/src/common/helpers/getSlug.spec.ts
@@ -1,18 +1,18 @@
 import { beforeAll, describe, expect, it } from '@jest/globals';
 
-import { NavbarPageName } from '../models/NavbarPageName';
+import { PageName } from '../models/PageName';
 import { getSlug } from './getSlug';
 
 describe(getSlug.name, () => {
-  describe.each<[NavbarPageName, string]>([
-    [NavbarPageName.createGame, '/games'],
-    [NavbarPageName.login, '/auth/login'],
-    [NavbarPageName.logout, '/'],
-    [NavbarPageName.register, '/auth/register'],
-    [NavbarPageName.userMe, '/users/me'],
+  describe.each<[PageName, string]>([
+    [PageName.createGame, '/games'],
+    [PageName.login, '/auth/login'],
+    [PageName.home, '/'],
+    [PageName.register, '/auth/register'],
+    [PageName.userMe, '/users/me'],
   ])(
     'having a page name "%s"',
-    (pageName: NavbarPageName, expectedResult: string) => {
+    (pageName: PageName, expectedResult: string) => {
       describe('when called', () => {
         let result: unknown;
 

--- a/packages/frontend/web-ui/src/common/helpers/getSlug.ts
+++ b/packages/frontend/web-ui/src/common/helpers/getSlug.ts
@@ -1,14 +1,13 @@
-import { NavbarPageName } from '../models/NavbarPageName';
+import { PageName } from '../models/PageName';
 
-const NAVBAR_PAGE_NAME_TO_PAGE_SLUG_MAP: { [TPage in NavbarPageName]: string } =
-  {
-    [NavbarPageName.createGame]: '/games',
-    [NavbarPageName.login]: '/auth/login',
-    [NavbarPageName.logout]: '/',
-    [NavbarPageName.register]: '/auth/register',
-    [NavbarPageName.userMe]: '/users/me',
-  };
+const NAVBAR_PAGE_NAME_TO_PAGE_SLUG_MAP: { [TPage in PageName]: string } = {
+  [PageName.createGame]: '/games',
+  [PageName.login]: '/auth/login',
+  [PageName.home]: '/',
+  [PageName.register]: '/auth/register',
+  [PageName.userMe]: '/users/me',
+};
 
-export function getSlug(pageName: NavbarPageName): string {
+export function getSlug(pageName: PageName): string {
   return NAVBAR_PAGE_NAME_TO_PAGE_SLUG_MAP[pageName];
 }

--- a/packages/frontend/web-ui/src/common/hooks/useRedirectUnauthorized.spec.ts
+++ b/packages/frontend/web-ui/src/common/hooks/useRedirectUnauthorized.spec.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 jest.mock('react-router-dom');
 
 jest.mock('../../app/store/hooks');
+jest.mock('../helpers/getSlug');
 
 import { renderHook } from '@testing-library/react';
 import { act } from 'react';
@@ -11,14 +12,20 @@ import { useNavigate } from 'react-router-dom';
 import { AuthenticatedAuthState } from '../../app/store/helpers/models/AuthState';
 import { AuthStateStatus } from '../../app/store/helpers/models/AuthStateStatus';
 import { useAppSelector } from '../../app/store/hooks';
+import { getSlug } from '../helpers/getSlug';
+import { PageName } from '../models/PageName';
 import { useRedirectUnauthorized } from './useRedirectUnauthorized';
 
 describe(useRedirectUnauthorized.name, () => {
   describe('when called, and useAppSelector() returns null', () => {
+    let slugFixture: string;
+
     let navigateMock: ReturnType<typeof useNavigate> &
       jest.Mock<ReturnType<typeof useNavigate>>;
 
     beforeAll(async () => {
+      slugFixture = '/slug-fixture';
+
       navigateMock = jest.fn<ReturnType<typeof useNavigate>>() as ReturnType<
         typeof useNavigate
       > &
@@ -31,6 +38,8 @@ describe(useRedirectUnauthorized.name, () => {
       (useAppSelector as jest.Mock<typeof useAppSelector>).mockReturnValueOnce(
         null,
       );
+
+      (getSlug as jest.Mock<typeof getSlug>).mockReturnValueOnce(slugFixture);
 
       await act(async () => {
         renderHook(() => useRedirectUnauthorized());
@@ -51,9 +60,14 @@ describe(useRedirectUnauthorized.name, () => {
       expect(useAppSelector).toHaveBeenCalledWith(expect.any(Function));
     });
 
+    it('should call getSlug()', () => {
+      expect(getSlug).toHaveBeenCalledTimes(1);
+      expect(getSlug).toHaveBeenCalledWith(PageName.home);
+    });
+
     it('should call navigate()', () => {
       expect(navigateMock).toHaveBeenCalledTimes(1);
-      expect(navigateMock).toHaveBeenCalledWith('/');
+      expect(navigateMock).toHaveBeenCalledWith(slugFixture);
     });
   });
 

--- a/packages/frontend/web-ui/src/common/hooks/useRedirectUnauthorized.ts
+++ b/packages/frontend/web-ui/src/common/hooks/useRedirectUnauthorized.ts
@@ -4,6 +4,8 @@ import { useNavigate } from 'react-router-dom';
 import { selectAuthenticatedAuth } from '../../app/store/features/authSlice';
 import { AuthenticatedAuthState } from '../../app/store/helpers/models/AuthState';
 import { useAppSelector } from '../../app/store/hooks';
+import { getSlug } from '../helpers/getSlug';
+import { PageName } from '../models/PageName';
 
 export function useRedirectUnauthorized(): void {
   const navigate = useNavigate();
@@ -14,7 +16,7 @@ export function useRedirectUnauthorized(): void {
 
   useEffect(() => {
     if (auth === null) {
-      navigate('/');
+      navigate(getSlug(PageName.home));
     }
   }, [auth]);
 }

--- a/packages/frontend/web-ui/src/common/models/NavbarPageName.ts
+++ b/packages/frontend/web-ui/src/common/models/NavbarPageName.ts
@@ -1,7 +1,0 @@
-export enum NavbarPageName {
-  createGame = 'NEW GAME',
-  login = 'LOGIN',
-  register = 'REGISTER',
-  userMe = 'PROFILE',
-  logout = 'LOGOUT',
-}

--- a/packages/frontend/web-ui/src/common/models/PageName.ts
+++ b/packages/frontend/web-ui/src/common/models/PageName.ts
@@ -1,0 +1,7 @@
+export enum PageName {
+  createGame,
+  home,
+  login,
+  register,
+  userMe,
+}

--- a/packages/frontend/web-ui/src/game/hooks/useJoinExistingGame.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useJoinExistingGame.ts
@@ -6,16 +6,18 @@ import { useNavigate } from 'react-router-dom';
 import { selectAuthenticatedAuth } from '../../app/store/features/authSlice';
 import { AuthenticatedAuthState } from '../../app/store/helpers/models/AuthState';
 import { useAppSelector } from '../../app/store/hooks';
+import { getSlug } from '../../common/helpers/getSlug';
 import { mapUseQueryHookResult } from '../../common/helpers/mapUseQueryHookResult';
 import { cornieApi } from '../../common/http/services/cornieApi';
 import { Either } from '../../common/models/Either';
+import { PageName } from '../../common/models/PageName';
 import { JoinExistingGameStatus } from '../models/JoinExistingGameStatus';
 import { UseJoinExistingGameResult } from '../models/UseJoinExistingGameResult';
 
 export const UNEXPECTED_ERROR_MESSAGE: string = 'Unexpected error';
 
 function buildLoginPageUrl(redirectTo: string): string {
-  return `/auth/login?redirectTo=${redirectTo}`;
+  return `${getSlug(PageName.login)}?redirectTo=${redirectTo}`;
 }
 
 export const useJoinExistingGame = (): UseJoinExistingGameResult => {

--- a/packages/frontend/web-ui/src/game/pages/CreateNewGame.spec.tsx
+++ b/packages/frontend/web-ui/src/game/pages/CreateNewGame.spec.tsx
@@ -1,3 +1,4 @@
+jest.mock('../../common/helpers/getSlug');
 jest.mock('../hooks/useCreateNewGame');
 jest.mock('../../app/store/hooks');
 
@@ -21,7 +22,9 @@ import { MemoryRouter, useNavigate } from 'react-router-dom';
 import { AuthenticatedAuthState } from '../../app/store/helpers/models/AuthState';
 import { AuthStateStatus } from '../../app/store/helpers/models/AuthStateStatus';
 import { useAppSelector } from '../../app/store/hooks';
+import { getSlug } from '../../common/helpers/getSlug';
 import { Either } from '../../common/models/Either';
+import { PageName } from '../../common/models/PageName';
 import {
   NUMBER_PLAYERS_MAXIMUM,
   NUMBER_PLAYERS_MINIMUM,
@@ -306,9 +309,13 @@ describe(CreateNewGame.name, () => {
   });
 
   describe('when called, and game is created and can navigate to the next page', () => {
+    let slugFixture: string;
+
     let renderResult: RenderResult;
 
     beforeAll(async () => {
+      slugFixture = '/slug-fixture';
+
       (useNavigate as jest.Mock<typeof useNavigate>).mockReturnValueOnce(
         navigateMock,
       );
@@ -354,11 +361,13 @@ describe(CreateNewGame.name, () => {
         status: CreateNewGameStatus.done,
       });
 
+      (getSlug as jest.Mock<typeof getSlug>).mockReturnValueOnce(slugFixture);
+
       fireEvent.click(formCornieHomeButton);
 
       await waitFor(() => {
         // eslint-disable-next-line jest/no-standalone-expect
-        expect(navigateMock).toHaveBeenCalledWith('/');
+        expect(navigateMock).toHaveBeenCalledWith(slugFixture);
       });
     });
 
@@ -366,8 +375,13 @@ describe(CreateNewGame.name, () => {
       jest.clearAllMocks();
     });
 
-    it('should navigate to Cornie Home page', () => {
-      expect(navigateMock).toHaveBeenCalledWith('/');
+    it('should call getSlug()', () => {
+      expect(getSlug).toHaveBeenCalledWith(PageName.home);
+    });
+
+    it('should call navigate()', () => {
+      expect(navigateMock).toHaveBeenCalledTimes(1);
+      expect(navigateMock).toHaveBeenCalledWith(slugFixture);
     });
   });
 });

--- a/packages/frontend/web-ui/src/game/pages/CreateNewGame.tsx
+++ b/packages/frontend/web-ui/src/game/pages/CreateNewGame.tsx
@@ -24,7 +24,9 @@ import React, { useState } from 'react';
 import { NavigateFunction, useNavigate } from 'react-router-dom';
 
 import { CircularProgressModal } from '../../common/components/CircularProgressModal';
+import { getSlug } from '../../common/helpers/getSlug';
 import { CornieLayout } from '../../common/layout/CornieLayout';
+import { PageName } from '../../common/models/PageName';
 import { useCreateNewGame } from '../hooks/useCreateNewGame';
 import { CreateNewGameStatus } from '../models/CreateNewGameStatus';
 
@@ -59,7 +61,7 @@ export const CreateNewGame = (): React.JSX.Element => {
 
   const onGoHome = (event: React.FormEvent): void => {
     event.preventDefault();
-    navigate('/');
+    navigate(getSlug(PageName.home));
   };
 
   const isTextFieldDisabled = (): boolean => {


### PR DESCRIPTION
### Changed
- Updated `getSlug` to be used to get the slug of any page, not only navbar related pages.