### PR TITLE
Update use game to count down on edge cases

### DIFF
--- a/packages/frontend/web-ui/src/common/hooks/useCountdown.ts
+++ b/packages/frontend/web-ui/src/common/hooks/useCountdown.ts
@@ -11,8 +11,12 @@ export interface UseCountdownResult {
   currentSeconds: number;
   durationSeconds: number;
   isRunning: boolean;
-  start: () => void;
+  start: (seconds?: number) => void;
   stop: () => void;
+}
+
+function isNatural(number: number): boolean {
+  return number > 0 && number === Math.floor(number);
 }
 
 export const useCountdown = (
@@ -21,16 +25,22 @@ export const useCountdown = (
   const [currentSeconds, setCurrentSeconds] = useState(params.durationSeconds);
   const [timerId, setTimerId] = useState<number>();
 
-  if (
-    params.durationSeconds <= 0 ||
-    params.durationSeconds !== Math.floor(params.durationSeconds)
-  ) {
+  if (!isNatural(params.durationSeconds)) {
     throw new Error(
       'Unable to initialize hook: durationSeconds must be a natural number',
     );
   }
 
-  const start: () => void = (): void => {
+  const start: (seconds?: number) => void = (seconds?: number): void => {
+    if (seconds !== undefined) {
+      const naturalSeconds: number = Math.min(
+        params.durationSeconds,
+        Math.max(1, Math.floor(seconds)),
+      );
+
+      setCurrentSeconds(naturalSeconds);
+    }
+
     if (timerId !== undefined) {
       clearInterval(timerId);
     }

--- a/packages/frontend/web-ui/src/game/helpers/handleGameMessageEvents.spec.ts
+++ b/packages/frontend/web-ui/src/game/helpers/handleGameMessageEvents.spec.ts
@@ -577,6 +577,10 @@ describe(handleGameMessageEvents.name, () => {
       let result: unknown;
 
       beforeAll(() => {
+        jest.useFakeTimers({
+          now: new Date('2020-01-02'),
+        });
+
         (cloneGame as jest.Mock<typeof cloneGame>).mockReturnValueOnce(
           buildGameFixture(),
         );
@@ -591,6 +595,7 @@ describe(handleGameMessageEvents.name, () => {
 
       afterAll(() => {
         jest.clearAllMocks();
+        jest.useRealTimers();
       });
 
       it('should call cloneGame', () => {
@@ -619,6 +624,7 @@ describe(handleGameMessageEvents.name, () => {
             currentPlayingSlotIndex:
               turnPassedGameEventV2.nextPlayingSlotIndex as number,
             lastEventId: eventId,
+            turnExpiresAt: '2020-01-02T00:00:30.000Z',
           },
         };
 

--- a/packages/frontend/web-ui/src/game/helpers/handleGameMessageEvents.spec.ts
+++ b/packages/frontend/web-ui/src/game/helpers/handleGameMessageEvents.spec.ts
@@ -12,6 +12,7 @@ describe(handleGameMessageEvents.name, () => {
     let gameFixture: apiModels.ActiveGameV1;
     let messageEventsQueueFixture: [];
     let onCardsChangeMock: jest.Mock<(gameSlotIndex: number) => void>;
+    let onTurnChangeMock: jest.Mock<(gameSlotIndex: number) => void>;
 
     beforeAll(() => {
       gameFixture = {
@@ -37,6 +38,7 @@ describe(handleGameMessageEvents.name, () => {
       messageEventsQueueFixture = [];
 
       onCardsChangeMock = jest.fn();
+      onTurnChangeMock = jest.fn();
     });
 
     describe('when called', () => {
@@ -51,6 +53,7 @@ describe(handleGameMessageEvents.name, () => {
           gameFixture,
           messageEventsQueueFixture,
           onCardsChangeMock,
+          onTurnChangeMock,
         );
       });
 
@@ -73,6 +76,7 @@ describe(handleGameMessageEvents.name, () => {
     let buildGameFixture: () => apiModels.ActiveGameV1;
     let messageEventsQueueFixture: [[string, apiModels.CardsDrawnGameEventV2]];
     let onCardsChangeMock: jest.Mock<(gameSlotIndex: number) => void>;
+    let onTurnChangeMock: jest.Mock<(gameSlotIndex: number) => void>;
 
     beforeAll(() => {
       buildGameFixture = () => ({
@@ -113,6 +117,7 @@ describe(handleGameMessageEvents.name, () => {
       ];
 
       onCardsChangeMock = jest.fn();
+      onTurnChangeMock = jest.fn();
     });
 
     describe('when called', () => {
@@ -127,6 +132,7 @@ describe(handleGameMessageEvents.name, () => {
           buildGameFixture(),
           messageEventsQueueFixture,
           onCardsChangeMock,
+          onTurnChangeMock,
         );
       });
 
@@ -182,6 +188,7 @@ describe(handleGameMessageEvents.name, () => {
     let buildGameFixture: () => apiModels.ActiveGameV1;
     let messageEventsQueueFixture: [[string, apiModels.CardsPlayedGameEventV2]];
     let onCardsChangeMock: jest.Mock<(gameSlotIndex: number) => void>;
+    let onTurnChangeMock: jest.Mock<(gameSlotIndex: number) => void>;
 
     beforeAll(() => {
       buildGameFixture = () => ({
@@ -230,6 +237,7 @@ describe(handleGameMessageEvents.name, () => {
       ];
 
       onCardsChangeMock = jest.fn();
+      onTurnChangeMock = jest.fn();
     });
 
     describe('when called', () => {
@@ -244,6 +252,7 @@ describe(handleGameMessageEvents.name, () => {
           buildGameFixture(),
           messageEventsQueueFixture,
           onCardsChangeMock,
+          onTurnChangeMock,
         );
       });
 
@@ -296,6 +305,7 @@ describe(handleGameMessageEvents.name, () => {
     let buildGameFixture: () => apiModels.ActiveGameV1;
     let messageEventsQueueFixture: [[string, apiModels.CardsPlayedGameEventV2]];
     let onCardsChangeMock: jest.Mock<(gameSlotIndex: number) => void>;
+    let onTurnChangeMock: jest.Mock<(gameSlotIndex: number) => void>;
 
     beforeAll(() => {
       buildGameFixture = () => ({
@@ -346,6 +356,7 @@ describe(handleGameMessageEvents.name, () => {
       ];
 
       onCardsChangeMock = jest.fn();
+      onTurnChangeMock = jest.fn();
     });
 
     describe('when called', () => {
@@ -360,6 +371,7 @@ describe(handleGameMessageEvents.name, () => {
           buildGameFixture(),
           messageEventsQueueFixture,
           onCardsChangeMock,
+          onTurnChangeMock,
         );
       });
 
@@ -420,6 +432,7 @@ describe(handleGameMessageEvents.name, () => {
     let buildGameFixture: () => apiModels.ActiveGameV1;
     let messageEventsQueueFixture: [[string, apiModels.TurnPassedGameEventV2]];
     let onCardsChangeMock: jest.Mock<(gameSlotIndex: number) => void>;
+    let onTurnChangeMock: jest.Mock<(gameSlotIndex: number) => void>;
 
     beforeAll(() => {
       buildGameFixture = () => ({
@@ -460,6 +473,7 @@ describe(handleGameMessageEvents.name, () => {
       ];
 
       onCardsChangeMock = jest.fn();
+      onTurnChangeMock = jest.fn();
     });
 
     describe('when called', () => {
@@ -474,6 +488,7 @@ describe(handleGameMessageEvents.name, () => {
           buildGameFixture(),
           messageEventsQueueFixture,
           onCardsChangeMock,
+          onTurnChangeMock,
         );
       });
 
@@ -514,6 +529,7 @@ describe(handleGameMessageEvents.name, () => {
     let buildGameFixture: () => apiModels.ActiveGameV1;
     let messageEventsQueueFixture: [[string, apiModels.TurnPassedGameEventV2]];
     let onCardsChangeMock: jest.Mock<(gameSlotIndex: number) => void>;
+    let onTurnChangeMock: jest.Mock<(gameSlotIndex: number) => void>;
 
     beforeAll(() => {
       buildGameFixture = () => ({
@@ -554,6 +570,7 @@ describe(handleGameMessageEvents.name, () => {
       ];
 
       onCardsChangeMock = jest.fn();
+      onTurnChangeMock = jest.fn();
     });
 
     describe('when called', () => {
@@ -568,6 +585,7 @@ describe(handleGameMessageEvents.name, () => {
           buildGameFixture(),
           messageEventsQueueFixture,
           onCardsChangeMock,
+          onTurnChangeMock,
         );
       });
 
@@ -578,6 +596,15 @@ describe(handleGameMessageEvents.name, () => {
       it('should call cloneGame', () => {
         expect(cloneGame).toHaveBeenCalledTimes(1);
         expect(cloneGame).toHaveBeenCalledWith(buildGameFixture());
+      });
+
+      it('should call onTurnChange()', () => {
+        const [[, messageEventFixture]] = messageEventsQueueFixture;
+
+        expect(onTurnChangeMock).toHaveBeenCalledTimes(1);
+        expect(onTurnChangeMock).toHaveBeenCalledWith(
+          messageEventFixture.nextPlayingSlotIndex,
+        );
       });
 
       it('should return game', () => {

--- a/packages/frontend/web-ui/src/game/helpers/handleGameMessageEvents.ts
+++ b/packages/frontend/web-ui/src/game/helpers/handleGameMessageEvents.ts
@@ -2,6 +2,8 @@ import { models as apiModels } from '@cornie-js/api-models';
 
 import { cloneGame } from './cloneGame';
 
+const GAME_TURN_MS: number = 30000;
+
 function buildFinishedGame(
   game: apiModels.ActiveGameV1,
 ): apiModels.FinishedGameV1 {
@@ -78,6 +80,11 @@ export function handleGameMessageEvents(
         } else {
           updatedGame.state.currentPlayingSlotIndex =
             messageEvent.nextPlayingSlotIndex;
+
+          const date: Date = new Date();
+          date.setMilliseconds(date.getMilliseconds() + GAME_TURN_MS);
+
+          updatedGame.state.turnExpiresAt = date.toISOString();
 
           onTurnChange(updatedGame.state.currentPlayingSlotIndex);
         }

--- a/packages/frontend/web-ui/src/game/helpers/handleGameMessageEvents.ts
+++ b/packages/frontend/web-ui/src/game/helpers/handleGameMessageEvents.ts
@@ -34,6 +34,7 @@ export function handleGameMessageEvents(
   game: apiModels.ActiveGameV1,
   messageEventsQueue: [string, apiModels.GameEventV2][],
   onCardsChange: (gameSlotIndex: number) => void,
+  onTurnChange: (gameSlotIndex: number) => void,
 ): apiModels.ActiveGameV1 | apiModels.FinishedGameV1 {
   const updatedGame: apiModels.ActiveGameV1 = cloneGame(game);
 
@@ -77,6 +78,8 @@ export function handleGameMessageEvents(
         } else {
           updatedGame.state.currentPlayingSlotIndex =
             messageEvent.nextPlayingSlotIndex;
+
+          onTurnChange(updatedGame.state.currentPlayingSlotIndex);
         }
 
         break;

--- a/packages/frontend/web-ui/src/game/hooks/useGame.spec.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useGame.spec.ts
@@ -72,6 +72,7 @@ describe(useGame.name, () => {
       ).mockReturnValueOnce(urlLikeLocationFixture);
 
       (useGetUserMe as jest.Mock<typeof useGetUserMe>).mockReturnValueOnce({
+        queryResult: Symbol(),
         result: null,
       });
 
@@ -268,6 +269,7 @@ describe(useGame.name, () => {
       ).mockReturnValue(urlLikeLocationFixture);
 
       (useGetUserMe as jest.Mock<typeof useGetUserMe>).mockReturnValue({
+        queryResult: Symbol(),
         result: {
           isRight: true,
           value: userFixture,

--- a/packages/frontend/web-ui/src/game/hooks/useGame.spec.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useGame.spec.ts
@@ -155,7 +155,7 @@ describe(useGame.name, () => {
     });
   });
 
-  describe('when called, and queries return non null results', () => {
+  describe('when called, and queries return non null results, and getGameSlotIndex returns playing slot index', () => {
     let cornieEventSourceMock: jest.Mocked<CornieEventSource>;
     let gameCardsFixture: apiModels.CardArrayV1;
     let gameFixture: apiModels.ActiveGameV1;
@@ -206,7 +206,7 @@ describe(useGame.name, () => {
         },
       };
 
-      gameSlotIndexFixture = 0;
+      gameSlotIndexFixture = gameFixture.state.currentPlayingSlotIndex;
 
       userFixture = {
         active: true,
@@ -359,7 +359,7 @@ describe(useGame.name, () => {
       expect(getGameSlotIndex).toHaveBeenCalledTimes(2);
       expect(getGameSlotIndex).toHaveBeenNthCalledWith(
         1,
-        undefined,
+        gameFixture,
         userFixture,
       );
       expect(getGameSlotIndex).toHaveBeenNthCalledWith(

--- a/packages/frontend/web-ui/src/game/hooks/useGame.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useGame.ts
@@ -22,6 +22,7 @@ import { useGetGamesV1GameIdSlotsSlotIdCards } from './useGetGamesV1GameIdSlotsS
 
 const GAME_CURRENT_CARDS: number = 1;
 const MAX_SECONDS_PER_TURN: number = 30;
+const MS_PER_SECOND: number = 1000;
 
 export interface UseGameResult {
   currentCard: apiModels.CardV1 | undefined;
@@ -68,7 +69,8 @@ export const useGame = (): UseGameResult => {
   const gameIdParam: string | undefined =
     url.searchParams.get('gameId') ?? undefined;
 
-  const { result: usersV1MeResult } = useGetUserMe();
+  const { queryResult: usersV1MeQueryResult, result: usersV1MeResult } =
+    useGetUserMe();
 
   const { queryResult: gamesV1GameIdQueryResult, result: gamesV1GameIdResult } =
     useGetGamesV1GameId(gameIdParam);
@@ -81,9 +83,14 @@ export const useGame = (): UseGameResult => {
 
   const [eventSource, setEventSource] = useState<CornieEventSource>();
 
+  const gameOrUndefined: apiModels.GameV1 | undefined =
+    gamesV1GameIdResult?.isRight === true
+      ? gamesV1GameIdResult.value
+      : undefined;
+
   const gameSlotIndexParam: number | undefined =
     usersV1MeResult?.isRight === true
-      ? getGameSlotIndex(game, usersV1MeResult.value)
+      ? getGameSlotIndex(gameOrUndefined, usersV1MeResult.value)
       : undefined;
 
   const {
@@ -99,20 +106,39 @@ export const useGame = (): UseGameResult => {
   });
 
   useEffect(() => {
-    const game: apiModels.GameV1 | undefined =
+    const gameResult: apiModels.GameV1 | undefined =
       gamesV1GameIdResult?.isRight === true
         ? gamesV1GameIdResult.value
         : undefined;
 
-    if (isActiveGame(game)) {
-      setGame(game);
+    if (isActiveGame(gameResult)) {
+      if (game !== gameResult) {
+        setGame(gameResult);
+      }
 
       if (eventSource === undefined) {
-        setEventSource(buildEventSource(game, setMessageEventsQueue));
+        setEventSource(buildEventSource(gameResult, setMessageEventsQueue));
+      }
+
+      if (
+        gameResult.state.currentPlayingSlotIndex === gameSlotIndexParam &&
+        !useCountdownResult.isRunning
+      ) {
+        const seconds = Math.floor(
+          (new Date(gameResult.state.turnExpiresAt).getTime() -
+            new Date().getTime()) /
+            MS_PER_SECOND,
+        );
+
+        if (seconds > 0) {
+          useCountdownResult.start(seconds);
+        }
       }
     } else {
-      if (isFinishedGame(game)) {
-        setGame(game);
+      if (isFinishedGame(gameResult)) {
+        if (game !== gameResult) {
+          setGame(gameResult);
+        }
 
         if (eventSource !== undefined) {
           eventSource.close();
@@ -120,7 +146,7 @@ export const useGame = (): UseGameResult => {
         }
       }
     }
-  }, [gamesV1GameIdQueryResult]);
+  }, [gamesV1GameIdQueryResult, usersV1MeQueryResult]);
 
   useEffect(() => {
     if (isActiveGame(game)) {

--- a/packages/frontend/web-ui/src/game/hooks/useGame.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useGame.ts
@@ -130,8 +130,12 @@ export const useGame = (): UseGameResult => {
           messageEventsQueue,
           (gameSlotIndex: number): void => {
             if (gameSlotIndex === gameSlotIndexParam) {
-              useCountdownResult.start();
               void refetchGamesV1GameIdSlotsSlotIdCards();
+            }
+          },
+          (gameSlotIndex: number): void => {
+            if (gameSlotIndex === gameSlotIndexParam) {
+              useCountdownResult.start();
             } else {
               useCountdownResult.stop();
             }

--- a/packages/frontend/web-ui/src/game/hooks/useGame.ts
+++ b/packages/frontend/web-ui/src/game/hooks/useGame.ts
@@ -149,7 +149,12 @@ export const useGame = (): UseGameResult => {
     }
 
     if (messageEventsQueue.length > 0) {
-      setMessageEventsQueue([]);
+      setMessageEventsQueue(
+        (
+          currentMessageEventsQueue: [string, apiModels.GameEventV2][],
+        ): [string, apiModels.GameEventV2][] =>
+          currentMessageEventsQueue.slice(messageEventsQueue.length),
+      );
     }
   }, [messageEventsQueue]);
 

--- a/packages/frontend/web-ui/src/game/pages/PublicGames.spec.tsx
+++ b/packages/frontend/web-ui/src/game/pages/PublicGames.spec.tsx
@@ -39,6 +39,7 @@ describe(PublicGames.name, () => {
       ).mockReturnValueOnce({ result: null });
 
       (useGetUserMe as jest.Mock<typeof useGetUserMe>).mockReturnValueOnce({
+        queryResult: Symbol(),
         result: null,
       });
 

--- a/packages/frontend/web-ui/src/home/components/HomeWithAuth.spec.tsx
+++ b/packages/frontend/web-ui/src/home/components/HomeWithAuth.spec.tsx
@@ -67,6 +67,7 @@ describe(HomeWithAuth.name, () => {
       });
 
       (useGetUserMe as jest.Mock<typeof useGetUserMe>).mockReturnValueOnce({
+        queryResult: Symbol(),
         result: null,
       });
 

--- a/packages/frontend/web-ui/src/user/hooks/useGetUserMe.spec.ts
+++ b/packages/frontend/web-ui/src/user/hooks/useGetUserMe.spec.ts
@@ -67,6 +67,7 @@ describe(useGetUserMe.name, () => {
 
     it('should return expected result', () => {
       const expected: UseGetUserMeResult = {
+        queryResult: useQueryStateResultFixture,
         result: mapUseQueryHookResultResult,
       };
 

--- a/packages/frontend/web-ui/src/user/hooks/useGetUserMe.ts
+++ b/packages/frontend/web-ui/src/user/hooks/useGetUserMe.ts
@@ -5,6 +5,7 @@ import { cornieApi } from '../../common/http/services/cornieApi';
 import { Either } from '../../common/models/Either';
 
 export interface UseGetUserMeResult {
+  queryResult: unknown;
   result: Either<string, apiModels.UserV1> | null;
 }
 
@@ -17,5 +18,8 @@ export function useGetUserMe(): UseGetUserMeResult {
     useGetUsersV1MeQueryResult,
   );
 
-  return { result };
+  return {
+    queryResult: useGetUsersV1MeQueryResult,
+    result,
+  };
 }


### PR DESCRIPTION
### Changed
- Updated `handleGameMessageEvents` to update `turnExpiresAt`.
- Updated `useGame` to set count down on edge cases.
- Updated `UseCountDownResult.start` to be called with seconds param.
- Updated `handleGameMessageEvents` with `onTurnChange`.
- Updated `UseGetUserMeResult` with queryResult.