### PR TITLE
Fix GameIdUpdateQueryV1Handler

### DIFF
--- a/.changeset/long-tigers-brake.md
+++ b/.changeset/long-tigers-brake.md
@@ -1,0 +1,5 @@
+---
+"@cornie-js/backend-game-application": patch
+---
+
+Fixed GameIdUpdateQueryV1Handler.\_getUpdatedGame to require a TransactionWrapper

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdDrawCardsQueryV1Handler.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdDrawCardsQueryV1Handler.spec.ts
@@ -562,6 +562,7 @@ describe(GameIdDrawCardsQueryV1Handler.name, () => {
         expect(gamePersistenceOutputPortMock.findOne).toHaveBeenNthCalledWith(
           2,
           expectedSecondGameFindQuery,
+          transactionWrapperMock,
         );
       });
 

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdDrawCardsQueryV1Handler.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdDrawCardsQueryV1Handler.ts
@@ -114,7 +114,7 @@ export class GameIdDrawCardsQueryV1Handler extends GameIdUpdateQueryV1Handler<ap
 
     return {
       draw: drawMutation.cards,
-      game: await this._getUpdatedGame(game),
+      game: await this._getUpdatedGame(game, transactionWrapper),
       gameBeforeUpdate: game,
       kind: ActiveGameUpdatedEventKind.cardsDraw,
       transactionWrapper,

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPassTurnQueryV1Handler.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPassTurnQueryV1Handler.spec.ts
@@ -543,6 +543,7 @@ describe(GameIdPassTurnQueryV1Handler.name, () => {
         expect(gamePersistenceOutputPortMock.findOne).toHaveBeenNthCalledWith(
           2,
           expectedSecondGameFindQuery,
+          transactionWrapperMock,
         );
       });
 

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPassTurnQueryV1Handler.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPassTurnQueryV1Handler.ts
@@ -104,7 +104,7 @@ export class GameIdPassTurnQueryV1Handler extends GameIdUpdateQueryV1Handler<api
     );
 
     return {
-      game: await this._getUpdatedGame(game),
+      game: await this._getUpdatedGame(game, transactionWrapper),
       gameBeforeUpdate: game,
       kind: ActiveGameUpdatedEventKind.turnPass,
       transactionWrapper,

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPlayCardsQueryV1Handler.spec.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPlayCardsQueryV1Handler.spec.ts
@@ -585,6 +585,7 @@ describe(GameIdPlayCardsQueryV1Handler.name, () => {
         expect(gamePersistenceOutputPortMock.findOne).toHaveBeenNthCalledWith(
           2,
           expectedSecondGameFindQuery,
+          transactionWrapperMock,
         );
       });
 
@@ -835,6 +836,7 @@ describe(GameIdPlayCardsQueryV1Handler.name, () => {
         expect(gamePersistenceOutputPortMock.findOne).toHaveBeenNthCalledWith(
           2,
           expectedSecondGameFindQuery,
+          transactionWrapperMock,
         );
       });
 

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPlayCardsQueryV1Handler.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdPlayCardsQueryV1Handler.ts
@@ -146,7 +146,7 @@ export class GameIdPlayCardsQueryV1Handler extends GameIdUpdateQueryV1Handler<ap
 
     return {
       cards,
-      game: await this._getUpdatedGame(game),
+      game: await this._getUpdatedGame(game, transactionWrapper),
       gameBeforeUpdate: game,
       kind: ActiveGameUpdatedEventKind.cardsPlay,
       transactionWrapper,

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdUpdateQueryV1Handler.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/GameIdUpdateQueryV1Handler.ts
@@ -86,9 +86,13 @@ ${JSON.stringify(gameIdUpdateQueryV1)}`);
 
   protected async _getUpdatedGame(
     game: ActiveGame,
+    transactionWrapper: TransactionWrapper,
   ): Promise<ActiveGame | FinishedGame> {
     const gameFound: Game | undefined =
-      await this.#gamePersistenceOutputPort.findOne({ id: game.id });
+      await this.#gamePersistenceOutputPort.findOne(
+        { id: game.id },
+        transactionWrapper,
+      );
 
     if (gameFound === undefined || this.#isNonStartedGame(gameFound)) {
       throw new AppError(


### PR DESCRIPTION
### Changed
- Update `GameIdUpdateQueryV1Handler._getUpdatedGame` to rely on a `TransactionWrapper`.