### PR TITLE
Update commit-msg hook to rely on pwd

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_DIR=$( pwd )
 
 pnpm exec commitlint --config "$SCRIPT_DIR/config/commitlint/commitlint.config.js" --edit ""


### PR DESCRIPTION
### Changed
- Updated `commit-msg` hook to rely on `pwd`.