### PR TITLE
Fix UserCodeCreateQueryTypeOrmFromUserCodeCreateQueryBuilder

### DIFF
--- a/.changeset/eleven-geese-stare.md
+++ b/.changeset/eleven-geese-stare.md
@@ -1,0 +1,5 @@
+---
+"@cornie-js/backend-service-user": patch
+---
+
+Updated POST `/v1/users/email/{email}/code` to trigger proper reset password mail messages

--- a/.changeset/silent-pigs-worry.md
+++ b/.changeset/silent-pigs-worry.md
@@ -1,0 +1,5 @@
+---
+"@cornie-js/backend-user-adapter-typeorm": patch
+---
+
+Updated `UserCodeCreateQueryTypeOrmFromUserCodeCreateQueryBuilder`to set kind

--- a/packages/api/libraries/api-openapi-schema/schemas/src/one-game.yaml
+++ b/packages/api/libraries/api-openapi-schema/schemas/src/one-game.yaml
@@ -543,7 +543,7 @@ paths:
               schema:
                 $ref: 'https://onegame.schemas/api/v1/errors/error.json'
         '422':
-          description: Unprocessable operation. This is likely to happen if no user with the email address provided is found
+          description: Unprocessable operation. This is likely to happen if the kind of request cannot be accepted for the user given its current state.
           content:
             application/json:
               schema:

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/builders/UserCodeCreateQueryTypeOrmFromUserCodeCreateQueryBuilder.spec.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/builders/UserCodeCreateQueryTypeOrmFromUserCodeCreateQueryBuilder.spec.ts
@@ -1,18 +1,33 @@
-import { beforeAll, describe, expect, it } from '@jest/globals';
+import { beforeAll, describe, expect, it, jest } from '@jest/globals';
 
-import { UserCodeCreateQuery } from '@cornie-js/backend-user-domain/users';
+import { Builder } from '@cornie-js/backend-common';
+import {
+  UserCodeCreateQuery,
+  UserCodeKind,
+} from '@cornie-js/backend-user-domain/users';
 import { UserCodeCreateQueryFixtures } from '@cornie-js/backend-user-domain/users/fixtures';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity.js';
 
 import { UserCodeDb } from '../models/UserCodeDb';
+import { UserCodeKindDb } from '../models/UserCodeKindDb';
 import { UserCodeCreateQueryTypeOrmFromUserCodeCreateQueryBuilder } from './UserCodeCreateQueryTypeOrmFromUserCodeCreateQueryBuilder';
 
 describe(UserCodeCreateQueryTypeOrmFromUserCodeCreateQueryBuilder.name, () => {
+  let userCodeKindDbFromUserCodeKindBuilderMock: jest.Mocked<
+    Builder<UserCodeKindDb, [UserCodeKind]>
+  >;
+
   let userCodeCreateQueryTypeOrmFromUserCodeCreateQueryBuilder: UserCodeCreateQueryTypeOrmFromUserCodeCreateQueryBuilder;
 
   beforeAll(() => {
+    userCodeKindDbFromUserCodeKindBuilderMock = {
+      build: jest.fn(),
+    };
+
     userCodeCreateQueryTypeOrmFromUserCodeCreateQueryBuilder =
-      new UserCodeCreateQueryTypeOrmFromUserCodeCreateQueryBuilder();
+      new UserCodeCreateQueryTypeOrmFromUserCodeCreateQueryBuilder(
+        userCodeKindDbFromUserCodeKindBuilderMock,
+      );
   });
 
   describe('.build', () => {
@@ -23,18 +38,36 @@ describe(UserCodeCreateQueryTypeOrmFromUserCodeCreateQueryBuilder.name, () => {
     });
 
     describe('when called', () => {
+      let userCodeKindDbFixture: UserCodeKindDb;
+
       let result: unknown;
 
       beforeAll(() => {
+        userCodeKindDbFixture = UserCodeKindDb.resetPassword;
+
+        userCodeKindDbFromUserCodeKindBuilderMock.build.mockReturnValueOnce(
+          userCodeKindDbFixture,
+        );
+
         result = userCodeCreateQueryTypeOrmFromUserCodeCreateQueryBuilder.build(
           userCodeCreateQueryFixture,
         );
+      });
+
+      it('should call userCodeKindDbFromUserCodeKindBuilder.build()', () => {
+        expect(
+          userCodeKindDbFromUserCodeKindBuilderMock.build,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          userCodeKindDbFromUserCodeKindBuilderMock.build,
+        ).toHaveBeenCalledWith(userCodeCreateQueryFixture.kind);
       });
 
       it('should return a QueryDeepPartial<UserCodeDb>', () => {
         const expected: QueryDeepPartialEntity<UserCodeDb> = {
           code: userCodeCreateQueryFixture.code,
           id: userCodeCreateQueryFixture.id,
+          kind: userCodeKindDbFixture,
           user: {
             id: userCodeCreateQueryFixture.userId,
           },

--- a/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/builders/UserCodeCreateQueryTypeOrmFromUserCodeCreateQueryBuilder.ts
+++ b/packages/backend/apps/user/backend-user-adapter-typeorm/src/users/adapter/typeorm/builders/UserCodeCreateQueryTypeOrmFromUserCodeCreateQueryBuilder.ts
@@ -1,20 +1,44 @@
 import { Builder } from '@cornie-js/backend-common';
-import { UserCodeCreateQuery } from '@cornie-js/backend-user-domain/users';
-import { Injectable } from '@nestjs/common';
+import {
+  UserCodeCreateQuery,
+  UserCodeKind,
+} from '@cornie-js/backend-user-domain/users';
+import { Inject, Injectable } from '@nestjs/common';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity.js';
 
 import { UserCodeDb } from '../models/UserCodeDb';
+import { UserCodeKindDb } from '../models/UserCodeKindDb';
+import { UserCodeKindDbFromUserCodeKindBuilder } from './UserCodeKindDbFromUserCodeKindBuilder';
 
 @Injectable()
 export class UserCodeCreateQueryTypeOrmFromUserCodeCreateQueryBuilder
   implements Builder<QueryDeepPartialEntity<UserCodeDb>, [UserCodeCreateQuery]>
 {
+  readonly #userCodeKindDbFromUserCodeKindBuilder: Builder<
+    UserCodeKindDb,
+    [UserCodeKind]
+  >;
+
+  constructor(
+    @Inject(UserCodeKindDbFromUserCodeKindBuilder)
+    userCodeKindDbFromUserCodeKindBuilder: Builder<
+      UserCodeKindDb,
+      [UserCodeKind]
+    >,
+  ) {
+    this.#userCodeKindDbFromUserCodeKindBuilder =
+      userCodeKindDbFromUserCodeKindBuilder;
+  }
+
   public build(
     userCodeCreateQuery: UserCodeCreateQuery,
   ): QueryDeepPartialEntity<UserCodeDb> {
     return {
       code: userCodeCreateQuery.code,
       id: userCodeCreateQuery.id,
+      kind: this.#userCodeKindDbFromUserCodeKindBuilder.build(
+        userCodeCreateQuery.kind,
+      ),
       user: {
         id: userCodeCreateQuery.userId,
       },


### PR DESCRIPTION
### Changed
- Updated `UserCodeCreateQueryTypeOrmFromUserCodeCreateQueryBuilder` to persist user code create query kinds.

### Context
This fixes POST `/v1/users/email/{email}/code` to trigger proper reset password mail messages.