### PR TITLE
refactor(web-ui): change property InputProps to slotProps on TextFiel…

### DIFF
--- a/packages/frontend/web-ui/src/auth/pages/Login.tsx
+++ b/packages/frontend/web-ui/src/auth/pages/Login.tsx
@@ -121,25 +121,27 @@ export const Login = (): React.JSX.Element => {
                       disabled={isTextFieldDisabled()}
                       label="Password"
                       type={showPassword ? 'text' : 'password'}
-                      InputProps={{
-                        endAdornment: (
-                          <InputAdornment position="end">
-                            <IconButton
-                              disabled={isShowPasswordButtonDisabled()}
-                              color="primary"
-                              aria-label="toggle password visibility"
-                              onClick={handleClickShowPassword}
-                              onMouseDown={handleMouseDownPassword}
-                              edge="end"
-                            >
-                              {showPassword ? (
-                                <VisibilityOff />
-                              ) : (
-                                <Visibility />
-                              )}
-                            </IconButton>
-                          </InputAdornment>
-                        ),
+                      slotProps={{
+                        input: {
+                          endAdornment: (
+                            <InputAdornment position="end">
+                              <IconButton
+                                disabled={isShowPasswordButtonDisabled()}
+                                color="primary"
+                                aria-label="toggle password visibility"
+                                onClick={handleClickShowPassword}
+                                onMouseDown={handleMouseDownPassword}
+                                edge="end"
+                              >
+                                {showPassword ? (
+                                  <VisibilityOff />
+                                ) : (
+                                  <Visibility />
+                                )}
+                              </IconButton>
+                            </InputAdornment>
+                          ),
+                        },
                       }}
                       placeholder="******"
                       fullWidth

--- a/packages/frontend/web-ui/src/auth/pages/Register.tsx
+++ b/packages/frontend/web-ui/src/auth/pages/Register.tsx
@@ -116,25 +116,27 @@ export const Register = () => {
                       disabled={isTextFieldDisabled()}
                       label="Password"
                       type={showPassword ? 'text' : 'password'}
-                      InputProps={{
-                        endAdornment: (
-                          <InputAdornment position="end">
-                            <IconButton
-                              disabled={isShowPasswordButtonDisabled()}
-                              color="primary"
-                              aria-label="toggle password visibility"
-                              onClick={handleClickShowPassword}
-                              onMouseDown={handleMouseDownPassword}
-                              edge="end"
-                            >
-                              {showPassword ? (
-                                <VisibilityOff />
-                              ) : (
-                                <Visibility />
-                              )}
-                            </IconButton>
-                          </InputAdornment>
-                        ),
+                      slotProps={{
+                        input: {
+                          endAdornment: (
+                            <InputAdornment position="end">
+                              <IconButton
+                                disabled={isShowPasswordButtonDisabled()}
+                                color="primary"
+                                aria-label="toggle password visibility"
+                                onClick={handleClickShowPassword}
+                                onMouseDown={handleMouseDownPassword}
+                                edge="end"
+                              >
+                                {showPassword ? (
+                                  <VisibilityOff />
+                                ) : (
+                                  <Visibility />
+                                )}
+                              </IconButton>
+                            </InputAdornment>
+                          ),
+                        },
                       }}
                       placeholder="******"
                       fullWidth
@@ -151,25 +153,27 @@ export const Register = () => {
                       disabled={isTextFieldDisabled()}
                       label="Confirm Password"
                       type={showPassword ? 'text' : 'password'}
-                      InputProps={{
-                        endAdornment: (
-                          <InputAdornment position="end">
-                            <IconButton
-                              disabled={isShowPasswordButtonDisabled()}
-                              color="primary"
-                              aria-label="toggle password visibility"
-                              onClick={handleClickShowPassword}
-                              onMouseDown={handleMouseDownPassword}
-                              edge="end"
-                            >
-                              {showPassword ? (
-                                <VisibilityOff />
-                              ) : (
-                                <Visibility />
-                              )}
-                            </IconButton>
-                          </InputAdornment>
-                        ),
+                      slotProps={{
+                        input: {
+                          endAdornment: (
+                            <InputAdornment position="end">
+                              <IconButton
+                                disabled={isShowPasswordButtonDisabled()}
+                                color="primary"
+                                aria-label="toggle password visibility"
+                                onClick={handleClickShowPassword}
+                                onMouseDown={handleMouseDownPassword}
+                                edge="end"
+                              >
+                                {showPassword ? (
+                                  <VisibilityOff />
+                                ) : (
+                                  <Visibility />
+                                )}
+                              </IconButton>
+                            </InputAdornment>
+                          ),
+                        },
                       }}
                       placeholder="******"
                       fullWidth


### PR DESCRIPTION
### Changed:

- Modified component `Login.tsx` to change deprecated property `InputProps` to `slotProps` on Textfield Material UI.
- Modified component `Register.tsx` to change deprecated property `InputProps` to `slotProps` on Textfield Material UI.