### PR TITLE
Update NonStartedGameFilledEventHandler

### DIFF
--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameUpdatedEventHandler.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameUpdatedEventHandler.ts
@@ -80,8 +80,8 @@ export class GameUpdatedEventHandler
     gameEventsSubscriptionOutputPort: GameEventsSubscriptionOutputPort,
     @Inject(gamePersistenceOutputPortSymbol)
     gamePersistenceOutputPort: GamePersistenceOutputPort,
-    @Optional()
     @Inject(gameTurnEndSignalMessageSendOutputPortSymbol)
+    @Optional()
     gameTurnEndSignalMessageSendOutputPort:
       | GameTurnEndSignalMessageSendOutputPort
       | undefined,


### PR DESCRIPTION
### Changed
- Update `NonStartedGameFilledEventHandler` to send missing `GameTurnEndSignalMessage`.