### PR TITLE
Add public games page

### DIFF
--- a/packages/frontend/web-ui/src/common/components/NavbarGamesMenu.tsx
+++ b/packages/frontend/web-ui/src/common/components/NavbarGamesMenu.tsx
@@ -1,4 +1,5 @@
 import AddIcon from '@mui/icons-material/Add';
+import PublicIcon from '@mui/icons-material/Public';
 import { Box, Button, Menu, MenuItem } from '@mui/material';
 
 import { getSlug } from '../helpers/getSlug';
@@ -32,6 +33,20 @@ const NavbarGamesMenuItems = (
           startIcon={<AddIcon />}
         >
           NEW GAME
+        </Button>
+      </MenuItem>
+      <MenuItem
+        className="navbar-menu-item"
+        key={PageName.publicGames}
+        onClick={buildCloseMenu(params)}
+      >
+        <Button
+          component="a"
+          className="navbar-link"
+          href={getSlug(PageName.publicGames)}
+          startIcon={<PublicIcon />}
+        >
+          PUBLIC GAMES
         </Button>
       </MenuItem>
     </Box>

--- a/packages/frontend/web-ui/src/common/http/services/__mocks__/cornieApi.ts
+++ b/packages/frontend/web-ui/src/common/http/services/__mocks__/cornieApi.ts
@@ -9,6 +9,7 @@ export const cornieApi: jest.Mocked<typeof originalCornieApi> = {
   useCreateUsersV1EmailCodeMutation: jest.fn(),
   useCreateUsersV1Mutation: jest.fn(),
   useGetGamesV1MineQuery: jest.fn(),
+  useGetGamesV1Query: jest.fn(),
   useGetUsersV1MeDetailQuery: jest.fn(),
   useGetUsersV1MeQuery: jest.fn(),
   useUpdateUsersV1MeMutation: jest.fn(),

--- a/packages/frontend/web-ui/src/game/components/NonStartedGameList.spec.tsx
+++ b/packages/frontend/web-ui/src/game/components/NonStartedGameList.spec.tsx
@@ -18,6 +18,7 @@ describe(NonStartedGameList.name, () => {
   beforeAll(() => {
     optionsFixture = {
       gamesResult: null,
+      usersMeResult: null,
     };
   });
 
@@ -40,7 +41,7 @@ describe(NonStartedGameList.name, () => {
       );
 
       const renderResult: RenderResult = render(
-        <NonStartedGameList gamesResult={optionsFixture.gamesResult} />,
+        <NonStartedGameList {...optionsFixture} />,
       );
 
       const baseGameList: ChildNode | undefined =

--- a/packages/frontend/web-ui/src/game/components/NonStartedGameList.tsx
+++ b/packages/frontend/web-ui/src/game/components/NonStartedGameList.tsx
@@ -19,10 +19,11 @@ export interface NonStartedGameListButtonsOptions {
 }
 
 export interface NonStartedGameListOptions {
-  buttons?: NonStartedGameListButtonsOptions;
+  buttons?: NonStartedGameListButtonsOptions | undefined;
   pagination?: BaseGameListPaginationOptions | undefined;
   title?: string | undefined;
   gamesResult: Either<string, apiModels.GameArrayV1> | null;
+  usersMeResult: Either<string, apiModels.UserV1> | null;
 }
 
 function buildGameItemBuilder(
@@ -69,7 +70,8 @@ export const NonStartedGameList = (options: NonStartedGameListOptions) => {
       ></Snackbar>
       <BaseGameList
         buildGameItem={buildGameItemBuilder(enqueue, options)}
-        {...options}
+        gamesResult={options.gamesResult}
+        pagination={options.pagination}
       />
     </>
   );

--- a/packages/frontend/web-ui/src/game/components/NonStartedGameListItem.spec.tsx
+++ b/packages/frontend/web-ui/src/game/components/NonStartedGameListItem.spec.tsx
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 jest.mock('../../common/helpers/getSlug');
+jest.mock('../helpers/userCanJoinGame');
 jest.mock('./BaseGameListItem');
 
 import { render, RenderResult } from '@testing-library/react';
@@ -8,6 +9,7 @@ import React from 'react';
 
 import { getSlug } from '../../common/helpers/getSlug';
 import { PageName } from '../../common/models/PageName';
+import { userCanJoinGame } from '../helpers/userCanJoinGame';
 import { BaseGameListItem, BaseGameListItemOptions } from './BaseGameListItem';
 import {
   NonStartedGameListItem,
@@ -38,12 +40,14 @@ describe(NonStartedGameListItem.name, () => {
   describe('when called', () => {
     let baseGameListItemContentFixture: string;
     let slugFixture: string;
+    let userCanJoinGameResultFixture: boolean;
 
     let baseGameListItemContent: string | null | undefined;
 
     beforeAll(() => {
       baseGameListItemContentFixture = 'Expected content fixture';
       slugFixture = '/slug-fixture';
+      userCanJoinGameResultFixture = true;
 
       const baseGameListItemFixture = (
         <div className="base-game-list-item-fixture">
@@ -56,6 +60,10 @@ describe(NonStartedGameListItem.name, () => {
       ).mockReturnValueOnce(baseGameListItemFixture);
 
       (getSlug as jest.Mock<typeof getSlug>).mockReturnValueOnce(slugFixture);
+
+      (
+        userCanJoinGame as jest.Mock<typeof userCanJoinGame>
+      ).mockReturnValueOnce(userCanJoinGameResultFixture);
 
       const renderResult: RenderResult = render(
         <NonStartedGameListItem {...nonStartedGameListItemOptionsMock} />,

--- a/packages/frontend/web-ui/src/game/components/NonStartedGameListItem.tsx
+++ b/packages/frontend/web-ui/src/game/components/NonStartedGameListItem.tsx
@@ -5,6 +5,7 @@ import { MouseEvent, MouseEventHandler } from 'react';
 
 import { getSlug } from '../../common/helpers/getSlug';
 import { PageName } from '../../common/models/PageName';
+import { userCanJoinGame } from '../helpers/userCanJoinGame';
 import { BaseGameListItem } from './BaseGameListItem';
 
 export type NonStartedGameListItemButtonOptions =
@@ -20,6 +21,7 @@ export interface NonStartedGameListItemButtonsOptions {
 
 export interface NonStartedGameListItemOptions {
   buttons?: NonStartedGameListItemButtonsOptions;
+  user?: apiModels.UserV1;
   game: apiModels.GameV1;
 }
 
@@ -63,6 +65,7 @@ export const NonStartedGameListItem = (
       <Button
         className="game-list-item-button"
         component="a"
+        disabled={!userCanJoinGame(options.game, options.user)}
         href={`${getSlug(PageName.joinGame)}?gameId=${options.game.id}`}
         startIcon={<JoinInner />}
       >

--- a/packages/frontend/web-ui/src/game/helpers/userCanJoinGame.spec.ts
+++ b/packages/frontend/web-ui/src/game/helpers/userCanJoinGame.spec.ts
@@ -1,0 +1,140 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { models as apiModels } from '@cornie-js/api-models';
+
+import { userCanJoinGame } from './userCanJoinGame';
+
+describe(userCanJoinGame.name, () => {
+  describe('having an undefined user', () => {
+    let gameV1Fixture: apiModels.GameV1;
+
+    beforeAll(() => {
+      gameV1Fixture = {
+        id: 'game-id',
+        isPublic: false,
+        state: {
+          slots: [],
+          status: 'nonStarted',
+        },
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = userCanJoinGame(gameV1Fixture, undefined);
+      });
+
+      it('should return false', () => {
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('having an user and a finished game', () => {
+    let gameV1Fixture: apiModels.FinishedGameV1;
+    let userV1Fixture: apiModels.UserV1;
+
+    beforeAll(() => {
+      gameV1Fixture = {
+        id: 'game-id',
+        isPublic: false,
+        state: {
+          slots: [],
+          status: 'finished',
+        },
+      };
+
+      userV1Fixture = {
+        active: true,
+        id: 'id',
+        name: 'name',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = userCanJoinGame(gameV1Fixture, userV1Fixture);
+      });
+
+      it('should return false', () => {
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('having an user and a non started game with slot with user id', () => {
+    let gameV1Fixture: apiModels.NonStartedGameV1;
+    let userV1Fixture: apiModels.UserV1;
+
+    beforeAll(() => {
+      userV1Fixture = {
+        active: true,
+        id: 'id',
+        name: 'name',
+      };
+
+      gameV1Fixture = {
+        id: 'game-id',
+        isPublic: false,
+        state: {
+          slots: [
+            {
+              userId: userV1Fixture.id,
+            },
+          ],
+          status: 'nonStarted',
+        },
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = userCanJoinGame(gameV1Fixture, userV1Fixture);
+      });
+
+      it('should return false', () => {
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('having an user and a non started game without slot with user id', () => {
+    let gameV1Fixture: apiModels.NonStartedGameV1;
+    let userV1Fixture: apiModels.UserV1;
+
+    beforeAll(() => {
+      userV1Fixture = {
+        active: true,
+        id: 'id',
+        name: 'name',
+      };
+
+      gameV1Fixture = {
+        id: 'game-id',
+        isPublic: false,
+        state: {
+          slots: [],
+          status: 'nonStarted',
+        },
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = userCanJoinGame(gameV1Fixture, userV1Fixture);
+      });
+
+      it('should return true', () => {
+        expect(result).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/frontend/web-ui/src/game/helpers/userCanJoinGame.ts
+++ b/packages/frontend/web-ui/src/game/helpers/userCanJoinGame.ts
@@ -1,0 +1,15 @@
+import { models as apiModels } from '@cornie-js/api-models';
+
+export function userCanJoinGame(
+  game: apiModels.GameV1,
+  user: apiModels.UserV1 | undefined,
+): boolean {
+  return (
+    user !== undefined &&
+    game.state.status === 'nonStarted' &&
+    !game.state.slots.some(
+      (slot: apiModels.NonStartedGameSlotV1): boolean =>
+        slot.userId === user.id,
+    )
+  );
+}

--- a/packages/frontend/web-ui/src/game/pages/PublicGames.spec.tsx
+++ b/packages/frontend/web-ui/src/game/pages/PublicGames.spec.tsx
@@ -1,0 +1,114 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('../../common/helpers/mapUseQueryHookResult');
+jest.mock('../../common/hooks/useRedirectUnauthorized');
+jest.mock('../../common/http/services/cornieApi');
+jest.mock('../../common/layout/CornieLayout');
+jest.mock('../components/NonStartedGameList');
+
+import { render, RenderResult } from '@testing-library/react';
+import { MouseEventHandler } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { mapUseQueryHookResult } from '../../common/helpers/mapUseQueryHookResult';
+import { cornieApi } from '../../common/http/services/cornieApi';
+import {
+  NonStartedGameList,
+  NonStartedGameListOptions,
+} from '../components/NonStartedGameList';
+import { PublicGames } from './PublicGames';
+
+describe(PublicGames.name, () => {
+  describe('when called', () => {
+    let nonStartedGameListFixture: React.JSX.Element;
+
+    let expectedNonStartedGameListFixture: ChildNode;
+
+    let nonStartedGameListComponent: unknown;
+
+    beforeAll(() => {
+      (
+        cornieApi.useGetGamesV1MineQuery as jest.Mock<
+          typeof cornieApi.useGetGamesV1MineQuery
+        >
+      ).mockReturnValueOnce({
+        data: undefined,
+        error: undefined,
+        isLoading: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        refetch: jest.fn<any>(),
+      });
+
+      (
+        cornieApi.useGetUsersV1MeQuery as jest.Mock<
+          typeof cornieApi.useGetUsersV1MeQuery
+        >
+      ).mockReturnValueOnce({
+        data: undefined,
+        error: undefined,
+        isLoading: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        refetch: jest.fn<any>(),
+      });
+
+      (mapUseQueryHookResult as jest.Mock<typeof mapUseQueryHookResult>)
+        .mockReturnValueOnce(null)
+        .mockReturnValueOnce(null);
+
+      nonStartedGameListFixture = (
+        <div data-testid="non-started-game-list-fixture">
+          Non started game list mock
+        </div>
+      );
+
+      (
+        NonStartedGameList as jest.Mock<typeof NonStartedGameList>
+      ).mockReturnValueOnce(nonStartedGameListFixture);
+
+      const renderResult: RenderResult = render(
+        <MemoryRouter>
+          <PublicGames />
+        </MemoryRouter>,
+      );
+
+      nonStartedGameListComponent = renderResult.getByTestId(
+        'non-started-game-list-fixture',
+      );
+
+      expectedNonStartedGameListFixture = render(nonStartedGameListFixture)
+        .container.childNodes[0] as ChildNode;
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call NonStartedGameList()', () => {
+      const expectedOptions: NonStartedGameListOptions = {
+        buttons: {
+          join: true,
+        },
+        gamesResult: null,
+        pagination: {
+          onNextPageButtonClick: expect.any(
+            Function,
+          ) as unknown as MouseEventHandler<HTMLButtonElement>,
+          onPreviousPageButtonClick: expect.any(
+            Function,
+          ) as unknown as MouseEventHandler<HTMLButtonElement>,
+        },
+        title: 'Public Games',
+        usersMeResult: null,
+      };
+
+      expect(NonStartedGameList).toHaveBeenCalledTimes(1);
+      expect(NonStartedGameList).toHaveBeenCalledWith(expectedOptions, {});
+    });
+
+    it('should render a non started game list', () => {
+      expect(nonStartedGameListComponent).toStrictEqual(
+        expectedNonStartedGameListFixture,
+      );
+    });
+  });
+});

--- a/packages/frontend/web-ui/src/game/pages/PublicGames.tsx
+++ b/packages/frontend/web-ui/src/game/pages/PublicGames.tsx
@@ -1,0 +1,111 @@
+import { models as apiModels } from '@cornie-js/api-models';
+import { Box, Grid2 } from '@mui/material';
+import { useState } from 'react';
+
+import { mapUseQueryHookResult } from '../../common/helpers/mapUseQueryHookResult';
+import { useRedirectUnauthorized } from '../../common/hooks/useRedirectUnauthorized';
+import { cornieApi } from '../../common/http/services/cornieApi';
+import { CornieLayout } from '../../common/layout/CornieLayout';
+import { Either } from '../../common/models/Either';
+import { NonStartedGameList } from '../components/NonStartedGameList';
+import { GameStatus } from '../models/GameStatus';
+
+const GAME_STATUS_NON_STARTED: GameStatus = 'nonStarted';
+const GAMES_REFRESH_INTERVAL_MS = 10000;
+const PAGE_SIZE: number = 10;
+
+function useGetGamesV1(
+  page: number,
+  status: string,
+): { result: Either<string, apiModels.GameArrayV1> | null } {
+  const result = cornieApi.useGetGamesV1Query(
+    {
+      params: [
+        {
+          isPublic: 'true',
+          page: page.toString(),
+          pageSize: PAGE_SIZE.toString(),
+          status,
+        },
+      ],
+    },
+    {
+      pollingInterval: GAMES_REFRESH_INTERVAL_MS,
+    },
+  );
+
+  return { result: mapUseQueryHookResult(result) };
+}
+
+function useGetUserMe(): { result: Either<string, apiModels.UserV1> | null } {
+  const useGetUsersV1MeQueryResult = cornieApi.useGetUsersV1MeQuery({
+    params: [],
+  });
+
+  const result: Either<string, apiModels.UserV1> | null = mapUseQueryHookResult(
+    useGetUsersV1MeQueryResult,
+  );
+
+  return { result };
+}
+
+export const PublicGames = (): React.JSX.Element => {
+  useRedirectUnauthorized();
+
+  const [nonStartedPage, setNonStartedPage] = useState<number>(1);
+
+  const { result: nonStartedGamesResult } = useGetGamesV1(
+    nonStartedPage,
+    GAME_STATUS_NON_STARTED,
+  );
+
+  const { result: usersV1MeResult } = useGetUserMe();
+
+  const onNextPage = (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (
+      nonStartedGamesResult?.isRight === true &&
+      nonStartedGamesResult.value.length > 0
+    ) {
+      setNonStartedPage(nonStartedPage + 1);
+    }
+  };
+
+  const onPreviousPage = (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (nonStartedGamesResult?.isRight === true) {
+      const previousPage: number = nonStartedPage - 1;
+      if (previousPage > 0) {
+        setNonStartedPage(previousPage);
+      }
+    }
+  };
+
+  return (
+    <CornieLayout withFooter withNavBar>
+      <Box
+        component="div"
+        className="page-section-container public-games-page-container"
+      >
+        <Grid2 container>
+          <Grid2 size={12}>
+            <NonStartedGameList
+              buttons={{
+                join: true,
+              }}
+              gamesResult={nonStartedGamesResult}
+              pagination={{
+                onNextPageButtonClick: onNextPage,
+                onPreviousPageButtonClick: onPreviousPage,
+              }}
+              title="Public Games"
+              usersMeResult={usersV1MeResult}
+            />
+          </Grid2>
+        </Grid2>
+      </Box>
+    </CornieLayout>
+  );
+};

--- a/packages/frontend/web-ui/src/game/routes/GameRoutes.tsx
+++ b/packages/frontend/web-ui/src/game/routes/GameRoutes.tsx
@@ -2,12 +2,14 @@ import { Route, Routes } from 'react-router-dom';
 
 import { CreateNewGame } from '../pages/CreateNewGame';
 import { JoinExistingGame } from '../pages/JoinExistingGame';
+import { PublicGames } from '../pages/PublicGames';
 
 export const GameRoutes = (): React.JSX.Element => {
   return (
     <Routes>
       <Route path="/" element={<CreateNewGame />} />
-      <Route path="join" element={<JoinExistingGame />} />
+      <Route path="/join" element={<JoinExistingGame />} />
+      <Route path="/public" element={<PublicGames />} />
     </Routes>
   );
 };

--- a/packages/frontend/web-ui/src/home/components/HomeWithAuth.spec.tsx
+++ b/packages/frontend/web-ui/src/home/components/HomeWithAuth.spec.tsx
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 jest.mock('../../app/store/hooks');
+jest.mock('../../common/helpers/mapUseQueryHookResult');
 jest.mock('../../common/http/services/cornieApi');
 jest.mock('../../game/components/ActiveGameList');
 jest.mock('../../game/components/NonStartedGameList');
@@ -10,6 +11,7 @@ import { MouseEventHandler } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { useAppSelector } from '../../app/store/hooks';
+import { mapUseQueryHookResult } from '../../common/helpers/mapUseQueryHookResult';
 import { cornieApi } from '../../common/http/services/cornieApi';
 import {
   ActiveGameList,
@@ -61,6 +63,23 @@ describe(HomeWithAuth.name, () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           refetch: jest.fn<any>(),
         });
+
+      (
+        cornieApi.useGetUsersV1MeQuery as jest.Mock<
+          typeof cornieApi.useGetUsersV1MeQuery
+        >
+      ).mockReturnValueOnce({
+        data: undefined,
+        error: undefined,
+        isLoading: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        refetch: jest.fn<any>(),
+      });
+
+      (mapUseQueryHookResult as jest.Mock<typeof mapUseQueryHookResult>)
+        .mockReturnValueOnce(null)
+        .mockReturnValueOnce(null)
+        .mockReturnValueOnce(null);
 
       activeGameListFixture = (
         <div className="active-game-list-fixture">Active game list mock</div>
@@ -138,6 +157,7 @@ describe(HomeWithAuth.name, () => {
           ) as unknown as MouseEventHandler<HTMLButtonElement>,
         },
         title: 'Pending Games',
+        usersMeResult: null,
       };
 
       expect(NonStartedGameList).toHaveBeenCalledTimes(1);

--- a/packages/frontend/web-ui/src/scss/game/pages/_index.scss
+++ b/packages/frontend/web-ui/src/scss/game/pages/_index.scss
@@ -1,2 +1,3 @@
 @use 'createGame';
 @use 'joinGame';
+@use 'publicGames';

--- a/packages/frontend/web-ui/src/scss/game/pages/_publicGames.scss
+++ b/packages/frontend/web-ui/src/scss/game/pages/_publicGames.scss
@@ -1,0 +1,7 @@
+.public-games-page-container {
+  padding: 1rem;
+}
+
+.public-games-page-container .games-container {
+  min-height: 800px;
+}

--- a/packages/frontend/web-ui/src/scss/home/_gameList.scss
+++ b/packages/frontend/web-ui/src/scss/home/_gameList.scss
@@ -11,72 +11,71 @@
   box-shadow:
     0 4px 8px 0 var(--cg-bkg-secondary-dark),
     0 6px 20px 0 var(--cg-bkg-secondary-dark);
-}
 
-.games-container .game-list-text {
-  color: var(--cg-text-primary);
-  padding: 0.5rem;
-  text-align: left;
-  font-size: variables.$font-sm;
-}
+  .game-list-text {
+    color: var(--cg-text-primary);
+    padding: 0.5rem;
+    text-align: left;
+    font-size: variables.$font-sm;
+  }
 
-.games-container .game-list-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  background-color: var(--cg-bkg-primary-light);
-  border: 2px solid var(--cg-bkg-secondary-light);
-  border-radius: 10px;
-  box-shadow: 0 2px 4px 0 var(--cg-bkg-secondary-dark);
-  margin: 0.5rem;
-  padding: 0.5rem;
-}
+  .game-list-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background-color: var(--cg-bkg-primary-light);
+    border: 2px solid var(--cg-bkg-secondary-light);
+    border-radius: 10px;
+    box-shadow: 0 2px 4px 0 var(--cg-bkg-secondary-dark);
+    margin: 0.5rem;
+    padding: 0.5rem;
 
-.games-container .game-list-item .game-list-item-button:hover {
-  background-color: var(--cg-bkg-secondary-main);
-  font-weight: bold;
-  color: var(--cg-btn-third-txt);
-}
+    .game-list-item-button {
+      background-color: var(--cg-bkg-primary-dark);
+      border: 1px solid var(--cg-bkg-secondary-light);
+      box-shadow: 0 4px 8px 0 var(--cg-text-primary);
+      color: var(--cg-text-primary);
+      font-weight: bold;
+      height: 2.5rem;
+      width: 7rem;
 
-.games-container .game-list-item .game-list-item-text {
-  color: var(--cg-text-primary);
-  text-align: center;
-  font-size: variables.$font-xs;
-}
+      &:disabled,
+      &[aria-disabled='true'] {
+        color: var(--cg-bkg-primary-light);
+      }
 
-.games-container .game-list-item .game-list-item-button {
-  background-color: var(--cg-bkg-primary-dark);
-  border: 1px solid var(--cg-bkg-secondary-light);
-  box-shadow: 0 4px 8px 0 var(--cg-text-primary);
-  color: var(--cg-text-primary);
-  font-weight: bold;
-  height: 2.5rem;
-  width: 7rem;
-}
+      &:hover {
+        background-color: var(--cg-bkg-secondary-main);
+        font-weight: bold;
+        color: var(--cg-btn-third-txt);
+      }
+    }
 
-.games-container .game-list-item .game-list-item-button:hover {
-  background-color: var(--cg-bkg-secondary-main);
-  color: var(--cg-btn-third-txt);
-  font-weight: bold;
-}
+    .game-list-item-text {
+      color: var(--cg-text-primary);
+      text-align: center;
+      font-size: variables.$font-xs;
+    }
+  }
 
-.games-container .game-list-pagination {
-  display: flex;
-  justify-content: center;
-  gap: 1rem;
-  margin: 1rem auto;
-}
+  .game-list-pagination {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin: 1rem auto;
 
-.games-container .game-list-pagination .game-list-pagination-button {
-  background-color: var(--cg-bkg-primary-main);
-  border: 1px solid var(--cg-bkg-secondary-light);
-  box-shadow:
-    0 2px 6px 0 var(--cg-bkg-secondary-main),
-    0 2px 6px 0 var(--cg-bkg-secondary-main);
-}
+    .game-list-pagination-button {
+      background-color: var(--cg-bkg-primary-main);
+      border: 1px solid var(--cg-bkg-secondary-light);
+      box-shadow:
+        0 2px 6px 0 var(--cg-bkg-secondary-main),
+        0 2px 6px 0 var(--cg-bkg-secondary-main);
 
-.games-container .game-list-pagination .game-list-pagination-button:hover {
-  background-color: var(--cg-bkg-secondary-main);
-  font-weight: bold;
-  color: var(--cg-btn-third-txt);
+      &:hover {
+        background-color: var(--cg-bkg-secondary-main);
+        font-weight: bold;
+        color: var(--cg-btn-third-txt);
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Added
- Added `PublicGames` page component.
- Added `userCanJoinGame` helper.

### Changed
- Updated navbar with public games link.
- Updated game routes with public games one.
- Updated `cornieApi` mock with `useGetGamesV1Query`.
- Updated `NonStartedGameListItem` join button to be disabled if user cannot join the game.
