### PR TITLE
Update play card game event

### DIFF
--- a/packages/api/libraries/api-json-schemas/schemas/v2/gameEvents/cards-played-game-event.json
+++ b/packages/api/libraries/api-json-schemas/schemas/v2/gameEvents/cards-played-game-event.json
@@ -2,38 +2,88 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://onegame.schemas/api/v2/game-events/cards-played-game-event.json",
   "title": "CardsPlayedGameEventV2",
-  "additionalProperties": false,
-  "type": "object",
-  "properties": {
-    "cards": {
-      "$ref": "https://onegame.schemas/api/v1/cards/card-array.json"
-    },
-    "currentCard": {
-      "anyOf": [
-        {
+  "anyOf": [
+    {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "cards": {
+          "$ref": "https://onegame.schemas/api/v1/cards/card-array.json"
+        },
+        "currentCard": {
           "$ref": "https://onegame.schemas/api/v1/cards/card.json"
         },
-        {
-          "type": "null"
+        "currentColor": {
+          "$ref": "https://onegame.schemas/api/v1/cards/card-color.json"
+        },
+        "currentDirection": {
+          "$ref": "https://onegame.schemas/api/v1/games/game-direction.json"
+        },
+        "currentPlayingSlotIndex": {
+          "type": "integer"
+        },
+        "drawCount": {
+          "type": "number"
+        },
+        "kind": {
+          "const": "cardsPlayed",
+          "type": "string"
+        },
+        "position": {
+          "type": "integer"
         }
+      },
+      "required": [
+        "cards",
+        "currentCard",
+        "currentColor",
+        "currentDirection",
+        "drawCount",
+        "currentPlayingSlotIndex",
+        "kind",
+        "position"
       ]
     },
-    "currentPlayingSlotIndex": {
-      "type": "integer"
-    },
-    "kind": {
-      "const": "cardsPlayed",
-      "type": "string"
-    },
-    "position": {
-      "type": "integer"
+    {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "cards": {
+          "$ref": "https://onegame.schemas/api/v1/cards/card-array.json"
+        },
+        "currentCard": {
+          "type": "null"
+        },
+        "currentColor": {
+          "type": "null"
+        },
+        "currentDirection": {
+          "type": "null"
+        },
+        "currentPlayingSlotIndex": {
+          "type": "integer"
+        },
+        "drawCount": {
+          "type": "null"
+        },
+        "kind": {
+          "const": "cardsPlayed",
+          "type": "string"
+        },
+        "position": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cards",
+        "currentCard",
+        "currentColor",
+        "currentDirection",
+        "drawCount",
+        "currentPlayingSlotIndex",
+        "kind",
+        "position"
+      ]
     }
-  },
-  "required": [
-    "cards",
-    "currentCard",
-    "currentPlayingSlotIndex",
-    "kind",
-    "position"
   ]
 }

--- a/packages/api/libraries/api-models/src/models/types.ts
+++ b/packages/api/libraries/api-models/src/models/types.ts
@@ -66,6 +66,27 @@ export type GameEventV2 =
   | CardsDrawnGameEventV2
   | CardsPlayedGameEventV2
   | TurnPassedGameEventV2;
+export type CardsPlayedGameEventV2 =
+  | {
+      cards: CardArrayV1;
+      currentCard: CardV1;
+      currentColor: CardColorV1;
+      currentDirection: GameDirectionV1;
+      currentPlayingSlotIndex: number;
+      drawCount: number;
+      kind: 'cardsPlayed';
+      position: number;
+    }
+  | {
+      cards: CardArrayV1;
+      currentCard: null;
+      currentColor: null;
+      currentDirection: null;
+      currentPlayingSlotIndex: number;
+      drawCount: null;
+      kind: 'cardsPlayed';
+      position: number;
+    };
 
 export interface DrawCardV1 {
   color: CardColorV1;
@@ -230,13 +251,6 @@ export interface CardsDrawnGameEventV2 {
   currentPlayingSlotIndex: number;
   drawAmount: number;
   kind: 'cardsDrawn';
-  position: number;
-}
-export interface CardsPlayedGameEventV2 {
-  cards: CardArrayV1;
-  currentCard: CardV1 | null;
-  currentPlayingSlotIndex: number;
-  kind: 'cardsPlayed';
   position: number;
 }
 export interface TurnPassedGameEventV2 {

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/nest/modules/GameActionDbModule.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/nest/modules/GameActionDbModule.ts
@@ -4,6 +4,7 @@ import { DynamicModule, Module } from '@nestjs/common';
 import { CardDbModule } from '../../../../cards/adapter/nest/modules/CardDbModule';
 import { DbModuleOptions } from '../../../../foundation/db/adapter/nest/models/DbModuleOptions';
 import { DbModule } from '../../../../foundation/db/adapter/nest/modules/DbModule';
+import { GameDbModule } from '../../../../games/adapter/nest/modules/GameDbModule';
 import { GameActionPersistenceTypeOrmAdapter } from '../../typeorm/adapters/GameActionPersistenceTypeOrmAdapter';
 import { GameActionCreateQueryTypeOrmFromGameActionCreateQueryBuilder } from '../../typeorm/builders/GameActionCreateQueryTypeOrmFromGameActionCreateQueryBuilder';
 import { GameActionFindQueryTypeOrmFromGameActionFindQueryBuilder } from '../../typeorm/builders/GameActionFindQueryTypeOrmFromGameActionFindQueryBuilder';
@@ -21,6 +22,7 @@ export class GameActionDbModule {
       imports: [
         CardDbModule,
         DbModule.forRootAsync(dbModuleOptions),
+        GameDbModule.forRootAsync(dbModuleOptions),
         dbModuleOptions.builders.feature([GameActionDb]),
       ],
       module: GameActionDbModule,

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/builders/GameActionCreateQueryTypeOrmFromGameActionCreateQueryBuilder.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/builders/GameActionCreateQueryTypeOrmFromGameActionCreateQueryBuilder.ts
@@ -1,9 +1,11 @@
 import { Builder } from '@cornie-js/backend-common';
-import { Card } from '@cornie-js/backend-game-domain/cards';
+import { Card, CardColor } from '@cornie-js/backend-game-domain/cards';
 import {
   GameActionCreateQuery,
   GameActionKind,
+  PlayCardsGameActionCreateQueryStateUpdate,
 } from '@cornie-js/backend-game-domain/gameActions';
+import { GameDirection } from '@cornie-js/backend-game-domain/games';
 import { Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
@@ -14,12 +16,17 @@ import {
 } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity.js';
 
+import { CardColorDbBuilder } from '../../../../cards/adapter/typeorm/builders/CardColorDbBuilder';
 import { CardDbBuilder } from '../../../../cards/adapter/typeorm/builders/CardDbBuilder';
+import { CardColorDb } from '../../../../cards/adapter/typeorm/models/CardColorDb';
 import { CardDb } from '../../../../cards/adapter/typeorm/models/CardDb';
+import { GameDirectionDbFromGameDirectionBuilder } from '../../../../games/adapter/typeorm/builders/GameDirectionDbFromGameDirectionBuilder';
+import { GameDirectionDb } from '../../../../games/adapter/typeorm/models/GameDirectionDb';
 import { GameActionDb } from '../models/GameActionDb';
 import { GameActionDbPayload } from '../models/GameActionDbPayload';
 import { GameActionDbVersion } from '../models/GameActionDbVersion';
 import { GameActionDbPayloadV1Kind } from '../models/v1/GameActionDbPayloadV1Kind';
+import { PlayCardsGameActionStateUpdateDbPayloadV1 } from '../models/v1/PlayCardsGameActionDbPayloadV1';
 
 @Injectable()
 export class GameActionCreateQueryTypeOrmFromGameActionCreateQueryBuilder
@@ -29,16 +36,27 @@ export class GameActionCreateQueryTypeOrmFromGameActionCreateQueryBuilder
       [GameActionCreateQuery, InsertQueryBuilder<GameActionDb>]
     >
 {
+  readonly #cardColorDbBuilder: Builder<CardColorDb, [CardColor]>;
   readonly #cardDbBuilder: Builder<CardDb, [Card]>;
+  readonly #gameDirectionDbFromGameDirection: Builder<
+    GameDirectionDb,
+    [GameDirection]
+  >;
   readonly #repository: Repository<GameActionDb>;
 
   constructor(
+    @Inject(CardColorDbBuilder)
+    cardColorDbBuilder: Builder<CardColorDb, [CardColor]>,
     @Inject(CardDbBuilder)
     cardDbBuilder: Builder<CardDb, [Card]>,
+    @Inject(GameDirectionDbFromGameDirectionBuilder)
+    gameDirectionDbFromGameDirection: Builder<GameDirectionDb, [GameDirection]>,
     @InjectRepository(GameActionDb)
     repository: Repository<GameActionDb>,
   ) {
+    this.#cardColorDbBuilder = cardColorDbBuilder;
     this.#cardDbBuilder = cardDbBuilder;
+    this.#gameDirectionDbFromGameDirection = gameDirectionDbFromGameDirection;
     this.#repository = repository;
   }
 
@@ -85,11 +103,10 @@ export class GameActionCreateQueryTypeOrmFromGameActionCreateQueryBuilder
           cards: gameActionCreateQuery.cards.map((card: Card) =>
             this.#cardDbBuilder.build(card),
           ),
-          currentCard:
-            gameActionCreateQuery.currentCard === null
-              ? null
-              : this.#cardDbBuilder.build(gameActionCreateQuery.currentCard),
           kind: GameActionDbPayloadV1Kind.playCards,
+          stateUpdate: this.#buildStateUpdateDb(
+            gameActionCreateQuery.stateUpdate,
+          ),
           version: GameActionDbVersion.v1,
         };
     }
@@ -115,5 +132,27 @@ export class GameActionCreateQueryTypeOrmFromGameActionCreateQueryBuilder
     return {
       [`${GameActionDb.name}.game`]: gameActionCreateQuery.gameId,
     };
+  }
+
+  #buildStateUpdateDb(
+    stateUpdate: PlayCardsGameActionCreateQueryStateUpdate,
+  ): PlayCardsGameActionStateUpdateDbPayloadV1 {
+    if (stateUpdate.currentCard === null) {
+      return {
+        currentCard: null,
+        currentColor: null,
+        currentDirection: null,
+        drawCount: null,
+      };
+    } else {
+      return {
+        currentCard: this.#cardDbBuilder.build(stateUpdate.currentCard),
+        currentColor: this.#cardColorDbBuilder.build(stateUpdate.currentColor),
+        currentDirection: this.#gameDirectionDbFromGameDirection.build(
+          stateUpdate.currentDirection,
+        ),
+        drawCount: stateUpdate.drawCount,
+      };
+    }
   }
 }

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/fixtures/GameActionDbFixtures.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/fixtures/GameActionDbFixtures.ts
@@ -19,6 +19,16 @@ export class GameActionDbFixtures {
     };
   }
 
+  public static get withGameActive(): GameActionDb {
+    const gameDbFixture: GameDb =
+      GameDbFixtures.withStatusActiveAndGameSlotsOne;
+
+    return {
+      ...GameActionDbFixtures.any,
+      game: gameDbFixture,
+    };
+  }
+
   public static get withPayloadWithKindDrawCardsAndCardsOne(): GameActionDb {
     return {
       ...GameActionDbFixtures.any,
@@ -35,7 +45,7 @@ export class GameActionDbFixtures {
     };
   }
 
-  public static get withPayloadWithKindPlayCardsAndCardsOne(): GameActionDb {
+  public static get withActiveGamePayloadWithKindPlayCardsAndCardsOne(): GameActionDb {
     return {
       ...GameActionDbFixtures.any,
       payload: JSON.stringify(

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/fixtures/GameActionDbPayloadV1Fixtures.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/fixtures/GameActionDbPayloadV1Fixtures.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
+import { GameDirectionDb } from '../../../../games/adapter/typeorm/models/GameDirectionDb';
 import { GameActionDbVersion } from '../models/GameActionDbVersion';
 import { DrawCardsGameActionDbPayloadV1 } from '../models/v1/DrawCardsGameActionDbPayloadV1';
 import { GameActionDbPayloadV1 } from '../models/v1/GameActionDbPayloadV1';
@@ -34,8 +35,13 @@ export class GameActionDbPayloadV1Fixtures {
   public static get withKindPlayCardsAndCardsOne(): PlayCardsGameActionDbPayloadV1 {
     return {
       cards: [0x0039],
-      currentCard: 0x0039,
       kind: GameActionDbPayloadV1Kind.playCards,
+      stateUpdate: {
+        currentCard: 0x0039,
+        currentColor: 0x0030,
+        currentDirection: GameDirectionDb.antiClockwise,
+        drawCount: 0,
+      },
       version: GameActionDbVersion.v1,
     };
   }

--- a/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/models/v1/PlayCardsGameActionDbPayloadV1.ts
+++ b/packages/backend/apps/game/backend-game-adapter-typeorm/src/gameActions/adapter/typeorm/models/v1/PlayCardsGameActionDbPayloadV1.ts
@@ -1,9 +1,25 @@
+import { CardColorDb } from '../../../../../cards/adapter/typeorm/models/CardColorDb';
 import { CardDb } from '../../../../../cards/adapter/typeorm/models/CardDb';
+import { GameDirectionDb } from '../../../../../games/adapter/typeorm/models/GameDirectionDb';
 import { BaseGameActionDbPayloadV1 } from './BaseGameActionDbPayloadV1';
 import { GameActionDbPayloadV1Kind } from './GameActionDbPayloadV1Kind';
+
+export type PlayCardsGameActionStateUpdateDbPayloadV1 =
+  | {
+      currentCard: CardDb;
+      currentColor: CardColorDb;
+      currentDirection: GameDirectionDb;
+      drawCount: number;
+    }
+  | {
+      currentCard: null;
+      currentColor: null;
+      currentDirection: null;
+      drawCount: null;
+    };
 
 export interface PlayCardsGameActionDbPayloadV1
   extends BaseGameActionDbPayloadV1<GameActionDbPayloadV1Kind.playCards> {
   readonly cards: CardDb[];
-  readonly currentCard: CardDb | null;
+  readonly stateUpdate: PlayCardsGameActionStateUpdateDbPayloadV1;
 }

--- a/packages/backend/apps/game/backend-game-application/src/gameActions/adapter/nest/modules/GameActionApplicationModule.ts
+++ b/packages/backend/apps/game/backend-game-application/src/gameActions/adapter/nest/modules/GameActionApplicationModule.ts
@@ -1,6 +1,7 @@
 import { DynamicModule, ForwardReference, Module, Type } from '@nestjs/common';
 
 import { CardModule } from '../../../../cards/adapter/nest/modules/CardModule';
+import { GameDirectionApplicationModule } from '../../../../games/adapter/nest/modules/GameDirectionApplicationModule';
 import { GameEventV2FromGameActionBuilder } from '../../../application/builders/GameEventV2FromGameActionBuilder';
 import { MessageEventFromGameActionBuilder } from '../../../application/builders/MessageEventFromGameActionBuilder';
 import { GameActionManagementInputPort } from '../../../application/ports/input/GameActionManagementInputPort';
@@ -18,7 +19,7 @@ export class GameActionApplicationModule {
         GameEventV2FromGameActionBuilder,
       ],
       global: false,
-      imports: [...(imports ?? []), CardModule],
+      imports: [...(imports ?? []), CardModule, GameDirectionApplicationModule],
       module: GameActionApplicationModule,
       providers: [
         GameActionManagementInputPort,

--- a/packages/backend/apps/game/backend-game-application/src/gameActions/application/builders/GameEventV2FromGameActionBuilder.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/gameActions/application/builders/GameEventV2FromGameActionBuilder.spec.ts
@@ -2,29 +2,45 @@ import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 import { models as apiModels } from '@cornie-js/api-models';
 import { Builder } from '@cornie-js/backend-common';
-import { Card } from '@cornie-js/backend-game-domain/cards';
+import { Card, CardColor } from '@cornie-js/backend-game-domain/cards';
 import {
   DrawGameAction,
   GameAction,
   PassTurnGameAction,
+  PlayCardsGameAction,
 } from '@cornie-js/backend-game-domain/gameActions';
 import { GameActionFixtures } from '@cornie-js/backend-game-domain/gameActions/fixtures';
+import { GameDirection } from '@cornie-js/backend-game-domain/games';
 
 import { CardV1Fixtures } from '../../../cards/application/fixtures';
 import { GameEventV2FromGameActionBuilder } from './GameEventV2FromGameActionBuilder';
 
 describe(GameEventV2FromGameActionBuilder.name, () => {
+  let cardColorV1FromCardColorBuilderMock: jest.Mocked<
+    Builder<apiModels.CardColorV1, [CardColor]>
+  >;
   let cardV1FromCardBuilderMock: jest.Mocked<Builder<apiModels.CardV1, [Card]>>;
+  let gameDirectionV1FromGameDirectionBuilder: jest.Mocked<
+    Builder<apiModels.GameDirectionV1, [GameDirection]>
+  >;
 
   let gameEventV2FromGameActionBuilder: GameEventV2FromGameActionBuilder;
 
   beforeAll(() => {
+    cardColorV1FromCardColorBuilderMock = {
+      build: jest.fn(),
+    };
     cardV1FromCardBuilderMock = {
+      build: jest.fn(),
+    };
+    gameDirectionV1FromGameDirectionBuilder = {
       build: jest.fn(),
     };
 
     gameEventV2FromGameActionBuilder = new GameEventV2FromGameActionBuilder(
+      cardColorV1FromCardColorBuilderMock,
       cardV1FromCardBuilderMock,
+      gameDirectionV1FromGameDirectionBuilder,
     );
   });
 
@@ -100,23 +116,33 @@ describe(GameEventV2FromGameActionBuilder.name, () => {
       });
     });
 
-    describe('having a GameMessageEvent with an play cards game action and current card', () => {
-      let gameActionFixture: GameAction;
+    describe('having a GameMessageEvent with an play cards game action and state update', () => {
+      let gameActionFixture: PlayCardsGameAction;
 
       beforeAll(() => {
         gameActionFixture =
-          GameActionFixtures.withKindPlayCardsAndCardsOneAndCurrentCard;
+          GameActionFixtures.withKindPlayCardsAndCardsOneAndStateUpdateNonNull;
       });
 
       describe('when called', () => {
+        let cardColorV1Fixture: apiModels.CardColorV1;
         let cardV1Fixture: apiModels.CardV1;
+        let gameDirectionV1Fixture: apiModels.GameDirectionV1;
 
         let result: unknown;
 
         beforeAll(() => {
+          cardColorV1Fixture = CardColor.blue;
           cardV1Fixture = CardV1Fixtures.any;
+          gameDirectionV1Fixture = GameDirection.antiClockwise;
 
+          cardColorV1FromCardColorBuilderMock.build.mockReturnValueOnce(
+            cardColorV1Fixture,
+          );
           cardV1FromCardBuilderMock.build.mockReturnValue(cardV1Fixture);
+          gameDirectionV1FromGameDirectionBuilder.build.mockReturnValueOnce(
+            gameDirectionV1Fixture,
+          );
 
           result = gameEventV2FromGameActionBuilder.build(gameActionFixture);
         });
@@ -133,8 +159,11 @@ describe(GameEventV2FromGameActionBuilder.name, () => {
             {
               cards: [cardV1Fixture],
               currentCard: cardV1Fixture,
+              currentColor: cardColorV1Fixture,
+              currentDirection: gameDirectionV1Fixture,
               currentPlayingSlotIndex:
                 gameActionFixture.currentPlayingSlotIndex,
+              drawCount: gameActionFixture.stateUpdate.drawCount as number,
               kind: 'cardsPlayed',
               position: gameActionFixture.position,
             },
@@ -178,8 +207,11 @@ describe(GameEventV2FromGameActionBuilder.name, () => {
             {
               cards: [cardV1Fixture],
               currentCard: null,
+              currentColor: null,
+              currentDirection: null,
               currentPlayingSlotIndex:
                 gameActionFixture.currentPlayingSlotIndex,
+              drawCount: null,
               kind: 'cardsPlayed',
               position: gameActionFixture.position,
             },

--- a/packages/backend/apps/game/backend-game-application/src/gameActions/application/builders/GameEventV2FromGameActionBuilder.ts
+++ b/packages/backend/apps/game/backend-game-application/src/gameActions/application/builders/GameEventV2FromGameActionBuilder.ts
@@ -1,6 +1,6 @@
 import { models as apiModels } from '@cornie-js/api-models';
 import { Builder } from '@cornie-js/backend-common';
-import { Card } from '@cornie-js/backend-game-domain/cards';
+import { Card, CardColor } from '@cornie-js/backend-game-domain/cards';
 import {
   DrawGameAction,
   GameAction,
@@ -8,21 +8,45 @@ import {
   PassTurnGameAction,
   PlayCardsGameAction,
 } from '@cornie-js/backend-game-domain/gameActions';
+import { GameDirection } from '@cornie-js/backend-game-domain/games';
 import { Inject, Injectable } from '@nestjs/common';
 
+import { CardColorV1FromCardColorBuilder } from '../../../cards/application/builders/CardColorV1FromCardColorBuilder';
 import { CardV1FromCardBuilder } from '../../../cards/application/builders/CardV1FromCardBuilder';
+import { GameDirectionV1FromGameDirectionBuilder } from '../../../games/application/builders/GameDirectionV1FromGameDirectionBuilder';
 
 @Injectable()
 export class GameEventV2FromGameActionBuilder
   implements Builder<[string | null, apiModels.GameEventV2], [GameAction]>
 {
+  readonly #cardColorV1FromCardColorBuilder: Builder<
+    apiModels.CardColorV1,
+    [CardColor]
+  >;
   readonly #cardV1FromCardBuilder: Builder<apiModels.CardV1, [Card]>;
+  readonly #gameDirectionV1FromGameDirectionBuilder: Builder<
+    apiModels.GameDirectionV1,
+    [GameDirection]
+  >;
 
   constructor(
+    @Inject(CardColorV1FromCardColorBuilder)
+    cardColorV1FromCardColorBuilder: Builder<
+      apiModels.CardColorV1,
+      [CardColor]
+    >,
     @Inject(CardV1FromCardBuilder)
     cardV1FromCardBuilder: Builder<apiModels.CardV1, [Card]>,
+    @Inject(GameDirectionV1FromGameDirectionBuilder)
+    gameDirectionV1FromGameDirectionBuilder: Builder<
+      apiModels.GameDirectionV1,
+      [GameDirection]
+    >,
   ) {
+    this.#cardColorV1FromCardColorBuilder = cardColorV1FromCardColorBuilder;
     this.#cardV1FromCardBuilder = cardV1FromCardBuilder;
+    this.#gameDirectionV1FromGameDirectionBuilder =
+      gameDirectionV1FromGameDirectionBuilder;
   }
 
   public build(gameAction: GameAction): [string | null, apiModels.GameEventV2] {
@@ -45,18 +69,39 @@ export class GameEventV2FromGameActionBuilder
   #buildCardsPlayedGameEventV2(
     gameAction: PlayCardsGameAction,
   ): apiModels.CardsPlayedGameEventV2 {
-    return {
-      cards: gameAction.cards.map((card: Card) =>
-        this.#cardV1FromCardBuilder.build(card),
-      ),
-      currentCard:
-        gameAction.currentCard === null
-          ? null
-          : this.#cardV1FromCardBuilder.build(gameAction.currentCard),
-      currentPlayingSlotIndex: gameAction.currentPlayingSlotIndex,
-      kind: 'cardsPlayed',
-      position: gameAction.position,
-    };
+    if (gameAction.stateUpdate.currentCard === null) {
+      return {
+        cards: gameAction.cards.map((card: Card) =>
+          this.#cardV1FromCardBuilder.build(card),
+        ),
+        currentCard: null,
+        currentColor: null,
+        currentDirection: null,
+        currentPlayingSlotIndex: gameAction.currentPlayingSlotIndex,
+        drawCount: null,
+        kind: 'cardsPlayed',
+        position: gameAction.position,
+      };
+    } else {
+      return {
+        cards: gameAction.cards.map((card: Card) =>
+          this.#cardV1FromCardBuilder.build(card),
+        ),
+        currentCard: this.#cardV1FromCardBuilder.build(
+          gameAction.stateUpdate.currentCard,
+        ),
+        currentColor: this.#cardColorV1FromCardColorBuilder.build(
+          gameAction.stateUpdate.currentColor,
+        ),
+        currentDirection: this.#gameDirectionV1FromGameDirectionBuilder.build(
+          gameAction.stateUpdate.currentDirection,
+        ),
+        currentPlayingSlotIndex: gameAction.currentPlayingSlotIndex,
+        drawCount: gameAction.stateUpdate.drawCount,
+        kind: 'cardsPlayed',
+        position: gameAction.position,
+      };
+    }
   }
 
   #buildGameEventV2(gameAction: GameAction): apiModels.GameEventV2 {

--- a/packages/backend/apps/game/backend-game-application/src/games/application/builders/GameActionCreateQueryFromGameUpdateEventBuilder.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/builders/GameActionCreateQueryFromGameUpdateEventBuilder.spec.ts
@@ -89,15 +89,26 @@ describe(GameActionCreateQueryFromGameUpdateEventBuilder.name, () => {
         it('should return a GameActionCreateQuery', () => {
           const expected: GameActionCreateQuery = {
             cards: activeGameUpdatedCardsDrawEventFixture.cards,
-            currentCard: (
-              activeGameUpdatedCardsDrawEventFixture.game as ActiveGame
-            ).state.currentCard,
             currentPlayingSlotIndex:
               activeGameUpdatedCardsDrawEventFixture.gameBeforeUpdate.state
                 .currentPlayingSlotIndex,
             gameId: activeGameUpdatedCardsDrawEventFixture.gameBeforeUpdate.id,
             id: uuidContextFixture.uuid,
             kind: GameActionKind.playCards,
+            stateUpdate: {
+              currentCard: (
+                activeGameUpdatedCardsDrawEventFixture.game as ActiveGame
+              ).state.currentCard,
+              currentColor: (
+                activeGameUpdatedCardsDrawEventFixture.game as ActiveGame
+              ).state.currentColor,
+              currentDirection: (
+                activeGameUpdatedCardsDrawEventFixture.game as ActiveGame
+              ).state.currentDirection,
+              drawCount: (
+                activeGameUpdatedCardsDrawEventFixture.game as ActiveGame
+              ).state.drawCount,
+            },
             turn: activeGameUpdatedCardsDrawEventFixture.gameBeforeUpdate.state
               .turn,
           };
@@ -133,13 +144,18 @@ describe(GameActionCreateQueryFromGameUpdateEventBuilder.name, () => {
         it('should return a GameActionCreateQuery', () => {
           const expected: GameActionCreateQuery = {
             cards: activeGameUpdatedCardsDrawEventFixture.cards,
-            currentCard: null,
             currentPlayingSlotIndex:
               activeGameUpdatedCardsDrawEventFixture.gameBeforeUpdate.state
                 .currentPlayingSlotIndex,
             gameId: activeGameUpdatedCardsDrawEventFixture.gameBeforeUpdate.id,
             id: uuidContextFixture.uuid,
             kind: GameActionKind.playCards,
+            stateUpdate: {
+              currentCard: null,
+              currentColor: null,
+              currentDirection: null,
+              drawCount: null,
+            },
             turn: activeGameUpdatedCardsDrawEventFixture.gameBeforeUpdate.state
               .turn,
           };

--- a/packages/backend/apps/game/backend-game-application/src/games/application/builders/GameActionCreateQueryFromGameUpdateEventBuilder.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/builders/GameActionCreateQueryFromGameUpdateEventBuilder.ts
@@ -90,18 +90,39 @@ export class GameActionCreateQueryFromGameUpdateEventBuilder
     event: ActiveGameUpdatedCardsPlayEvent,
     context: UuidContext,
   ): PlayCardsGameActionCreateQuery {
-    return {
-      cards: event.cards,
-      currentCard: this.#isActiveGame(event.game)
-        ? event.game.state.currentCard
-        : null,
-      currentPlayingSlotIndex:
-        event.gameBeforeUpdate.state.currentPlayingSlotIndex,
-      gameId: event.gameBeforeUpdate.id,
-      id: context.uuid,
-      kind: GameActionKind.playCards,
-      turn: event.gameBeforeUpdate.state.turn,
-    };
+    if (this.#isActiveGame(event.game)) {
+      return {
+        cards: event.cards,
+        currentPlayingSlotIndex:
+          event.gameBeforeUpdate.state.currentPlayingSlotIndex,
+        gameId: event.gameBeforeUpdate.id,
+        id: context.uuid,
+        kind: GameActionKind.playCards,
+        stateUpdate: {
+          currentCard: event.game.state.currentCard,
+          currentColor: event.game.state.currentColor,
+          currentDirection: event.game.state.currentDirection,
+          drawCount: event.game.state.drawCount,
+        },
+        turn: event.gameBeforeUpdate.state.turn,
+      };
+    } else {
+      return {
+        cards: event.cards,
+        currentPlayingSlotIndex:
+          event.gameBeforeUpdate.state.currentPlayingSlotIndex,
+        gameId: event.gameBeforeUpdate.id,
+        id: context.uuid,
+        kind: GameActionKind.playCards,
+        stateUpdate: {
+          currentCard: null,
+          currentColor: null,
+          currentDirection: null,
+          drawCount: null,
+        },
+        turn: event.gameBeforeUpdate.state.turn,
+      };
+    }
   }
 
   #isActiveGame(game: Game): game is ActiveGame {

--- a/packages/backend/apps/game/backend-game-application/src/games/application/fixtures/GameUpdatedMessageEventFixtures.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/fixtures/GameUpdatedMessageEventFixtures.ts
@@ -55,7 +55,8 @@ export class GameUpdatedMessageEventFixtures {
   public static get withPlayCardsGameActionWithCardsOneAndCurrentCard(): GameUpdatedMessageEvent {
     return {
       ...GameUpdatedMessageEventFixtures.any,
-      gameAction: GameActionFixtures.withKindPlayCardsAndCardsOneAndCurrentCard,
+      gameAction:
+        GameActionFixtures.withKindPlayCardsAndCardsOneAndStateUpdateNonNull,
     };
   }
 

--- a/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/fixtures/GameActionCreateQueryFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/fixtures/GameActionCreateQueryFixtures.ts
@@ -1,4 +1,6 @@
 import { CardFixtures } from '../../../cards/domain/fixtures/CardFixtures';
+import { CardColor } from '../../../cards/domain/valueObjects/CardColor';
+import { GameDirection } from '../../../games/domain/valueObjects/GameDirection';
 import { DrawGameActionCreateQuery } from '../query/DrawGameActionCreateQuery';
 import { PassTurnGameActionCreateQuery } from '../query/PassTurnGameActionCreateQuery';
 import { PlayCardsGameActionCreateQuery } from '../query/PlayCardsGameActionCreateQuery';
@@ -30,11 +32,16 @@ export class GameActionCreateQueryFixtures {
   public static get withKindPlayCardsAndCardsOne(): PlayCardsGameActionCreateQuery {
     return {
       cards: [CardFixtures.any],
-      currentCard: CardFixtures.any,
       currentPlayingSlotIndex: 0,
       gameId: 'e6b54159-a4ef-41fc-994a-20709526bdaa',
       id: '20f00a2b-bc9f-47fd-afb2-c2ed1b60e1b3',
       kind: GameActionKind.playCards,
+      stateUpdate: {
+        currentCard: CardFixtures.any,
+        currentColor: CardColor.blue,
+        currentDirection: GameDirection.antiClockwise,
+        drawCount: 0,
+      },
       turn: 1,
     };
   }

--- a/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/fixtures/GameActionFixtures.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/fixtures/GameActionFixtures.ts
@@ -1,4 +1,6 @@
 import { CardFixtures } from '../../../cards/domain/fixtures/CardFixtures';
+import { CardColor } from '../../../cards/domain/valueObjects/CardColor';
+import { GameDirection } from '../../../games/domain/valueObjects/GameDirection';
 import { DrawGameAction } from '../valueObjects/DrawGameAction';
 import { GameAction } from '../valueObjects/GameAction';
 import { GameActionKind } from '../valueObjects/GameActionKind';
@@ -45,21 +47,31 @@ export class GameActionFixtures {
   public static get withKindPlayCards(): PlayCardsGameAction {
     return {
       cards: [],
-      currentCard: null,
       currentPlayingSlotIndex: 0,
       gameId: 'e6b54159-a4ef-41fc-994a-20709526bdaa',
       id: '16b54159-a4ef-41fc-994a-20709526bda0',
       kind: GameActionKind.playCards,
       position: 1,
+      stateUpdate: {
+        currentCard: null,
+        currentColor: null,
+        currentDirection: null,
+        drawCount: null,
+      },
       turn: 1,
     };
   }
 
-  public static get withKindPlayCardsAndCardsOneAndCurrentCard(): PlayCardsGameAction {
+  public static get withKindPlayCardsAndCardsOneAndStateUpdateNonNull(): PlayCardsGameAction {
     return {
       ...GameActionFixtures.withKindPlayCards,
       cards: [CardFixtures.any],
-      currentCard: CardFixtures.any,
+      stateUpdate: {
+        currentCard: CardFixtures.any,
+        currentColor: CardColor.blue,
+        currentDirection: GameDirection.antiClockwise,
+        drawCount: 0,
+      },
     };
   }
 
@@ -67,7 +79,12 @@ export class GameActionFixtures {
     return {
       ...GameActionFixtures.withKindPlayCards,
       cards: [CardFixtures.any],
-      currentCard: null,
+      stateUpdate: {
+        currentCard: null,
+        currentColor: null,
+        currentDirection: null,
+        drawCount: null,
+      },
     };
   }
 }

--- a/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/index.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/index.ts
@@ -3,13 +3,19 @@ import { DrawGameActionCreateQuery } from './query/DrawGameActionCreateQuery';
 import { GameActionCreateQuery } from './query/GameActionCreateQuery';
 import { GameActionFindQuery } from './query/GameActionFindQuery';
 import { PassTurnGameActionCreateQuery } from './query/PassTurnGameActionCreateQuery';
-import { PlayCardsGameActionCreateQuery } from './query/PlayCardsGameActionCreateQuery';
+import {
+  PlayCardsGameActionCreateQuery,
+  PlayCardsGameActionCreateQueryStateUpdate,
+} from './query/PlayCardsGameActionCreateQuery';
 import { BaseGameAction } from './valueObjects/BaseGameAction';
 import { DrawGameAction } from './valueObjects/DrawGameAction';
 import { GameAction } from './valueObjects/GameAction';
 import { GameActionKind } from './valueObjects/GameActionKind';
 import { PassTurnGameAction } from './valueObjects/PassTurnGameAction';
-import { PlayCardsGameAction } from './valueObjects/PlayCardsGameAction';
+import {
+  PlayCardsGameAction,
+  PlayCardsGameActionStateUpdate,
+} from './valueObjects/PlayCardsGameAction';
 
 export type {
   BaseGameAction,
@@ -22,7 +28,9 @@ export type {
   PassTurnGameAction,
   PassTurnGameActionCreateQuery,
   PlayCardsGameAction,
+  PlayCardsGameActionStateUpdate,
   PlayCardsGameActionCreateQuery,
+  PlayCardsGameActionCreateQueryStateUpdate,
 };
 
 export { GameActionKind };

--- a/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/query/PlayCardsGameActionCreateQuery.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/query/PlayCardsGameActionCreateQuery.ts
@@ -1,9 +1,25 @@
 import { Card } from '../../../cards/domain/valueObjects/Card';
+import { CardColor } from '../../../cards/domain/valueObjects/CardColor';
+import { GameDirection } from '../../../games/domain/valueObjects/GameDirection';
 import { GameActionKind } from '../valueObjects/GameActionKind';
 import { BaseGameActionCreateQuery } from './BaseGameActionCreateQuery';
+
+export type PlayCardsGameActionCreateQueryStateUpdate =
+  | {
+      currentCard: Card;
+      currentColor: CardColor;
+      currentDirection: GameDirection;
+      drawCount: number;
+    }
+  | {
+      currentCard: null;
+      currentColor: null;
+      currentDirection: null;
+      drawCount: null;
+    };
 
 export interface PlayCardsGameActionCreateQuery
   extends BaseGameActionCreateQuery<GameActionKind.playCards> {
   readonly cards: Card[];
-  readonly currentCard: Card | null;
+  readonly stateUpdate: PlayCardsGameActionCreateQueryStateUpdate;
 }

--- a/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/valueObjects/PlayCardsGameAction.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/gameActions/domain/valueObjects/PlayCardsGameAction.ts
@@ -1,9 +1,25 @@
 import { Card } from '../../../cards/domain/valueObjects/Card';
+import { CardColor } from '../../../cards/domain/valueObjects/CardColor';
+import { GameDirection } from '../../../games/domain/valueObjects/GameDirection';
 import { BaseGameAction } from './BaseGameAction';
 import { GameActionKind } from './GameActionKind';
+
+export type PlayCardsGameActionStateUpdate =
+  | {
+      currentCard: Card;
+      currentColor: CardColor;
+      currentDirection: GameDirection;
+      drawCount: number;
+    }
+  | {
+      currentCard: null;
+      currentColor: null;
+      currentDirection: null;
+      drawCount: null;
+    };
 
 export interface PlayCardsGameAction
   extends BaseGameAction<GameActionKind.playCards> {
   readonly cards: Card[];
-  readonly currentCard: Card | null;
+  readonly stateUpdate: PlayCardsGameActionStateUpdate;
 }


### PR DESCRIPTION
### Changed
- Updated `CardsPlayedGameEventV2` with additional fields.
- Updated `GameAction` play cards payload with additional fields.

### Context
`currentColor`, `currentDirection` and `drawCount` are required to compute game state updates on the client side. For such a reason these fields are provided in the events and stored in the corresponding game action payloads.