### PR TITLE
Delete conflict code when user use forgot password

### DIFF
--- a/packages/frontend/libraries/frontend-api-rtk-query/src/index.ts
+++ b/packages/frontend/libraries/frontend-api-rtk-query/src/index.ts
@@ -33,10 +33,12 @@ import { getGamesV1GameIdSlotsSlotIdCards } from './games/queries/getGamesV1Game
 import { getGamesV1Mine } from './games/queries/getGamesV1Mine';
 import { CreateUsersV1Args } from './users/models/CreateUsersV1Args';
 import { CreateUsersV1EmailCodeArgs } from './users/models/CreateUsersV1EmailCodeArgs';
+import { DeleteUsersV1EmailCodeArgs } from './users/models/DeleteUsersV1EmailCodeArgs';
 import { GetUsersV1MeArgs } from './users/models/GetUsersV1MeArgs';
 import { UpdateUsersV1MeArgs } from './users/models/UpdateUsersV1MeArgs';
 import { createUsersV1 } from './users/mutations/createUsersV1';
 import { createUsersV1EmailCode } from './users/mutations/createUsersV1EmailCode';
+import { deleteUsersV1EmailCode } from './users/mutations/deleteUsersV1EmailCode';
 import { updateUsersV1Me } from './users/mutations/updateUsersV1Me';
 import { getUsersV1Me } from './users/queries/getUsersV1Me';
 import { getUsersV1MeDetail } from './users/queries/getUsersV1MeDetail';
@@ -47,6 +49,7 @@ export type {
   CreateGamesV1SlotsArgs,
   CreateUsersV1Args,
   CreateUsersV1EmailCodeArgs,
+  DeleteUsersV1EmailCodeArgs,
   GetGamesGameIdSpecsV1Args,
   GetGamesSpecsV1Args,
   GetGamesV1Args,
@@ -130,6 +133,12 @@ export function buildApi<TState>(options: BuildApiOptions<TState>) {
         CreateUsersV1EmailCodeArgs
       >({
         queryFn: createUsersV1EmailCode(options.httpClient),
+      }),
+      deleteUsersV1EmailCode: build.mutation<
+        undefined,
+        DeleteUsersV1EmailCodeArgs
+      >({
+        queryFn: deleteUsersV1EmailCode(options.httpClient),
       }),
       getGamesGameIdSpecsV1: build.query<
         apiModels.GameSpecV1,

--- a/packages/frontend/libraries/frontend-api-rtk-query/src/users/models/DeleteUsersV1EmailCodeArgs.ts
+++ b/packages/frontend/libraries/frontend-api-rtk-query/src/users/models/DeleteUsersV1EmailCodeArgs.ts
@@ -1,0 +1,5 @@
+import { HttpApiParamsWithNoHeaders } from '../../foundation/http/models/HttpApiParamsWithNoHeaders';
+
+export interface DeleteUsersV1EmailCodeArgs {
+  params: HttpApiParamsWithNoHeaders<'deleteUserByEmailCode'>;
+}

--- a/packages/frontend/libraries/frontend-api-rtk-query/src/users/mutations/deleteUsersV1EmailCode.spec.ts
+++ b/packages/frontend/libraries/frontend-api-rtk-query/src/users/mutations/deleteUsersV1EmailCode.spec.ts
@@ -1,0 +1,164 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import {
+  HttpClient,
+  HttpClientEndpoints,
+  Response,
+} from '@cornie-js/api-http-client';
+import { models as apiModels } from '@cornie-js/api-models';
+import { AppErrorKind } from '@cornie-js/frontend-common';
+import { BaseQueryApi } from '@reduxjs/toolkit/query';
+
+import { SerializableAppError } from '../../foundation/error/SerializableAppError';
+import { HttpApiResult } from '../../foundation/http/models/HttpApiResult';
+import {
+  OK,
+  UNPROCESSABLE_CONTENT,
+} from '../../foundation/http/models/httpCodes';
+import { QueryReturnValue } from '../../foundation/http/models/QueryReturnValue';
+import { DeleteUsersV1EmailCodeArgs } from '../models/DeleteUsersV1EmailCodeArgs';
+import { deleteUsersV1EmailCode } from './deleteUsersV1EmailCode';
+
+describe(deleteUsersV1EmailCode.name, () => {
+  describe('having an httpClient', () => {
+    let httpClientMock: jest.Mocked<HttpClient>;
+
+    let deleteUsersV1EmailCodeFunction: (
+      args: DeleteUsersV1EmailCodeArgs,
+      api: BaseQueryApi,
+    ) => Promise<QueryReturnValue<undefined, SerializableAppError, never>>;
+
+    beforeAll(() => {
+      httpClientMock = {
+        endpoints: {
+          deleteUserByEmailCode: jest.fn(),
+        } as Partial<
+          jest.Mocked<HttpClientEndpoints>
+        > as jest.Mocked<HttpClientEndpoints>,
+      } as Partial<jest.Mocked<HttpClient>> as jest.Mocked<HttpClient>;
+
+      deleteUsersV1EmailCodeFunction = deleteUsersV1EmailCode(httpClientMock);
+    });
+
+    describe('having args and api', () => {
+      let argsFixture: DeleteUsersV1EmailCodeArgs;
+      let apiFixture: BaseQueryApi;
+
+      beforeAll(() => {
+        argsFixture = {
+          params: [
+            {
+              email: 'mail@sample.com',
+            },
+          ],
+        };
+        apiFixture = Symbol() as unknown as BaseQueryApi;
+      });
+
+      describe('when called, and httpClient.endpoints.createUserByEmailCode() returns a DeleteUsersV1EmailCodeResult with 200 http status code', () => {
+        let resultFixture: HttpApiResult<'deleteUserByEmailCode'> &
+          Response<Record<string, string>, unknown, typeof OK>;
+
+        let result: unknown;
+
+        beforeAll(async () => {
+          resultFixture = {
+            body: undefined,
+            headers: {},
+            statusCode: OK,
+          };
+
+          httpClientMock.endpoints.deleteUserByEmailCode.mockResolvedValueOnce(
+            resultFixture,
+          );
+
+          result = await deleteUsersV1EmailCodeFunction(
+            argsFixture,
+            apiFixture,
+          );
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call httpClient.endpoints.deleteUserByEmailCode()', () => {
+          expect(
+            httpClientMock.endpoints.deleteUserByEmailCode,
+          ).toHaveBeenCalledTimes(1);
+          expect(
+            httpClientMock.endpoints.deleteUserByEmailCode,
+          ).toHaveBeenCalledWith({}, ...argsFixture.params);
+        });
+
+        it('should return QueryReturnValue', () => {
+          const expected: QueryReturnValue<
+            undefined,
+            SerializableAppError,
+            never
+          > = {
+            data: resultFixture.body,
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+
+      describe('when called, and httpClient.endpoints.deleteUserByEmailCode() returns a DeleteUsersV1EmailCodeResult with 422 http status code', () => {
+        let resultFixture: HttpApiResult<'deleteUserByEmailCode'> &
+          Response<
+            Record<string, string>,
+            unknown,
+            typeof UNPROCESSABLE_CONTENT
+          >;
+
+        let result: unknown;
+
+        beforeAll(async () => {
+          resultFixture = {
+            body: Symbol() as unknown as apiModels.ErrorV1,
+            headers: {},
+            statusCode: UNPROCESSABLE_CONTENT,
+          };
+
+          httpClientMock.endpoints.deleteUserByEmailCode.mockResolvedValueOnce(
+            resultFixture,
+          );
+
+          result = await deleteUsersV1EmailCodeFunction(
+            argsFixture,
+            apiFixture,
+          );
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call httpClient.endpoints.createUserByEmailCode()', () => {
+          expect(
+            httpClientMock.endpoints.deleteUserByEmailCode,
+          ).toHaveBeenCalledTimes(1);
+          expect(
+            httpClientMock.endpoints.deleteUserByEmailCode,
+          ).toHaveBeenCalledWith({}, ...argsFixture.params);
+        });
+
+        it('should return QueryReturnValue', () => {
+          const expected: QueryReturnValue<
+            undefined,
+            SerializableAppError,
+            never
+          > = {
+            error: {
+              kind: AppErrorKind.unprocessableOperation,
+              message: resultFixture.body.description,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+  });
+});

--- a/packages/frontend/libraries/frontend-api-rtk-query/src/users/mutations/deleteUsersV1EmailCode.ts
+++ b/packages/frontend/libraries/frontend-api-rtk-query/src/users/mutations/deleteUsersV1EmailCode.ts
@@ -1,0 +1,49 @@
+import { HttpClient } from '@cornie-js/api-http-client';
+import { AppErrorKind } from '@cornie-js/frontend-common';
+import { BaseQueryApi } from '@reduxjs/toolkit/query';
+
+import { SerializableAppError } from '../../foundation/error/SerializableAppError';
+import { HttpApiResult } from '../../foundation/http/models/HttpApiResult';
+import {
+  OK,
+  UNPROCESSABLE_CONTENT,
+} from '../../foundation/http/models/httpCodes';
+import { QueryReturnValue } from '../../foundation/http/models/QueryReturnValue';
+import { DeleteUsersV1EmailCodeArgs } from '../models/DeleteUsersV1EmailCodeArgs';
+
+type DeleteUsersV1EmailCodeResult = HttpApiResult<'deleteUserByEmailCode'>;
+
+export function deleteUsersV1EmailCode(
+  httpClient: HttpClient,
+): (
+  args: DeleteUsersV1EmailCodeArgs,
+  api: BaseQueryApi,
+) => Promise<QueryReturnValue<undefined, SerializableAppError, never>> {
+  return async (
+    args: DeleteUsersV1EmailCodeArgs,
+  ): Promise<QueryReturnValue<undefined, SerializableAppError, never>> => {
+    const httpResponse: DeleteUsersV1EmailCodeResult =
+      await httpClient.endpoints.deleteUserByEmailCode({}, ...args.params);
+
+    switch (httpResponse.statusCode) {
+      case OK:
+        return {
+          data: httpResponse.body,
+        };
+      case UNPROCESSABLE_CONTENT:
+        return {
+          error: {
+            kind: AppErrorKind.unprocessableOperation,
+            message: httpResponse.body.description,
+          },
+        };
+      default:
+        return {
+          error: {
+            kind: AppErrorKind.unknown,
+            message: 'Unexpected error',
+          },
+        };
+    }
+  };
+}

--- a/packages/frontend/web-ui/src/auth/hooks/useAuthForgot.spec.ts
+++ b/packages/frontend/web-ui/src/auth/hooks/useAuthForgot.spec.ts
@@ -7,7 +7,7 @@ jest.mock('../helpers/getCreateUserCodeErrorMessage');
 jest.mock('../../common/helpers/isSerializableAppError');
 
 import {
-  CreateUsersV1EmailCodeArgs,
+  DeleteUsersV1EmailCodeArgs,
   SerializableAppError,
 } from '@cornie-js/frontend-api-rtk-query';
 import { AppErrorKind } from '@cornie-js/frontend-common';
@@ -19,7 +19,7 @@ import { isSerializableAppError } from '../../common/helpers/isSerializableAppEr
 import { mapUseQueryHookResultV2 } from '../../common/helpers/mapUseQueryHookResultV2';
 import { cornieApi } from '../../common/http/services/cornieApi';
 import { Left, Right } from '../../common/models/Either';
-import { HTTP_CONFLICT_USER_ERROR_MESSAGE } from '../helpers/createUserErrorMessages';
+import { HTTP_UNPROCESSABLE_USERCODE_ERROR_MESSAGE } from '../helpers/createUserCodeErrorMessage';
 import { getCreateUserCodeErrorMessage } from '../helpers/getCreateUserCodeErrorMessage';
 import { validateEmail } from '../helpers/validateEmail';
 import { UseAuthForgotActions } from '../models/UseAuthForgotActions';
@@ -31,6 +31,9 @@ describe(useAuthForgot.name, () => {
   describe('when called', () => {
     let useCreateUsersV1EmailCodeMutationResultMock: jest.Mocked<
       ReturnType<typeof cornieApi.useCreateUsersV1EmailCodeMutation>
+    >;
+    let useDeleteUsersV1EmailCodeMutationResultMock: jest.Mocked<
+      ReturnType<typeof cornieApi.useDeleteUsersV1EmailCodeMutation>
     >;
 
     let renderResult: RenderHookResult<
@@ -47,6 +50,14 @@ describe(useAuthForgot.name, () => {
         },
       ];
 
+      useDeleteUsersV1EmailCodeMutationResultMock = [
+        jest.fn(),
+        {
+          reset: jest.fn(),
+          status: QueryStatus.uninitialized,
+        },
+      ];
+
       (
         mapUseQueryHookResultV2 as jest.Mock<typeof mapUseQueryHookResultV2>
       ).mockReturnValue(null);
@@ -56,6 +67,12 @@ describe(useAuthForgot.name, () => {
           typeof cornieApi.useCreateUsersV1EmailCodeMutation
         >
       ).mockReturnValue(useCreateUsersV1EmailCodeMutationResultMock);
+
+      (
+        cornieApi.useDeleteUsersV1EmailCodeMutation as jest.Mock<
+          typeof cornieApi.useDeleteUsersV1EmailCodeMutation
+        >
+      ).mockReturnValue(useDeleteUsersV1EmailCodeMutationResultMock);
 
       renderResult = renderHook(() => useAuthForgot());
     });
@@ -74,11 +91,24 @@ describe(useAuthForgot.name, () => {
       ).toHaveBeenCalledWith();
     });
 
+    it('should return cornieApi.useDeleteUsersV1EmailCodeMutation()', () => {
+      expect(cornieApi.useDeleteUsersV1EmailCodeMutation).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(
+        cornieApi.useDeleteUsersV1EmailCodeMutation,
+      ).toHaveBeenCalledWith();
+    });
+
     it('should call mapUseQueryHookResultV2()', () => {
-      expect(mapUseQueryHookResultV2).toHaveBeenCalledTimes(1);
+      expect(mapUseQueryHookResultV2).toHaveBeenCalledTimes(2);
       expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
         1,
         useCreateUsersV1EmailCodeMutationResultMock[1],
+      );
+      expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+        2,
+        useDeleteUsersV1EmailCodeMutationResultMock[1],
       );
     });
 
@@ -113,6 +143,9 @@ describe(useAuthForgot.name, () => {
     let useCreateUsersV1EmailCodeMutationResultMock: jest.Mocked<
       ReturnType<typeof cornieApi.useCreateUsersV1EmailCodeMutation>
     >;
+    let useDeleteUsersV1EmailCodeMutationResultMock: jest.Mocked<
+      ReturnType<typeof cornieApi.useDeleteUsersV1EmailCodeMutation>
+    >;
 
     let emailFixture: string;
     let eventMock: jest.Mocked<React.FormEvent>;
@@ -124,6 +157,14 @@ describe(useAuthForgot.name, () => {
 
     beforeAll(() => {
       useCreateUsersV1EmailCodeMutationResultMock = [
+        jest.fn(),
+        {
+          reset: jest.fn(),
+          status: QueryStatus.uninitialized,
+        },
+      ];
+
+      useDeleteUsersV1EmailCodeMutationResultMock = [
         jest.fn(),
         {
           reset: jest.fn(),
@@ -148,6 +189,12 @@ describe(useAuthForgot.name, () => {
           typeof cornieApi.useCreateUsersV1EmailCodeMutation
         >
       ).mockReturnValue(useCreateUsersV1EmailCodeMutationResultMock);
+
+      (
+        cornieApi.useDeleteUsersV1EmailCodeMutation as jest.Mock<
+          typeof cornieApi.useDeleteUsersV1EmailCodeMutation
+        >
+      ).mockReturnValue(useDeleteUsersV1EmailCodeMutationResultMock);
 
       (validateEmail as jest.Mocked<typeof validateEmail>).mockReturnValueOnce({
         isRight: true,
@@ -189,23 +236,20 @@ describe(useAuthForgot.name, () => {
       jest.resetAllMocks();
     });
 
-    it('should call triggerCreateUserCode()', () => {
-      const expected: CreateUsersV1EmailCodeArgs = {
+    it('should call triggerDeleteUserCode()', () => {
+      const expected: DeleteUsersV1EmailCodeArgs = {
         params: [
           {
             email: emailFixture,
           },
-          {
-            kind: 'resetPassword',
-          },
         ],
       };
 
-      const [triggerCreateUserCode] =
-        useCreateUsersV1EmailCodeMutationResultMock;
+      const [triggerDeleteUserCode] =
+        useDeleteUsersV1EmailCodeMutationResultMock;
 
-      expect(triggerCreateUserCode).toHaveBeenCalledTimes(1);
-      expect(triggerCreateUserCode).toHaveBeenCalledWith(expected);
+      expect(triggerDeleteUserCode).toHaveBeenCalledTimes(1);
+      expect(triggerDeleteUserCode).toHaveBeenCalledWith(expected);
     });
 
     it('should return expected result', () => {
@@ -217,7 +261,7 @@ describe(useAuthForgot.name, () => {
             },
             validation: {},
           },
-          status: UseAuthForgotStatus.creatingUserCode,
+          status: UseAuthForgotStatus.deletingUserCode,
         },
         {
           handlers: {
@@ -235,104 +279,15 @@ describe(useAuthForgot.name, () => {
     });
   });
 
-  describe('when called, and cornieApi.useCreateUsersV1EmailCodeMutation() returns Right user code result', () => {
+  describe('when called, and cornieApi.useDeleteUsersV1EmailCodeMutation() returns Left result error', () => {
     let useCreateUsersV1EmailCodeMutationResultMock: jest.Mocked<
       ReturnType<typeof cornieApi.useCreateUsersV1EmailCodeMutation>
     >;
-
-    let userCodeCreatedResultFixture: Right<undefined>;
-
-    let renderResult: RenderHookResult<
-      [UseAuthForgotData, UseAuthForgotActions],
-      unknown
+    let useDeleteUsersV1EmailCodeMutationResultMock: jest.Mocked<
+      ReturnType<typeof cornieApi.useDeleteUsersV1EmailCodeMutation>
     >;
 
-    beforeAll(() => {
-      useCreateUsersV1EmailCodeMutationResultMock = [
-        jest.fn(),
-        {
-          reset: jest.fn(),
-          status: QueryStatus.uninitialized,
-        },
-      ];
-
-      userCodeCreatedResultFixture = {
-        isRight: true,
-        value: undefined,
-      };
-
-      (mapUseQueryHookResultV2 as jest.Mock<typeof mapUseQueryHookResultV2>)
-        .mockReturnValueOnce(userCodeCreatedResultFixture)
-        .mockReturnValueOnce(userCodeCreatedResultFixture);
-
-      (
-        cornieApi.useCreateUsersV1EmailCodeMutation as jest.Mock<
-          typeof cornieApi.useCreateUsersV1EmailCodeMutation
-        >
-      ).mockReturnValue(useCreateUsersV1EmailCodeMutationResultMock);
-
-      renderResult = renderHook(() => useAuthForgot());
-    });
-
-    afterAll(() => {
-      jest.clearAllMocks();
-      jest.resetAllMocks();
-    });
-
-    it('should call cornieApi.useCreateUsersV1EmailCodeMutation()', () => {
-      expect(cornieApi.useCreateUsersV1EmailCodeMutation).toHaveBeenCalledTimes(
-        2,
-      );
-      expect(
-        cornieApi.useCreateUsersV1EmailCodeMutation,
-      ).toHaveBeenCalledWith();
-    });
-
-    it('should call mapUseQueryHookResultV2()', () => {
-      expect(mapUseQueryHookResultV2).toHaveBeenCalledTimes(2);
-      expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
-        1,
-        useCreateUsersV1EmailCodeMutationResultMock[1],
-      );
-      expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
-        2,
-        useCreateUsersV1EmailCodeMutationResultMock[1],
-      );
-    });
-
-    it('should return expected result', () => {
-      const expectedResult: [UseAuthForgotData, UseAuthForgotActions] = [
-        {
-          form: {
-            fields: {
-              email: '',
-            },
-            validation: {},
-          },
-          status: UseAuthForgotStatus.success,
-        },
-        {
-          handlers: {
-            onEmailChanged: expect.any(Function) as unknown as (
-              event: React.ChangeEvent<HTMLInputElement>,
-            ) => void,
-            onSubmit: expect.any(Function) as unknown as (
-              event: React.FormEvent,
-            ) => void,
-          },
-        },
-      ];
-
-      expect(renderResult.result.current).toStrictEqual(expectedResult);
-    });
-  });
-
-  describe('when called, and cornieApi.useCreateUsersV1Mutation() returns Left user error', () => {
-    let useCreateUsersV1EmailCodeMutationResultMock: jest.Mocked<
-      ReturnType<typeof cornieApi.useCreateUsersV1EmailCodeMutation>
-    >;
-
-    let userCodeCreatedResultFixture: Left<SerializableAppError>;
+    let userCodeDeletedResultFixture: Left<SerializableAppError>;
     let errorMessageFixture: string;
 
     let renderResult: RenderHookResult<
@@ -349,19 +304,27 @@ describe(useAuthForgot.name, () => {
         },
       ];
 
-      userCodeCreatedResultFixture = {
+      useDeleteUsersV1EmailCodeMutationResultMock = [
+        jest.fn(),
+        {
+          reset: jest.fn(),
+          status: QueryStatus.uninitialized,
+        },
+      ];
+
+      userCodeDeletedResultFixture = {
         isRight: false,
         value: {
-          kind: AppErrorKind.entityConflict,
+          kind: AppErrorKind.unprocessableOperation,
           message: 'message-fixture',
         },
       };
 
-      errorMessageFixture = HTTP_CONFLICT_USER_ERROR_MESSAGE;
+      errorMessageFixture = HTTP_UNPROCESSABLE_USERCODE_ERROR_MESSAGE;
 
       (mapUseQueryHookResultV2 as jest.Mock<typeof mapUseQueryHookResultV2>)
-        .mockReturnValueOnce(userCodeCreatedResultFixture)
-        .mockReturnValueOnce(userCodeCreatedResultFixture);
+        .mockReturnValueOnce(userCodeDeletedResultFixture)
+        .mockReturnValueOnce(userCodeDeletedResultFixture);
 
       (
         isSerializableAppError as unknown as jest.Mock<
@@ -381,6 +344,12 @@ describe(useAuthForgot.name, () => {
         >
       ).mockReturnValue(useCreateUsersV1EmailCodeMutationResultMock);
 
+      (
+        cornieApi.useDeleteUsersV1EmailCodeMutation as jest.Mock<
+          typeof cornieApi.useDeleteUsersV1EmailCodeMutation
+        >
+      ).mockReturnValue(useDeleteUsersV1EmailCodeMutationResultMock);
+
       renderResult = renderHook(() => useAuthForgot());
     });
 
@@ -398,31 +367,56 @@ describe(useAuthForgot.name, () => {
       ).toHaveBeenCalledWith();
     });
 
+    it('should return cornieApi.useDeleteUsersV1EmailCodeMutation()', () => {
+      expect(cornieApi.useDeleteUsersV1EmailCodeMutation).toHaveBeenCalledTimes(
+        2,
+      );
+      expect(
+        cornieApi.useDeleteUsersV1EmailCodeMutation,
+      ).toHaveBeenCalledWith();
+    });
+
     it('should call mapUseQueryHookResultV2()', () => {
-      expect(mapUseQueryHookResultV2).toHaveBeenCalledTimes(2);
+      expect(mapUseQueryHookResultV2).toHaveBeenCalledTimes(4);
       expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
         1,
         useCreateUsersV1EmailCodeMutationResultMock[1],
       );
       expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
         2,
+        useDeleteUsersV1EmailCodeMutationResultMock[1],
+      );
+      expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+        3,
         useCreateUsersV1EmailCodeMutationResultMock[1],
+      );
+      expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+        4,
+        useDeleteUsersV1EmailCodeMutationResultMock[1],
       );
     });
 
     it('should call isSerializableAppError()', () => {
-      expect(isSerializableAppError).toHaveBeenCalledTimes(1);
+      expect(isSerializableAppError).toHaveBeenCalledTimes(2);
       expect(isSerializableAppError).toHaveBeenNthCalledWith(
         1,
-        userCodeCreatedResultFixture.value,
+        userCodeDeletedResultFixture.value,
+      );
+      expect(isSerializableAppError).toHaveBeenNthCalledWith(
+        2,
+        userCodeDeletedResultFixture.value,
       );
     });
 
     it('should call getCreateUserCodeErrorMessage()', () => {
-      expect(getCreateUserCodeErrorMessage).toHaveBeenCalledTimes(1);
+      expect(getCreateUserCodeErrorMessage).toHaveBeenCalledTimes(2);
       expect(getCreateUserCodeErrorMessage).toHaveBeenNthCalledWith(
         1,
-        userCodeCreatedResultFixture.value.kind,
+        userCodeDeletedResultFixture.value.kind,
+      );
+      expect(isSerializableAppError).toHaveBeenNthCalledWith(
+        2,
+        userCodeDeletedResultFixture.value,
       );
     });
 
@@ -430,7 +424,7 @@ describe(useAuthForgot.name, () => {
       const expectedResult: [UseAuthForgotData, UseAuthForgotActions] = [
         {
           form: {
-            errorMessage: HTTP_CONFLICT_USER_ERROR_MESSAGE,
+            errorMessage: HTTP_UNPROCESSABLE_USERCODE_ERROR_MESSAGE,
             fields: {
               email: '',
             },
@@ -451,6 +445,312 @@ describe(useAuthForgot.name, () => {
       ];
 
       expect(renderResult.result.current).toStrictEqual(expectedResult);
+    });
+  });
+
+  describe('when called, and cornieApi.useDeleteUsersV1EmailCodeMutation() returns Right result delete user code', () => {
+    describe('when called, and cornieApi.useCreateUsersV1EmailCodeMutation() returns Right result user code', () => {
+      let useCreateUsersV1EmailCodeMutationResultMock: jest.Mocked<
+        ReturnType<typeof cornieApi.useCreateUsersV1EmailCodeMutation>
+      >;
+      let useDeleteUsersV1EmailCodeMutationResultMock: jest.Mocked<
+        ReturnType<typeof cornieApi.useDeleteUsersV1EmailCodeMutation>
+      >;
+
+      let userCodeDeletedResultFixture: Right<undefined>;
+
+      let userCodeCreatedResultFixture: Right<undefined>;
+
+      let renderResult: RenderHookResult<
+        [UseAuthForgotData, UseAuthForgotActions],
+        unknown
+      >;
+
+      beforeAll(() => {
+        useCreateUsersV1EmailCodeMutationResultMock = [
+          jest.fn(),
+          {
+            reset: jest.fn(),
+            status: QueryStatus.uninitialized,
+          },
+        ];
+
+        useDeleteUsersV1EmailCodeMutationResultMock = [
+          jest.fn(),
+          {
+            reset: jest.fn(),
+            status: QueryStatus.uninitialized,
+          },
+        ];
+
+        userCodeDeletedResultFixture = {
+          isRight: true,
+          value: undefined,
+        };
+
+        userCodeCreatedResultFixture = {
+          isRight: true,
+          value: undefined,
+        };
+
+        (mapUseQueryHookResultV2 as jest.Mock<typeof mapUseQueryHookResultV2>)
+          .mockReturnValueOnce(userCodeCreatedResultFixture)
+          .mockReturnValueOnce(userCodeDeletedResultFixture)
+          .mockReturnValueOnce(userCodeCreatedResultFixture)
+          .mockReturnValueOnce(userCodeDeletedResultFixture);
+
+        (
+          cornieApi.useCreateUsersV1EmailCodeMutation as jest.Mock<
+            typeof cornieApi.useCreateUsersV1EmailCodeMutation
+          >
+        ).mockReturnValue(useCreateUsersV1EmailCodeMutationResultMock);
+
+        (
+          cornieApi.useDeleteUsersV1EmailCodeMutation as jest.Mock<
+            typeof cornieApi.useDeleteUsersV1EmailCodeMutation
+          >
+        ).mockReturnValue(useDeleteUsersV1EmailCodeMutationResultMock);
+
+        renderResult = renderHook(() => useAuthForgot());
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+        jest.resetAllMocks();
+      });
+
+      it('should call cornieApi.useDeleteUsersV1EmailCodeMutationResultMock()', () => {
+        expect(
+          cornieApi.useCreateUsersV1EmailCodeMutation,
+        ).toHaveBeenCalledTimes(2);
+        expect(
+          cornieApi.useDeleteUsersV1EmailCodeMutation,
+        ).toHaveBeenCalledWith();
+      });
+
+      it('should call cornieApi.useCreateUsersV1EmailCodeMutationResultMock()', () => {
+        expect(
+          cornieApi.useCreateUsersV1EmailCodeMutation,
+        ).toHaveBeenCalledTimes(2);
+        expect(
+          cornieApi.useCreateUsersV1EmailCodeMutation,
+        ).toHaveBeenCalledWith();
+      });
+
+      it('should call mapUseQueryHookResultV2()', () => {
+        expect(mapUseQueryHookResultV2).toHaveBeenCalledTimes(4);
+        expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+          1,
+          useCreateUsersV1EmailCodeMutationResultMock[1],
+        );
+        expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+          2,
+          useDeleteUsersV1EmailCodeMutationResultMock[1],
+        );
+        expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+          3,
+          useCreateUsersV1EmailCodeMutationResultMock[1],
+        );
+        expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+          4,
+          useDeleteUsersV1EmailCodeMutationResultMock[1],
+        );
+      });
+
+      it('should return expected result', () => {
+        const expectedResult: [UseAuthForgotData, UseAuthForgotActions] = [
+          {
+            form: {
+              fields: {
+                email: '',
+              },
+              validation: {},
+            },
+            status: UseAuthForgotStatus.success,
+          },
+          {
+            handlers: {
+              onEmailChanged: expect.any(Function) as unknown as (
+                event: React.ChangeEvent<HTMLInputElement>,
+              ) => void,
+              onSubmit: expect.any(Function) as unknown as (
+                event: React.FormEvent,
+              ) => void,
+            },
+          },
+        ];
+
+        expect(renderResult.result.current).toStrictEqual(expectedResult);
+      });
+    });
+
+    describe('when called, and cornieApi.useCreateUsersV1EmailCodeMutation() returns Left user error', () => {
+      let useCreateUsersV1EmailCodeMutationResultMock: jest.Mocked<
+        ReturnType<typeof cornieApi.useCreateUsersV1EmailCodeMutation>
+      >;
+      let useDeleteUsersV1EmailCodeMutationResultMock: jest.Mocked<
+        ReturnType<typeof cornieApi.useDeleteUsersV1EmailCodeMutation>
+      >;
+
+      let userCodeDeletedResultFixture: Right<undefined>;
+      let userCodeCreatedResultFixture: Left<SerializableAppError>;
+      let errorMessageFixture: string;
+
+      let renderResult: RenderHookResult<
+        [UseAuthForgotData, UseAuthForgotActions],
+        unknown
+      >;
+
+      beforeAll(() => {
+        useCreateUsersV1EmailCodeMutationResultMock = [
+          jest.fn(),
+          {
+            reset: jest.fn(),
+            status: QueryStatus.uninitialized,
+          },
+        ];
+
+        useDeleteUsersV1EmailCodeMutationResultMock = [
+          jest.fn(),
+          {
+            reset: jest.fn(),
+            status: QueryStatus.uninitialized,
+          },
+        ];
+
+        userCodeCreatedResultFixture = {
+          isRight: false,
+          value: {
+            kind: AppErrorKind.unprocessableOperation,
+            message: 'message-fixture',
+          },
+        };
+
+        userCodeDeletedResultFixture = {
+          isRight: true,
+          value: undefined,
+        };
+
+        errorMessageFixture = HTTP_UNPROCESSABLE_USERCODE_ERROR_MESSAGE;
+
+        (mapUseQueryHookResultV2 as jest.Mock<typeof mapUseQueryHookResultV2>)
+          .mockReturnValueOnce(userCodeCreatedResultFixture)
+          .mockReturnValueOnce(userCodeDeletedResultFixture)
+          .mockReturnValueOnce(userCodeCreatedResultFixture)
+          .mockReturnValueOnce(userCodeDeletedResultFixture);
+
+        (
+          isSerializableAppError as unknown as jest.Mock<
+            typeof isSerializableAppError
+          >
+        ).mockReturnValue(true);
+
+        (
+          getCreateUserCodeErrorMessage as jest.Mock<
+            typeof getCreateUserCodeErrorMessage
+          >
+        ).mockReturnValue(errorMessageFixture);
+
+        (
+          cornieApi.useCreateUsersV1EmailCodeMutation as jest.Mock<
+            typeof cornieApi.useCreateUsersV1EmailCodeMutation
+          >
+        ).mockReturnValue(useCreateUsersV1EmailCodeMutationResultMock);
+
+        (
+          cornieApi.useDeleteUsersV1EmailCodeMutation as jest.Mock<
+            typeof cornieApi.useDeleteUsersV1EmailCodeMutation
+          >
+        ).mockReturnValue(useDeleteUsersV1EmailCodeMutationResultMock);
+
+        renderResult = renderHook(() => useAuthForgot());
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+        jest.resetAllMocks();
+      });
+
+      it('should return cornieApi.useCreateUsersV1EmailCodeMutation()', () => {
+        expect(
+          cornieApi.useCreateUsersV1EmailCodeMutation,
+        ).toHaveBeenCalledTimes(2);
+        expect(
+          cornieApi.useCreateUsersV1EmailCodeMutation,
+        ).toHaveBeenCalledWith();
+      });
+
+      it('should return cornieApi.useDeleteUsersV1EmailCodeMutation()', () => {
+        expect(
+          cornieApi.useDeleteUsersV1EmailCodeMutation,
+        ).toHaveBeenCalledTimes(2);
+        expect(
+          cornieApi.useDeleteUsersV1EmailCodeMutation,
+        ).toHaveBeenCalledWith();
+      });
+
+      it('should call mapUseQueryHookResultV2()', () => {
+        expect(mapUseQueryHookResultV2).toHaveBeenCalledTimes(4);
+        expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+          1,
+          useCreateUsersV1EmailCodeMutationResultMock[1],
+        );
+        expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+          2,
+          useDeleteUsersV1EmailCodeMutationResultMock[1],
+        );
+        expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+          3,
+          useCreateUsersV1EmailCodeMutationResultMock[1],
+        );
+        expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+          4,
+          useDeleteUsersV1EmailCodeMutationResultMock[1],
+        );
+      });
+
+      it('should call isSerializableAppError()', () => {
+        expect(isSerializableAppError).toHaveBeenCalledTimes(1);
+        expect(isSerializableAppError).toHaveBeenNthCalledWith(
+          1,
+          userCodeCreatedResultFixture.value,
+        );
+      });
+
+      it('should call getCreateUserCodeErrorMessage()', () => {
+        expect(getCreateUserCodeErrorMessage).toHaveBeenCalledTimes(1);
+        expect(getCreateUserCodeErrorMessage).toHaveBeenNthCalledWith(
+          1,
+          userCodeCreatedResultFixture.value.kind,
+        );
+      });
+
+      it('should return expected result', () => {
+        const expectedResult: [UseAuthForgotData, UseAuthForgotActions] = [
+          {
+            form: {
+              errorMessage: HTTP_UNPROCESSABLE_USERCODE_ERROR_MESSAGE,
+              fields: {
+                email: '',
+              },
+              validation: {},
+            },
+            status: UseAuthForgotStatus.backendError,
+          },
+          {
+            handlers: {
+              onEmailChanged: expect.any(Function) as unknown as (
+                event: React.ChangeEvent<HTMLInputElement>,
+              ) => void,
+              onSubmit: expect.any(Function) as unknown as (
+                event: React.FormEvent,
+              ) => void,
+            },
+          },
+        ];
+
+        expect(renderResult.result.current).toStrictEqual(expectedResult);
+      });
     });
   });
 });

--- a/packages/frontend/web-ui/src/auth/hooks/useAuthForgot.spec.ts
+++ b/packages/frontend/web-ui/src/auth/hooks/useAuthForgot.spec.ts
@@ -448,309 +448,307 @@ describe(useAuthForgot.name, () => {
     });
   });
 
-  describe('when called, and cornieApi.useDeleteUsersV1EmailCodeMutation() returns Right result delete user code', () => {
-    describe('when called, and cornieApi.useCreateUsersV1EmailCodeMutation() returns Right result user code', () => {
-      let useCreateUsersV1EmailCodeMutationResultMock: jest.Mocked<
-        ReturnType<typeof cornieApi.useCreateUsersV1EmailCodeMutation>
-      >;
-      let useDeleteUsersV1EmailCodeMutationResultMock: jest.Mocked<
-        ReturnType<typeof cornieApi.useDeleteUsersV1EmailCodeMutation>
-      >;
+  describe('when called, and cornieApi.useDeleteUsersV1EmailCodeMutation() returns Right and cornieApi.useCreateUsersV1EmailCodeMutation() returns Right result user code', () => {
+    let useCreateUsersV1EmailCodeMutationResultMock: jest.Mocked<
+      ReturnType<typeof cornieApi.useCreateUsersV1EmailCodeMutation>
+    >;
+    let useDeleteUsersV1EmailCodeMutationResultMock: jest.Mocked<
+      ReturnType<typeof cornieApi.useDeleteUsersV1EmailCodeMutation>
+    >;
 
-      let userCodeDeletedResultFixture: Right<undefined>;
+    let userCodeDeletedResultFixture: Right<undefined>;
 
-      let userCodeCreatedResultFixture: Right<undefined>;
+    let userCodeCreatedResultFixture: Right<undefined>;
 
-      let renderResult: RenderHookResult<
-        [UseAuthForgotData, UseAuthForgotActions],
-        unknown
-      >;
+    let renderResult: RenderHookResult<
+      [UseAuthForgotData, UseAuthForgotActions],
+      unknown
+    >;
 
-      beforeAll(() => {
-        useCreateUsersV1EmailCodeMutationResultMock = [
-          jest.fn(),
-          {
-            reset: jest.fn(),
-            status: QueryStatus.uninitialized,
-          },
-        ];
+    beforeAll(() => {
+      useCreateUsersV1EmailCodeMutationResultMock = [
+        jest.fn(),
+        {
+          reset: jest.fn(),
+          status: QueryStatus.uninitialized,
+        },
+      ];
 
-        useDeleteUsersV1EmailCodeMutationResultMock = [
-          jest.fn(),
-          {
-            reset: jest.fn(),
-            status: QueryStatus.uninitialized,
-          },
-        ];
+      useDeleteUsersV1EmailCodeMutationResultMock = [
+        jest.fn(),
+        {
+          reset: jest.fn(),
+          status: QueryStatus.uninitialized,
+        },
+      ];
 
-        userCodeDeletedResultFixture = {
-          isRight: true,
-          value: undefined,
-        };
+      userCodeDeletedResultFixture = {
+        isRight: true,
+        value: undefined,
+      };
 
-        userCodeCreatedResultFixture = {
-          isRight: true,
-          value: undefined,
-        };
+      userCodeCreatedResultFixture = {
+        isRight: true,
+        value: undefined,
+      };
 
-        (mapUseQueryHookResultV2 as jest.Mock<typeof mapUseQueryHookResultV2>)
-          .mockReturnValueOnce(userCodeCreatedResultFixture)
-          .mockReturnValueOnce(userCodeDeletedResultFixture)
-          .mockReturnValueOnce(userCodeCreatedResultFixture)
-          .mockReturnValueOnce(userCodeDeletedResultFixture);
+      (mapUseQueryHookResultV2 as jest.Mock<typeof mapUseQueryHookResultV2>)
+        .mockReturnValueOnce(userCodeCreatedResultFixture)
+        .mockReturnValueOnce(userCodeDeletedResultFixture)
+        .mockReturnValueOnce(userCodeCreatedResultFixture)
+        .mockReturnValueOnce(userCodeDeletedResultFixture);
 
-        (
-          cornieApi.useCreateUsersV1EmailCodeMutation as jest.Mock<
-            typeof cornieApi.useCreateUsersV1EmailCodeMutation
-          >
-        ).mockReturnValue(useCreateUsersV1EmailCodeMutationResultMock);
+      (
+        cornieApi.useCreateUsersV1EmailCodeMutation as jest.Mock<
+          typeof cornieApi.useCreateUsersV1EmailCodeMutation
+        >
+      ).mockReturnValue(useCreateUsersV1EmailCodeMutationResultMock);
 
-        (
-          cornieApi.useDeleteUsersV1EmailCodeMutation as jest.Mock<
-            typeof cornieApi.useDeleteUsersV1EmailCodeMutation
-          >
-        ).mockReturnValue(useDeleteUsersV1EmailCodeMutationResultMock);
+      (
+        cornieApi.useDeleteUsersV1EmailCodeMutation as jest.Mock<
+          typeof cornieApi.useDeleteUsersV1EmailCodeMutation
+        >
+      ).mockReturnValue(useDeleteUsersV1EmailCodeMutationResultMock);
 
-        renderResult = renderHook(() => useAuthForgot());
-      });
-
-      afterAll(() => {
-        jest.clearAllMocks();
-        jest.resetAllMocks();
-      });
-
-      it('should call cornieApi.useDeleteUsersV1EmailCodeMutationResultMock()', () => {
-        expect(
-          cornieApi.useCreateUsersV1EmailCodeMutation,
-        ).toHaveBeenCalledTimes(2);
-        expect(
-          cornieApi.useDeleteUsersV1EmailCodeMutation,
-        ).toHaveBeenCalledWith();
-      });
-
-      it('should call cornieApi.useCreateUsersV1EmailCodeMutationResultMock()', () => {
-        expect(
-          cornieApi.useCreateUsersV1EmailCodeMutation,
-        ).toHaveBeenCalledTimes(2);
-        expect(
-          cornieApi.useCreateUsersV1EmailCodeMutation,
-        ).toHaveBeenCalledWith();
-      });
-
-      it('should call mapUseQueryHookResultV2()', () => {
-        expect(mapUseQueryHookResultV2).toHaveBeenCalledTimes(4);
-        expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
-          1,
-          useCreateUsersV1EmailCodeMutationResultMock[1],
-        );
-        expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
-          2,
-          useDeleteUsersV1EmailCodeMutationResultMock[1],
-        );
-        expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
-          3,
-          useCreateUsersV1EmailCodeMutationResultMock[1],
-        );
-        expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
-          4,
-          useDeleteUsersV1EmailCodeMutationResultMock[1],
-        );
-      });
-
-      it('should return expected result', () => {
-        const expectedResult: [UseAuthForgotData, UseAuthForgotActions] = [
-          {
-            form: {
-              fields: {
-                email: '',
-              },
-              validation: {},
-            },
-            status: UseAuthForgotStatus.success,
-          },
-          {
-            handlers: {
-              onEmailChanged: expect.any(Function) as unknown as (
-                event: React.ChangeEvent<HTMLInputElement>,
-              ) => void,
-              onSubmit: expect.any(Function) as unknown as (
-                event: React.FormEvent,
-              ) => void,
-            },
-          },
-        ];
-
-        expect(renderResult.result.current).toStrictEqual(expectedResult);
-      });
+      renderResult = renderHook(() => useAuthForgot());
     });
 
-    describe('when called, and cornieApi.useCreateUsersV1EmailCodeMutation() returns Left user error', () => {
-      let useCreateUsersV1EmailCodeMutationResultMock: jest.Mocked<
-        ReturnType<typeof cornieApi.useCreateUsersV1EmailCodeMutation>
-      >;
-      let useDeleteUsersV1EmailCodeMutationResultMock: jest.Mocked<
-        ReturnType<typeof cornieApi.useDeleteUsersV1EmailCodeMutation>
-      >;
+    afterAll(() => {
+      jest.clearAllMocks();
+      jest.resetAllMocks();
+    });
 
-      let userCodeDeletedResultFixture: Right<undefined>;
-      let userCodeCreatedResultFixture: Left<SerializableAppError>;
-      let errorMessageFixture: string;
+    it('should call cornieApi.useDeleteUsersV1EmailCodeMutationResultMock()', () => {
+      expect(cornieApi.useCreateUsersV1EmailCodeMutation).toHaveBeenCalledTimes(
+        2,
+      );
+      expect(
+        cornieApi.useDeleteUsersV1EmailCodeMutation,
+      ).toHaveBeenCalledWith();
+    });
 
-      let renderResult: RenderHookResult<
-        [UseAuthForgotData, UseAuthForgotActions],
-        unknown
-      >;
+    it('should call cornieApi.useCreateUsersV1EmailCodeMutationResultMock()', () => {
+      expect(cornieApi.useCreateUsersV1EmailCodeMutation).toHaveBeenCalledTimes(
+        2,
+      );
+      expect(
+        cornieApi.useCreateUsersV1EmailCodeMutation,
+      ).toHaveBeenCalledWith();
+    });
 
-      beforeAll(() => {
-        useCreateUsersV1EmailCodeMutationResultMock = [
-          jest.fn(),
-          {
-            reset: jest.fn(),
-            status: QueryStatus.uninitialized,
-          },
-        ];
+    it('should call mapUseQueryHookResultV2()', () => {
+      expect(mapUseQueryHookResultV2).toHaveBeenCalledTimes(4);
+      expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+        1,
+        useCreateUsersV1EmailCodeMutationResultMock[1],
+      );
+      expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+        2,
+        useDeleteUsersV1EmailCodeMutationResultMock[1],
+      );
+      expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+        3,
+        useCreateUsersV1EmailCodeMutationResultMock[1],
+      );
+      expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+        4,
+        useDeleteUsersV1EmailCodeMutationResultMock[1],
+      );
+    });
 
-        useDeleteUsersV1EmailCodeMutationResultMock = [
-          jest.fn(),
-          {
-            reset: jest.fn(),
-            status: QueryStatus.uninitialized,
-          },
-        ];
-
-        userCodeCreatedResultFixture = {
-          isRight: false,
-          value: {
-            kind: AppErrorKind.unprocessableOperation,
-            message: 'message-fixture',
-          },
-        };
-
-        userCodeDeletedResultFixture = {
-          isRight: true,
-          value: undefined,
-        };
-
-        errorMessageFixture = HTTP_UNPROCESSABLE_USERCODE_ERROR_MESSAGE;
-
-        (mapUseQueryHookResultV2 as jest.Mock<typeof mapUseQueryHookResultV2>)
-          .mockReturnValueOnce(userCodeCreatedResultFixture)
-          .mockReturnValueOnce(userCodeDeletedResultFixture)
-          .mockReturnValueOnce(userCodeCreatedResultFixture)
-          .mockReturnValueOnce(userCodeDeletedResultFixture);
-
-        (
-          isSerializableAppError as unknown as jest.Mock<
-            typeof isSerializableAppError
-          >
-        ).mockReturnValue(true);
-
-        (
-          getCreateUserCodeErrorMessage as jest.Mock<
-            typeof getCreateUserCodeErrorMessage
-          >
-        ).mockReturnValue(errorMessageFixture);
-
-        (
-          cornieApi.useCreateUsersV1EmailCodeMutation as jest.Mock<
-            typeof cornieApi.useCreateUsersV1EmailCodeMutation
-          >
-        ).mockReturnValue(useCreateUsersV1EmailCodeMutationResultMock);
-
-        (
-          cornieApi.useDeleteUsersV1EmailCodeMutation as jest.Mock<
-            typeof cornieApi.useDeleteUsersV1EmailCodeMutation
-          >
-        ).mockReturnValue(useDeleteUsersV1EmailCodeMutationResultMock);
-
-        renderResult = renderHook(() => useAuthForgot());
-      });
-
-      afterAll(() => {
-        jest.clearAllMocks();
-        jest.resetAllMocks();
-      });
-
-      it('should return cornieApi.useCreateUsersV1EmailCodeMutation()', () => {
-        expect(
-          cornieApi.useCreateUsersV1EmailCodeMutation,
-        ).toHaveBeenCalledTimes(2);
-        expect(
-          cornieApi.useCreateUsersV1EmailCodeMutation,
-        ).toHaveBeenCalledWith();
-      });
-
-      it('should return cornieApi.useDeleteUsersV1EmailCodeMutation()', () => {
-        expect(
-          cornieApi.useDeleteUsersV1EmailCodeMutation,
-        ).toHaveBeenCalledTimes(2);
-        expect(
-          cornieApi.useDeleteUsersV1EmailCodeMutation,
-        ).toHaveBeenCalledWith();
-      });
-
-      it('should call mapUseQueryHookResultV2()', () => {
-        expect(mapUseQueryHookResultV2).toHaveBeenCalledTimes(4);
-        expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
-          1,
-          useCreateUsersV1EmailCodeMutationResultMock[1],
-        );
-        expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
-          2,
-          useDeleteUsersV1EmailCodeMutationResultMock[1],
-        );
-        expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
-          3,
-          useCreateUsersV1EmailCodeMutationResultMock[1],
-        );
-        expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
-          4,
-          useDeleteUsersV1EmailCodeMutationResultMock[1],
-        );
-      });
-
-      it('should call isSerializableAppError()', () => {
-        expect(isSerializableAppError).toHaveBeenCalledTimes(1);
-        expect(isSerializableAppError).toHaveBeenNthCalledWith(
-          1,
-          userCodeCreatedResultFixture.value,
-        );
-      });
-
-      it('should call getCreateUserCodeErrorMessage()', () => {
-        expect(getCreateUserCodeErrorMessage).toHaveBeenCalledTimes(1);
-        expect(getCreateUserCodeErrorMessage).toHaveBeenNthCalledWith(
-          1,
-          userCodeCreatedResultFixture.value.kind,
-        );
-      });
-
-      it('should return expected result', () => {
-        const expectedResult: [UseAuthForgotData, UseAuthForgotActions] = [
-          {
-            form: {
-              errorMessage: HTTP_UNPROCESSABLE_USERCODE_ERROR_MESSAGE,
-              fields: {
-                email: '',
-              },
-              validation: {},
+    it('should return expected result', () => {
+      const expectedResult: [UseAuthForgotData, UseAuthForgotActions] = [
+        {
+          form: {
+            fields: {
+              email: '',
             },
-            status: UseAuthForgotStatus.backendError,
+            validation: {},
           },
-          {
-            handlers: {
-              onEmailChanged: expect.any(Function) as unknown as (
-                event: React.ChangeEvent<HTMLInputElement>,
-              ) => void,
-              onSubmit: expect.any(Function) as unknown as (
-                event: React.FormEvent,
-              ) => void,
-            },
+          status: UseAuthForgotStatus.success,
+        },
+        {
+          handlers: {
+            onEmailChanged: expect.any(Function) as unknown as (
+              event: React.ChangeEvent<HTMLInputElement>,
+            ) => void,
+            onSubmit: expect.any(Function) as unknown as (
+              event: React.FormEvent,
+            ) => void,
           },
-        ];
+        },
+      ];
 
-        expect(renderResult.result.current).toStrictEqual(expectedResult);
-      });
+      expect(renderResult.result.current).toStrictEqual(expectedResult);
+    });
+  });
+
+  describe('when called, and cornieApi.useDeleteUsersV1EmailCodeMutation() returns Right and cornieApi.useCreateUsersV1EmailCodeMutation() returns Left user error', () => {
+    let useCreateUsersV1EmailCodeMutationResultMock: jest.Mocked<
+      ReturnType<typeof cornieApi.useCreateUsersV1EmailCodeMutation>
+    >;
+    let useDeleteUsersV1EmailCodeMutationResultMock: jest.Mocked<
+      ReturnType<typeof cornieApi.useDeleteUsersV1EmailCodeMutation>
+    >;
+
+    let userCodeDeletedResultFixture: Right<undefined>;
+    let userCodeCreatedResultFixture: Left<SerializableAppError>;
+    let errorMessageFixture: string;
+
+    let renderResult: RenderHookResult<
+      [UseAuthForgotData, UseAuthForgotActions],
+      unknown
+    >;
+
+    beforeAll(() => {
+      useCreateUsersV1EmailCodeMutationResultMock = [
+        jest.fn(),
+        {
+          reset: jest.fn(),
+          status: QueryStatus.uninitialized,
+        },
+      ];
+
+      useDeleteUsersV1EmailCodeMutationResultMock = [
+        jest.fn(),
+        {
+          reset: jest.fn(),
+          status: QueryStatus.uninitialized,
+        },
+      ];
+
+      userCodeCreatedResultFixture = {
+        isRight: false,
+        value: {
+          kind: AppErrorKind.unprocessableOperation,
+          message: 'message-fixture',
+        },
+      };
+
+      userCodeDeletedResultFixture = {
+        isRight: true,
+        value: undefined,
+      };
+
+      errorMessageFixture = HTTP_UNPROCESSABLE_USERCODE_ERROR_MESSAGE;
+
+      (mapUseQueryHookResultV2 as jest.Mock<typeof mapUseQueryHookResultV2>)
+        .mockReturnValueOnce(userCodeCreatedResultFixture)
+        .mockReturnValueOnce(userCodeDeletedResultFixture)
+        .mockReturnValueOnce(userCodeCreatedResultFixture)
+        .mockReturnValueOnce(userCodeDeletedResultFixture);
+
+      (
+        isSerializableAppError as unknown as jest.Mock<
+          typeof isSerializableAppError
+        >
+      ).mockReturnValue(true);
+
+      (
+        getCreateUserCodeErrorMessage as jest.Mock<
+          typeof getCreateUserCodeErrorMessage
+        >
+      ).mockReturnValue(errorMessageFixture);
+
+      (
+        cornieApi.useCreateUsersV1EmailCodeMutation as jest.Mock<
+          typeof cornieApi.useCreateUsersV1EmailCodeMutation
+        >
+      ).mockReturnValue(useCreateUsersV1EmailCodeMutationResultMock);
+
+      (
+        cornieApi.useDeleteUsersV1EmailCodeMutation as jest.Mock<
+          typeof cornieApi.useDeleteUsersV1EmailCodeMutation
+        >
+      ).mockReturnValue(useDeleteUsersV1EmailCodeMutationResultMock);
+
+      renderResult = renderHook(() => useAuthForgot());
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+      jest.resetAllMocks();
+    });
+
+    it('should return cornieApi.useCreateUsersV1EmailCodeMutation()', () => {
+      expect(cornieApi.useCreateUsersV1EmailCodeMutation).toHaveBeenCalledTimes(
+        2,
+      );
+      expect(
+        cornieApi.useCreateUsersV1EmailCodeMutation,
+      ).toHaveBeenCalledWith();
+    });
+
+    it('should return cornieApi.useDeleteUsersV1EmailCodeMutation()', () => {
+      expect(cornieApi.useDeleteUsersV1EmailCodeMutation).toHaveBeenCalledTimes(
+        2,
+      );
+      expect(
+        cornieApi.useDeleteUsersV1EmailCodeMutation,
+      ).toHaveBeenCalledWith();
+    });
+
+    it('should call mapUseQueryHookResultV2()', () => {
+      expect(mapUseQueryHookResultV2).toHaveBeenCalledTimes(4);
+      expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+        1,
+        useCreateUsersV1EmailCodeMutationResultMock[1],
+      );
+      expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+        2,
+        useDeleteUsersV1EmailCodeMutationResultMock[1],
+      );
+      expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+        3,
+        useCreateUsersV1EmailCodeMutationResultMock[1],
+      );
+      expect(mapUseQueryHookResultV2).toHaveBeenNthCalledWith(
+        4,
+        useDeleteUsersV1EmailCodeMutationResultMock[1],
+      );
+    });
+
+    it('should call isSerializableAppError()', () => {
+      expect(isSerializableAppError).toHaveBeenCalledTimes(1);
+      expect(isSerializableAppError).toHaveBeenNthCalledWith(
+        1,
+        userCodeCreatedResultFixture.value,
+      );
+    });
+
+    it('should call getCreateUserCodeErrorMessage()', () => {
+      expect(getCreateUserCodeErrorMessage).toHaveBeenCalledTimes(1);
+      expect(getCreateUserCodeErrorMessage).toHaveBeenNthCalledWith(
+        1,
+        userCodeCreatedResultFixture.value.kind,
+      );
+    });
+
+    it('should return expected result', () => {
+      const expectedResult: [UseAuthForgotData, UseAuthForgotActions] = [
+        {
+          form: {
+            errorMessage: HTTP_UNPROCESSABLE_USERCODE_ERROR_MESSAGE,
+            fields: {
+              email: '',
+            },
+            validation: {},
+          },
+          status: UseAuthForgotStatus.backendError,
+        },
+        {
+          handlers: {
+            onEmailChanged: expect.any(Function) as unknown as (
+              event: React.ChangeEvent<HTMLInputElement>,
+            ) => void,
+            onSubmit: expect.any(Function) as unknown as (
+              event: React.FormEvent,
+            ) => void,
+          },
+        },
+      ];
+
+      expect(renderResult.result.current).toStrictEqual(expectedResult);
     });
   });
 });

--- a/packages/frontend/web-ui/src/auth/models/UseAuthForgotStatus.ts
+++ b/packages/frontend/web-ui/src/auth/models/UseAuthForgotStatus.ts
@@ -1,5 +1,6 @@
 export enum UseAuthForgotStatus {
   creatingUserCode = 'creatingUserCode',
+  deletingUserCode = 'deletingUserCode',
   backendError = 'backendError',
   idle = 'idle',
   success = 'success',

--- a/packages/frontend/web-ui/src/common/http/services/__mocks__/cornieApi.ts
+++ b/packages/frontend/web-ui/src/common/http/services/__mocks__/cornieApi.ts
@@ -8,6 +8,7 @@ export const cornieApi: jest.Mocked<typeof originalCornieApi> = {
   useCreateGamesV1SlotsMutation: jest.fn(),
   useCreateUsersV1EmailCodeMutation: jest.fn(),
   useCreateUsersV1Mutation: jest.fn(),
+  useDeleteUsersV1EmailCodeMutation: jest.fn(),
   useGetGamesGameIdSpecsV1Query: jest.fn(),
   useGetGamesSpecsV1Query: jest.fn(),
   useGetGamesV1GameIdQuery: jest.fn(),


### PR DESCRIPTION
### Added:

 - Added new file `DeleteUserV1EmailCodeArgs.ts`, params for new mutation `useDeleteUserV1EmailCodeMutation`.
 - Added new file `deleteUserV1EmailCode.ts` and his test, to process the result of execution of the new mutation.

### Changed:

 - Modified file `cornieApi.ts` on mocks' carpet to add new _jest function_ to test `useDeleteUserV1EmailCodeMutation`.
 - Modified file `index.ts` to add new mutation `useDeleteUserV1EmailCodeMutation`.
 - Modified file `UseAuthForgotStatus.ts` to add new status on enum.
 - Modified files `useAuthForgot.ts` and his test, to add new functionality to delete user code before sending a recovery password email.