### PR TITLE
Update game update flow to set turnExpiresAt

### DIFF
--- a/.changeset/four-beans-laugh.md
+++ b/.changeset/four-beans-laugh.md
@@ -1,0 +1,5 @@
+---
+"@cornie-js/backend-adapter-pulsar": minor
+---
+
+Update MessageDeliverySchedule with MessageDeliveryTimeSchedule variant

--- a/packages/backend/apps/common/backend-adapter-pulsar/src/persistence/adapter/pulsar/adapters/MessageSendPulsarAdapter.ts
+++ b/packages/backend/apps/common/backend-adapter-pulsar/src/persistence/adapter/pulsar/adapters/MessageSendPulsarAdapter.ts
@@ -37,9 +37,11 @@ export class MessageSendPulsarAdapter<TMessage>
     if (options.delivery !== undefined) {
       if (options.delivery.schedule !== undefined) {
         switch (options.delivery.schedule.kind) {
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           case MessageDeliveryScheduleKind.delay:
             producerMessage.deliverAfter = options.delivery.schedule.delayMs;
+            break;
+          case MessageDeliveryScheduleKind.time:
+            producerMessage.deliverAt = options.delivery.schedule.timeStamp;
             break;
         }
       }

--- a/packages/backend/apps/common/backend-application-messaging/src/index.ts
+++ b/packages/backend/apps/common/backend-application-messaging/src/index.ts
@@ -3,6 +3,7 @@ import {
   MessageDeliveryOptions,
   MessageDeliverySchedule,
   MessageDeliveryScheduleKind,
+  MessageDeliveryTimeSchedule,
 } from './mail/application/models/MessageDeliveryOptions';
 import { MessageSendOptions } from './mail/application/models/MessageSendOptions';
 import {
@@ -14,6 +15,7 @@ export type {
   MessageDeliveryDelaySchedule,
   MessageDeliveryOptions,
   MessageDeliverySchedule,
+  MessageDeliveryTimeSchedule,
   MessageSendOptions,
   MessageSendOutputPort,
 };

--- a/packages/backend/apps/common/backend-application-messaging/src/mail/application/models/MessageDeliveryOptions.ts
+++ b/packages/backend/apps/common/backend-application-messaging/src/mail/application/models/MessageDeliveryOptions.ts
@@ -2,13 +2,21 @@ export interface MessageDeliveryOptions {
   schedule?: MessageDeliverySchedule;
 }
 
-export type MessageDeliverySchedule = MessageDeliveryDelaySchedule;
+export type MessageDeliverySchedule =
+  | MessageDeliveryDelaySchedule
+  | MessageDeliveryTimeSchedule;
 
 export interface MessageDeliveryDelaySchedule {
   delayMs: number;
   kind: MessageDeliveryScheduleKind.delay;
 }
 
+export interface MessageDeliveryTimeSchedule {
+  timeStamp: number;
+  kind: MessageDeliveryScheduleKind.time;
+}
+
 export enum MessageDeliveryScheduleKind {
   delay = 'delay',
+  time = 'time',
 }

--- a/packages/backend/apps/game/backend-game-application/src/games/application/handlers/NonStartedGameFilledEventHandler.ts
+++ b/packages/backend/apps/game/backend-game-application/src/games/application/handlers/NonStartedGameFilledEventHandler.ts
@@ -48,7 +48,7 @@ import {
   gameTurnEndSignalMessageSendOutputPortSymbol,
 } from '../ports/output/GameTurnEndSignalMessageSendOutputPort';
 
-const GAME_TURN_SIGNAL_DELAY_MS: number = 30000;
+const GAME_TURN_DURATION_MS: number = 30000;
 
 @Injectable()
 export class NonStartedGameFilledEventHandler
@@ -307,7 +307,7 @@ export class NonStartedGameFilledEventHandler
         },
         delivery: {
           schedule: {
-            delayMs: GAME_TURN_SIGNAL_DELAY_MS,
+            delayMs: GAME_TURN_DURATION_MS,
             kind: MessageDeliveryScheduleKind.delay,
           },
         },

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/builders/GamePassTurnUpdateQueryFromGameBuilder.spec.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/builders/GamePassTurnUpdateQueryFromGameBuilder.spec.ts
@@ -82,6 +82,7 @@ describe(GamePassTurnUpdateQueryFromGameBuilder.name, () => {
             },
             skipCount: 0,
             turn: activeGameFixture.state.turn + 1,
+            turnExpiresAt: expect.any(Date) as unknown as Date,
           };
 
           expect(result).toStrictEqual(expected);
@@ -127,6 +128,7 @@ describe(GamePassTurnUpdateQueryFromGameBuilder.name, () => {
             skipCount: 0,
             status: GameStatus.finished,
             turn: activeGameFixture.state.turn + 1,
+            turnExpiresAt: expect.any(Date) as unknown as Date,
           };
 
           expect(result).toStrictEqual(expected);
@@ -189,6 +191,7 @@ describe(GamePassTurnUpdateQueryFromGameBuilder.name, () => {
             },
             skipCount: 0,
             turn: activeGameFixture.state.turn + 1,
+            turnExpiresAt: expect.any(Date) as unknown as Date,
           };
 
           expect(result).toStrictEqual(expected);
@@ -234,6 +237,7 @@ describe(GamePassTurnUpdateQueryFromGameBuilder.name, () => {
             skipCount: 0,
             status: GameStatus.finished,
             turn: activeGameFixture.state.turn + 1,
+            turnExpiresAt: expect.any(Date) as unknown as Date,
           };
 
           expect(result).toStrictEqual(expected);
@@ -296,6 +300,7 @@ describe(GamePassTurnUpdateQueryFromGameBuilder.name, () => {
             },
             skipCount: 0,
             turn: activeGameFixture.state.turn + 1,
+            turnExpiresAt: expect.any(Date) as unknown as Date,
           };
 
           expect(result).toStrictEqual(expected);
@@ -341,6 +346,7 @@ describe(GamePassTurnUpdateQueryFromGameBuilder.name, () => {
             skipCount: 0,
             status: GameStatus.finished,
             turn: activeGameFixture.state.turn + 1,
+            turnExpiresAt: expect.any(Date) as unknown as Date,
           };
 
           expect(result).toStrictEqual(expected);
@@ -403,6 +409,7 @@ describe(GamePassTurnUpdateQueryFromGameBuilder.name, () => {
             },
             skipCount: 0,
             turn: activeGameFixture.state.turn + 1,
+            turnExpiresAt: expect.any(Date) as unknown as Date,
           };
 
           expect(result).toStrictEqual(expected);
@@ -448,6 +455,7 @@ describe(GamePassTurnUpdateQueryFromGameBuilder.name, () => {
             skipCount: 0,
             status: GameStatus.finished,
             turn: activeGameFixture.state.turn + 1,
+            turnExpiresAt: expect.any(Date) as unknown as Date,
           };
 
           expect(result).toStrictEqual(expected);

--- a/packages/backend/apps/game/backend-game-domain/src/games/domain/builders/GamePassTurnUpdateQueryFromGameBuilder.ts
+++ b/packages/backend/apps/game/backend-game-domain/src/games/domain/builders/GamePassTurnUpdateQueryFromGameBuilder.ts
@@ -8,6 +8,8 @@ import { GameDirection } from '../valueObjects/GameDirection';
 import { GameSpec } from '../valueObjects/GameSpec';
 import { GameStatus } from '../valueObjects/GameStatus';
 
+const GAME_TURN_DURATION_MS: number = 30000;
+
 @Injectable()
 export class GamePassTurnUpdateQueryFromGameBuilder
   implements Builder<GameUpdateQuery, [ActiveGame, GameSpec]>
@@ -22,6 +24,11 @@ export class GamePassTurnUpdateQueryFromGameBuilder
   }
 
   public build(game: ActiveGame, gameSpec: GameSpec): GameUpdateQuery {
+    const turnExpiresAt: Date = new Date();
+    turnExpiresAt.setMilliseconds(
+      turnExpiresAt.getMilliseconds() + GAME_TURN_DURATION_MS,
+    );
+
     const gameUpdateQuery: GameUpdateQuery = {
       currentPlayingSlotIndex: this.#getNextTurnPlayerIndex(game, gameSpec),
       currentTurnCardsDrawn: false,
@@ -35,6 +42,7 @@ export class GamePassTurnUpdateQueryFromGameBuilder
       },
       skipCount: 0,
       turn: game.state.turn + 1,
+      turnExpiresAt,
     };
 
     if (this.#isGameFinishedSpec.isSatisfiedBy(game)) {


### PR DESCRIPTION
### Changed
- Updated game update flow to set `turnExpiresAt`.
- Updated `MessageDeliverySchedule` with `MessageDeliveryTimeSchedule` variant.