### PR TITLE
Update cards module to change onDoubleClick to onClick

### DIFF
--- a/packages/frontend/web-ui/src/game/components/BaseCard.spec.tsx
+++ b/packages/frontend/web-ui/src/game/components/BaseCard.spec.tsx
@@ -16,14 +16,14 @@ describe(BaseCard.name, () => {
     let selectedClassName: string;
     let colorClassFixture: string;
     let isSelectedFixture: boolean;
-    let onDoubleClickMock: jest.Mock<(event: MouseEvent) => void>;
+    let onClickMock: jest.Mock<(event: MouseEvent) => void>;
 
     beforeAll(() => {
       childrenMock = jest.fn();
       selectedClassName = 'selected';
       colorClassFixture = 'blue-card';
       isSelectedFixture = true;
-      onDoubleClickMock = jest.fn();
+      onClickMock = jest.fn();
     });
 
     describe('when called', () => {
@@ -36,7 +36,7 @@ describe(BaseCard.name, () => {
             children={childrenMock()}
             colorClass={colorClassFixture}
             isSelected={isSelectedFixture}
-            onDoubleClick={onDoubleClickMock}
+            onClick={onClickMock}
           ></BaseCard>,
         );
 
@@ -57,11 +57,11 @@ describe(BaseCard.name, () => {
             '.cornie-card-inner-content',
           ) as Element;
 
-        fireEvent.dblClick(selectedCard);
+        fireEvent.click(selectedCard);
 
         void waitFor(() => {
           // eslint-disable-next-line jest/no-standalone-expect
-          expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
+          expect(onClickMock).toHaveBeenCalledTimes(1);
         });
       });
 
@@ -77,9 +77,9 @@ describe(BaseCard.name, () => {
         expect(isSelectedCard).toBe(true);
       });
 
-      it('should call a onDoubleClick()', () => {
-        expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
-        expect(onDoubleClickMock).toHaveBeenCalledWith(expect.any(Object));
+      it('should call a onClick()', () => {
+        expect(onClickMock).toHaveBeenCalledTimes(1);
+        expect(onClickMock).toHaveBeenCalledWith(expect.any(Object));
       });
     });
   });
@@ -89,14 +89,14 @@ describe(BaseCard.name, () => {
     let selectedClassName: string;
     let colorClassFixture: string;
     let isSelectedFixture: boolean;
-    let onDoubleClickMock: jest.Mock<(event: MouseEvent) => void>;
+    let onClickMock: jest.Mock<(event: MouseEvent) => void>;
 
     beforeAll(() => {
       childrenMock = jest.fn();
       selectedClassName = 'selected';
       colorClassFixture = 'blue-card';
       isSelectedFixture = false;
-      onDoubleClickMock = jest.fn();
+      onClickMock = jest.fn();
     });
 
     describe('when called', () => {
@@ -109,7 +109,7 @@ describe(BaseCard.name, () => {
             children={childrenMock()}
             colorClass={colorClassFixture}
             isSelected={isSelectedFixture}
-            onDoubleClick={onDoubleClickMock}
+            onClick={onClickMock}
           ></BaseCard>,
         );
 
@@ -130,11 +130,11 @@ describe(BaseCard.name, () => {
             '.cornie-card-inner-content',
           ) as Element;
 
-        fireEvent.dblClick(selectedCard);
+        fireEvent.click(selectedCard);
 
         void waitFor(() => {
           // eslint-disable-next-line jest/no-standalone-expect
-          expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
+          expect(onClickMock).toHaveBeenCalledTimes(1);
         });
       });
 
@@ -150,9 +150,9 @@ describe(BaseCard.name, () => {
         expect(isSelectedCard).toBe(false);
       });
 
-      it('should call a onDoubleClick()', () => {
-        expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
-        expect(onDoubleClickMock).toHaveBeenCalledWith(expect.any(Object));
+      it('should call a onClick()', () => {
+        expect(onClickMock).toHaveBeenCalledTimes(1);
+        expect(onClickMock).toHaveBeenCalledWith(expect.any(Object));
       });
     });
   });
@@ -162,14 +162,14 @@ describe(BaseCard.name, () => {
     let selectedClassName: string;
     let colorClassFixture: string;
     let isSelectedFixture: undefined;
-    let onDoubleClickMock: jest.Mock<(event: MouseEvent) => void>;
+    let onClickMock: jest.Mock<(event: MouseEvent) => void>;
 
     beforeAll(() => {
       childrenMock = jest.fn();
       selectedClassName = 'selected';
       colorClassFixture = 'blue-card';
       isSelectedFixture = undefined;
-      onDoubleClickMock = jest.fn();
+      onClickMock = jest.fn();
     });
 
     describe('when called', () => {
@@ -182,7 +182,7 @@ describe(BaseCard.name, () => {
             children={childrenMock()}
             colorClass={colorClassFixture}
             isSelected={isSelectedFixture}
-            onDoubleClick={onDoubleClickMock}
+            onClick={onClickMock}
           ></BaseCard>,
         );
 
@@ -203,11 +203,11 @@ describe(BaseCard.name, () => {
             '.cornie-card-inner-content',
           ) as Element;
 
-        fireEvent.dblClick(selectedCard);
+        fireEvent.click(selectedCard);
 
         void waitFor(() => {
           // eslint-disable-next-line jest/no-standalone-expect
-          expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
+          expect(onClickMock).toHaveBeenCalledTimes(1);
         });
       });
 
@@ -223,9 +223,9 @@ describe(BaseCard.name, () => {
         expect(isSelectedCard).toBe(false);
       });
 
-      it('should call a onDoubleClick()', () => {
-        expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
-        expect(onDoubleClickMock).toHaveBeenCalledWith(expect.any(Object));
+      it('should call a onClick()', () => {
+        expect(onClickMock).toHaveBeenCalledTimes(1);
+        expect(onClickMock).toHaveBeenCalledWith(expect.any(Object));
       });
     });
   });

--- a/packages/frontend/web-ui/src/game/components/BaseCard.tsx
+++ b/packages/frontend/web-ui/src/game/components/BaseCard.tsx
@@ -5,7 +5,7 @@ interface BaseCardOptions {
   children: React.JSX.Element | React.JSX.Element[];
   colorClass: string;
   isSelected?: boolean | undefined;
-  onDoubleClick?: ((event: MouseEvent) => void) | undefined;
+  onClick?: ((event: MouseEvent) => void) | undefined;
 }
 
 function addSelectedClassName(isSelected: boolean | undefined): string {
@@ -21,7 +21,7 @@ export const BaseCard = (params: BaseCardOptions) => {
     <Box
       component="div"
       className={`cornie-card ${addSelectedClassName(params.isSelected)}`}
-      onDoubleClick={params.onDoubleClick}
+      onClick={params.onClick}
     >
       <Box
         component="div"

--- a/packages/frontend/web-ui/src/game/components/Card.spec.tsx
+++ b/packages/frontend/web-ui/src/game/components/Card.spec.tsx
@@ -41,7 +41,7 @@ describe(Card.name, () => {
           number: 5,
         },
         isSelected: true,
-        onDoubleClick: () => undefined,
+        onClick: () => undefined,
       };
     });
 
@@ -90,7 +90,7 @@ describe(Card.name, () => {
           kind: 'draw',
         },
         isSelected: true,
-        onDoubleClick: () => undefined,
+        onClick: () => undefined,
       };
     });
 
@@ -139,7 +139,7 @@ describe(Card.name, () => {
           kind: 'reverse',
         },
         isSelected: true,
-        onDoubleClick: () => undefined,
+        onClick: () => undefined,
       };
     });
 
@@ -188,7 +188,7 @@ describe(Card.name, () => {
           kind: 'skip',
         },
         isSelected: true,
-        onDoubleClick: () => undefined,
+        onClick: () => undefined,
       };
     });
 
@@ -236,7 +236,7 @@ describe(Card.name, () => {
           kind: 'wild',
         },
         isSelected: true,
-        onDoubleClick: () => undefined,
+        onClick: () => undefined,
       };
     });
 
@@ -271,7 +271,7 @@ describe(Card.name, () => {
             card: cardOptionsFixture.card,
             colorClass: 'white-color',
             isSelected: true,
-            onDoubleClick: cardOptionsFixture.onDoubleClick,
+            onClick: cardOptionsFixture.onClick,
           },
           {},
         );
@@ -292,7 +292,7 @@ describe(Card.name, () => {
           kind: 'wildDraw4',
         },
         isSelected: true,
-        onDoubleClick: () => undefined,
+        onClick: () => undefined,
       };
     });
 
@@ -327,7 +327,7 @@ describe(Card.name, () => {
             card: cardOptionsFixture.card,
             colorClass: 'white-color',
             isSelected: true,
-            onDoubleClick: cardOptionsFixture.onDoubleClick,
+            onClick: cardOptionsFixture.onClick,
           },
           {},
         );

--- a/packages/frontend/web-ui/src/game/components/Card.tsx
+++ b/packages/frontend/web-ui/src/game/components/Card.tsx
@@ -11,7 +11,7 @@ import { WildDraw4Card } from './WildDraw4Card';
 export interface CardOptions {
   card: apiModels.CardV1;
   isSelected?: boolean | undefined;
-  onDoubleClick?: (event: MouseEvent) => void;
+  onClick?: (event: MouseEvent) => void;
 }
 
 export const Card = (params: CardOptions) => {
@@ -21,7 +21,7 @@ export const Card = (params: CardOptions) => {
         <DrawCard
           card={params.card}
           isSelected={params.isSelected}
-          onDoubleClick={params.onDoubleClick}
+          onClick={params.onClick}
         ></DrawCard>
       );
     case 'normal':
@@ -29,7 +29,7 @@ export const Card = (params: CardOptions) => {
         <NormalCard
           card={params.card}
           isSelected={params.isSelected}
-          onDoubleClick={params.onDoubleClick}
+          onClick={params.onClick}
         ></NormalCard>
       );
     case 'reverse':
@@ -37,7 +37,7 @@ export const Card = (params: CardOptions) => {
         <ReverseCard
           card={params.card}
           isSelected={params.isSelected}
-          onDoubleClick={params.onDoubleClick}
+          onClick={params.onClick}
         ></ReverseCard>
       );
     case 'skip':
@@ -45,7 +45,7 @@ export const Card = (params: CardOptions) => {
         <SkipCard
           card={params.card}
           isSelected={params.isSelected}
-          onDoubleClick={params.onDoubleClick}
+          onClick={params.onClick}
         ></SkipCard>
       );
     case 'wild':
@@ -54,7 +54,7 @@ export const Card = (params: CardOptions) => {
           card={params.card}
           colorClass="white-color"
           isSelected={params.isSelected}
-          onDoubleClick={params.onDoubleClick}
+          onClick={params.onClick}
         ></WildCard>
       );
     case 'wildDraw4':
@@ -63,7 +63,7 @@ export const Card = (params: CardOptions) => {
           card={params.card}
           colorClass="white-color"
           isSelected={params.isSelected}
-          onDoubleClick={params.onDoubleClick}
+          onClick={params.onClick}
         ></WildDraw4Card>
       );
   }

--- a/packages/frontend/web-ui/src/game/components/DrawCard.spec.tsx
+++ b/packages/frontend/web-ui/src/game/components/DrawCard.spec.tsx
@@ -27,7 +27,7 @@ describe(DrawCard.name, () => {
   let selectedClassName: string;
   let isSelectedFixture: boolean;
   let imageUrlFixture: string;
-  let onDoubleClickMock: jest.Mock<(event: MouseEvent) => void>;
+  let onClickMock: jest.Mock<(event: MouseEvent) => void>;
 
   beforeAll(() => {
     drawCardOptionsFixture = {
@@ -41,7 +41,7 @@ describe(DrawCard.name, () => {
     selectedClassName = 'selected';
     imageUrlFixture = 'image-url-fixture';
     isSelectedFixture = true;
-    onDoubleClickMock = jest.fn();
+    onClickMock = jest.fn();
   });
 
   describe('when called', () => {
@@ -62,7 +62,7 @@ describe(DrawCard.name, () => {
         <DrawCard
           card={drawCardOptionsFixture.card}
           isSelected={isSelectedFixture}
-          onDoubleClick={onDoubleClickMock}
+          onClick={onClickMock}
         ></DrawCard>,
       );
 
@@ -85,11 +85,11 @@ describe(DrawCard.name, () => {
         '.cornie-card-inner-content',
       ) as Element;
 
-      fireEvent.dblClick(selectedCard);
+      fireEvent.click(selectedCard);
 
       void waitFor(() => {
         // eslint-disable-next-line jest/no-standalone-expect
-        expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
+        expect(onClickMock).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -117,9 +117,9 @@ describe(DrawCard.name, () => {
       expect(imageSourceUrl).toStrictEqual(imageUrlFixture);
     });
 
-    it('should call a onDoubleClick()', () => {
-      expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
-      expect(onDoubleClickMock).toHaveBeenCalledWith(expect.any(Object));
+    it('should call a onClick()', () => {
+      expect(onClickMock).toHaveBeenCalledTimes(1);
+      expect(onClickMock).toHaveBeenCalledWith(expect.any(Object));
     });
   });
 });

--- a/packages/frontend/web-ui/src/game/components/DrawCard.tsx
+++ b/packages/frontend/web-ui/src/game/components/DrawCard.tsx
@@ -8,7 +8,7 @@ import { ImageCard } from './ImageCard';
 export interface DrawCardOptions {
   card: apiModels.DrawCardV1;
   isSelected?: boolean | undefined;
-  onDoubleClick?: ((event: MouseEvent) => void) | undefined;
+  onClick?: ((event: MouseEvent) => void) | undefined;
 }
 
 export const DrawCard = (params: DrawCardOptions) => {
@@ -17,7 +17,7 @@ export const DrawCard = (params: DrawCardOptions) => {
       image={getImageCardUrl(params.card)}
       colorClass={getCardColorClassName(params.card.color)}
       isSelected={params.isSelected}
-      onDoubleClick={params.onDoubleClick}
+      onClick={params.onClick}
     ></ImageCard>
   );
 };

--- a/packages/frontend/web-ui/src/game/components/ImageCard.spec.tsx
+++ b/packages/frontend/web-ui/src/game/components/ImageCard.spec.tsx
@@ -14,7 +14,7 @@ describe(ImageCard.name, () => {
   let selectedClassName: string;
   let imageCardOptionsFixture: ImageCardOptions;
   let isSelectedFixture: boolean;
-  let onDoubleClickMock: jest.Mock<(event: MouseEvent) => void>;
+  let onClickMock: jest.Mock<(event: MouseEvent) => void>;
 
   beforeAll(() => {
     selectedClassName = 'selected';
@@ -23,7 +23,7 @@ describe(ImageCard.name, () => {
       image: '/assets/image.png',
     };
     isSelectedFixture = true;
-    onDoubleClickMock = jest.fn();
+    onClickMock = jest.fn();
   });
 
   describe('when called', () => {
@@ -37,7 +37,7 @@ describe(ImageCard.name, () => {
           colorClass={imageCardOptionsFixture.colorClass}
           image={imageCardOptionsFixture.image}
           isSelected={isSelectedFixture}
-          onDoubleClick={onDoubleClickMock}
+          onClick={onClickMock}
         ></ImageCard>,
       );
 
@@ -63,11 +63,11 @@ describe(ImageCard.name, () => {
         '.cornie-card-inner-content',
       ) as Element;
 
-      fireEvent.dblClick(selectedCard);
+      fireEvent.click(selectedCard);
 
       void waitFor(() => {
         // eslint-disable-next-line jest/no-standalone-expect
-        expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
+        expect(onClickMock).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -87,9 +87,9 @@ describe(ImageCard.name, () => {
       expect(imageSourceUrl).toBe(imageCardOptionsFixture.image);
     });
 
-    it('should call a onDoubleClick()', () => {
-      expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
-      expect(onDoubleClickMock).toHaveBeenCalledWith(expect.any(Object));
+    it('should call a onClick()', () => {
+      expect(onClickMock).toHaveBeenCalledTimes(1);
+      expect(onClickMock).toHaveBeenCalledWith(expect.any(Object));
     });
   });
 });

--- a/packages/frontend/web-ui/src/game/components/ImageCard.tsx
+++ b/packages/frontend/web-ui/src/game/components/ImageCard.tsx
@@ -7,7 +7,7 @@ export interface ImageCardOptions {
   colorClass: string;
   image: string;
   isSelected?: boolean | undefined;
-  onDoubleClick?: ((event: MouseEvent) => void) | undefined;
+  onClick?: ((event: MouseEvent) => void) | undefined;
 }
 
 export const ImageCard = (params: ImageCardOptions) => {
@@ -15,7 +15,7 @@ export const ImageCard = (params: ImageCardOptions) => {
     <BaseCard
       colorClass={params.colorClass}
       isSelected={params.isSelected}
-      onDoubleClick={params.onDoubleClick}
+      onClick={params.onClick}
     >
       <Box component="div" className="cornie-card-image">
         <img src={params.image} />

--- a/packages/frontend/web-ui/src/game/components/NormalCard.spec.tsx
+++ b/packages/frontend/web-ui/src/game/components/NormalCard.spec.tsx
@@ -18,7 +18,7 @@ describe(NormalCard.name, () => {
   let classNameFixture: string;
   let selectedClassName: string;
   let isSelectedFixture: boolean;
-  let onDoubleClickMock: jest.Mock<(event: MouseEvent) => void>;
+  let onClickMock: jest.Mock<(event: MouseEvent) => void>;
 
   beforeAll(() => {
     normalCardOptionsFixture = {
@@ -32,7 +32,7 @@ describe(NormalCard.name, () => {
     classNameFixture = 'blue-card';
     selectedClassName = 'selected';
     isSelectedFixture = true;
-    onDoubleClickMock = jest.fn();
+    onClickMock = jest.fn();
   });
 
   describe('when called', () => {
@@ -49,7 +49,7 @@ describe(NormalCard.name, () => {
         <NormalCard
           card={normalCardOptionsFixture.card}
           isSelected={isSelectedFixture}
-          onDoubleClick={onDoubleClickMock}
+          onClick={onClickMock}
         ></NormalCard>,
       );
 
@@ -72,11 +72,11 @@ describe(NormalCard.name, () => {
         '.cornie-card-inner-content',
       ) as Element;
 
-      fireEvent.dblClick(selectedCard);
+      fireEvent.click(selectedCard);
 
       void waitFor(() => {
         // eslint-disable-next-line jest/no-standalone-expect
-        expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
+        expect(onClickMock).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -100,9 +100,9 @@ describe(NormalCard.name, () => {
       expect(cardValue).toBe(normalCardOptionsFixture.card.number.toString());
     });
 
-    it('should call a onDoubleClick()', () => {
-      expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
-      expect(onDoubleClickMock).toHaveBeenCalledWith(expect.any(Object));
+    it('should call a onClick()', () => {
+      expect(onClickMock).toHaveBeenCalledTimes(1);
+      expect(onClickMock).toHaveBeenCalledWith(expect.any(Object));
     });
   });
 });

--- a/packages/frontend/web-ui/src/game/components/NormalCard.tsx
+++ b/packages/frontend/web-ui/src/game/components/NormalCard.tsx
@@ -7,7 +7,7 @@ import { TextCard } from './TextCard';
 export interface NormalCardOptions {
   card: apiModels.NormalCardV1;
   isSelected?: boolean | undefined;
-  onDoubleClick?: ((event: MouseEvent) => void) | undefined;
+  onClick?: ((event: MouseEvent) => void) | undefined;
 }
 
 export const NormalCard = (params: NormalCardOptions) => {
@@ -16,7 +16,7 @@ export const NormalCard = (params: NormalCardOptions) => {
       text={params.card.number.toString()}
       colorClass={getCardColorClassName(params.card.color)}
       isSelected={params.isSelected}
-      onDoubleClick={params.onDoubleClick}
+      onClick={params.onClick}
     ></TextCard>
   );
 };

--- a/packages/frontend/web-ui/src/game/components/ReverseCard.spec.tsx
+++ b/packages/frontend/web-ui/src/game/components/ReverseCard.spec.tsx
@@ -27,7 +27,7 @@ describe(ReverseCard.name, () => {
   let selectedClassName: string;
   let isSelectedFixture: boolean;
   let imageUrlFixture: string;
-  let onDoubleClickMock: jest.Mock<(event: MouseEvent) => void>;
+  let onClickMock: jest.Mock<(event: MouseEvent) => void>;
 
   beforeAll(() => {
     reverseCardOptionsFixture = {
@@ -41,7 +41,7 @@ describe(ReverseCard.name, () => {
     selectedClassName = 'selected';
     imageUrlFixture = 'image-url-fixture';
     isSelectedFixture = true;
-    onDoubleClickMock = jest.fn();
+    onClickMock = jest.fn();
   });
 
   describe('when called', () => {
@@ -62,7 +62,7 @@ describe(ReverseCard.name, () => {
         <ReverseCard
           card={reverseCardOptionsFixture.card}
           isSelected={isSelectedFixture}
-          onDoubleClick={onDoubleClickMock}
+          onClick={onClickMock}
         ></ReverseCard>,
       );
 
@@ -85,11 +85,11 @@ describe(ReverseCard.name, () => {
         '.cornie-card-inner-content',
       ) as Element;
 
-      fireEvent.dblClick(selectedCard);
+      fireEvent.click(selectedCard);
 
       void waitFor(() => {
         // eslint-disable-next-line jest/no-standalone-expect
-        expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
+        expect(onClickMock).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -117,9 +117,9 @@ describe(ReverseCard.name, () => {
       expect(imageSourceUrl).toStrictEqual(imageUrlFixture);
     });
 
-    it('should call a onDoubleClick()', () => {
-      expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
-      expect(onDoubleClickMock).toHaveBeenCalledWith(expect.any(Object));
+    it('should call a onClick()', () => {
+      expect(onClickMock).toHaveBeenCalledTimes(1);
+      expect(onClickMock).toHaveBeenCalledWith(expect.any(Object));
     });
   });
 });

--- a/packages/frontend/web-ui/src/game/components/ReverseCard.tsx
+++ b/packages/frontend/web-ui/src/game/components/ReverseCard.tsx
@@ -8,7 +8,7 @@ import { ImageCard } from './ImageCard';
 export interface ReverseCardOptions {
   card: apiModels.ReverseCardV1;
   isSelected?: boolean | undefined;
-  onDoubleClick?: ((event: MouseEvent) => void) | undefined;
+  onClick?: ((event: MouseEvent) => void) | undefined;
 }
 
 export const ReverseCard = (params: ReverseCardOptions) => {
@@ -17,7 +17,7 @@ export const ReverseCard = (params: ReverseCardOptions) => {
       image={getImageCardUrl(params.card)}
       colorClass={getCardColorClassName(params.card.color)}
       isSelected={params.isSelected}
-      onDoubleClick={params.onDoubleClick}
+      onClick={params.onClick}
     ></ImageCard>
   );
 };

--- a/packages/frontend/web-ui/src/game/components/SkipCard.spec.tsx
+++ b/packages/frontend/web-ui/src/game/components/SkipCard.spec.tsx
@@ -27,7 +27,7 @@ describe(SkipCard.name, () => {
   let selectedClassName: string;
   let imageUrlFixture: string;
   let isSelectedFixture: boolean;
-  let onDoubleClickMock: jest.Mock<(event: MouseEvent) => void>;
+  let onClickMock: jest.Mock<(event: MouseEvent) => void>;
 
   beforeAll(() => {
     skipCardOptionsFixture = {
@@ -41,7 +41,7 @@ describe(SkipCard.name, () => {
     selectedClassName = 'selected';
     imageUrlFixture = 'image-url-fixture';
     isSelectedFixture = true;
-    onDoubleClickMock = jest.fn();
+    onClickMock = jest.fn();
   });
 
   describe('when called', () => {
@@ -62,7 +62,7 @@ describe(SkipCard.name, () => {
         <SkipCard
           card={skipCardOptionsFixture.card}
           isSelected={isSelectedFixture}
-          onDoubleClick={onDoubleClickMock}
+          onClick={onClickMock}
         ></SkipCard>,
       );
 
@@ -85,11 +85,11 @@ describe(SkipCard.name, () => {
         '.cornie-card-inner-content',
       ) as Element;
 
-      fireEvent.dblClick(selectedCard);
+      fireEvent.click(selectedCard);
 
       void waitFor(() => {
         // eslint-disable-next-line jest/no-standalone-expect
-        expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
+        expect(onClickMock).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -117,9 +117,9 @@ describe(SkipCard.name, () => {
       expect(imageSourceUrl).toStrictEqual(imageUrlFixture);
     });
 
-    it('should call a onDoubleClick()', () => {
-      expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
-      expect(onDoubleClickMock).toHaveBeenCalledWith(expect.any(Object));
+    it('should call a onClick()', () => {
+      expect(onClickMock).toHaveBeenCalledTimes(1);
+      expect(onClickMock).toHaveBeenCalledWith(expect.any(Object));
     });
   });
 });

--- a/packages/frontend/web-ui/src/game/components/SkipCard.tsx
+++ b/packages/frontend/web-ui/src/game/components/SkipCard.tsx
@@ -8,7 +8,7 @@ import { ImageCard } from './ImageCard';
 export interface SkipCardOptions {
   card: apiModels.SkipCardV1;
   isSelected?: boolean | undefined;
-  onDoubleClick?: ((event: MouseEvent) => void) | undefined;
+  onClick?: ((event: MouseEvent) => void) | undefined;
 }
 
 export const SkipCard = (params: SkipCardOptions) => {
@@ -17,7 +17,7 @@ export const SkipCard = (params: SkipCardOptions) => {
       image={getImageCardUrl(params.card)}
       colorClass={getCardColorClassName(params.card.color)}
       isSelected={params.isSelected}
-      onDoubleClick={params.onDoubleClick}
+      onClick={params.onClick}
     ></ImageCard>
   );
 };

--- a/packages/frontend/web-ui/src/game/components/TextCard.spec.tsx
+++ b/packages/frontend/web-ui/src/game/components/TextCard.spec.tsx
@@ -14,7 +14,7 @@ describe(TextCard.name, () => {
   let selectedClassName: string;
   let isSelectedFixture: boolean;
   let textCardOptionsFixture: TextCardOptions;
-  let onDoubleClickMock: jest.Mock<(event: MouseEvent) => void>;
+  let onClickMock: jest.Mock<(event: MouseEvent) => void>;
 
   beforeAll(() => {
     selectedClassName = 'selected';
@@ -23,7 +23,7 @@ describe(TextCard.name, () => {
       colorClass: 'blue-card',
       text: '4',
     };
-    onDoubleClickMock = jest.fn();
+    onClickMock = jest.fn();
   });
 
   describe('when called', () => {
@@ -37,7 +37,7 @@ describe(TextCard.name, () => {
           colorClass={textCardOptionsFixture.colorClass}
           isSelected={isSelectedFixture}
           text={textCardOptionsFixture.text}
-          onDoubleClick={onDoubleClickMock}
+          onClick={onClickMock}
         ></TextCard>,
       );
 
@@ -61,11 +61,11 @@ describe(TextCard.name, () => {
         '.cornie-card-inner-content',
       ) as Element;
 
-      fireEvent.dblClick(selectedCard);
+      fireEvent.click(selectedCard);
 
       void waitFor(() => {
         // eslint-disable-next-line jest/no-standalone-expect
-        expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
+        expect(onClickMock).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -85,9 +85,9 @@ describe(TextCard.name, () => {
       expect(cardValue).toBe(textCardOptionsFixture.text);
     });
 
-    it('should call a onDoubleClick()', () => {
-      expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
-      expect(onDoubleClickMock).toHaveBeenCalledWith(expect.any(Object));
+    it('should call a onClick()', () => {
+      expect(onClickMock).toHaveBeenCalledTimes(1);
+      expect(onClickMock).toHaveBeenCalledWith(expect.any(Object));
     });
   });
 });

--- a/packages/frontend/web-ui/src/game/components/TextCard.tsx
+++ b/packages/frontend/web-ui/src/game/components/TextCard.tsx
@@ -7,7 +7,7 @@ export interface TextCardOptions {
   colorClass: string;
   isSelected?: boolean | undefined;
   text: string;
-  onDoubleClick?: ((event: MouseEvent) => void) | undefined;
+  onClick?: ((event: MouseEvent) => void) | undefined;
 }
 
 export const TextCard = (params: TextCardOptions) => {
@@ -15,7 +15,7 @@ export const TextCard = (params: TextCardOptions) => {
     <BaseCard
       colorClass={params.colorClass}
       isSelected={params.isSelected}
-      onDoubleClick={params.onDoubleClick}
+      onClick={params.onClick}
     >
       <Box component="div" className="cornie-card-text cornie-text-card-text">
         {params.text}

--- a/packages/frontend/web-ui/src/game/components/WildCard.spec.tsx
+++ b/packages/frontend/web-ui/src/game/components/WildCard.spec.tsx
@@ -24,7 +24,7 @@ describe(WildCard.name, () => {
   let selectedClassName: string;
   let isSelectedFixture: boolean;
   let imageUrlFixture: string;
-  let onDoubleClickMock: jest.Mock<(event: MouseEvent) => void>;
+  let onClickMock: jest.Mock<(event: MouseEvent) => void>;
 
   beforeAll(() => {
     selectedClassName = 'selected';
@@ -37,7 +37,7 @@ describe(WildCard.name, () => {
     };
 
     imageUrlFixture = 'image-url-fixture';
-    onDoubleClickMock = jest.fn();
+    onClickMock = jest.fn();
   });
 
   describe('when called', () => {
@@ -55,7 +55,7 @@ describe(WildCard.name, () => {
           card={wildCardOptionsFixture.card}
           colorClass={wildCardOptionsFixture.colorClass}
           isSelected={isSelectedFixture}
-          onDoubleClick={onDoubleClickMock}
+          onClick={onClickMock}
         ></WildCard>,
       );
 
@@ -79,11 +79,11 @@ describe(WildCard.name, () => {
         '.cornie-card-inner-content',
       ) as Element;
 
-      fireEvent.dblClick(selectedCard);
+      fireEvent.click(selectedCard);
 
       void waitFor(() => {
         // eslint-disable-next-line jest/no-standalone-expect
-        expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
+        expect(onClickMock).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -107,9 +107,9 @@ describe(WildCard.name, () => {
       expect(imageSourceUrl).toStrictEqual(imageUrlFixture);
     });
 
-    it('should call a onDoubleClick()', () => {
-      expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
-      expect(onDoubleClickMock).toHaveBeenCalledWith(expect.any(Object));
+    it('should call a onClick()', () => {
+      expect(onClickMock).toHaveBeenCalledTimes(1);
+      expect(onClickMock).toHaveBeenCalledWith(expect.any(Object));
     });
   });
 });

--- a/packages/frontend/web-ui/src/game/components/WildCard.tsx
+++ b/packages/frontend/web-ui/src/game/components/WildCard.tsx
@@ -8,7 +8,7 @@ export interface WildCardOptions {
   card: apiModels.WildCardV1;
   colorClass: 'white-color';
   isSelected?: boolean | undefined;
-  onDoubleClick?: ((event: MouseEvent) => void) | undefined;
+  onClick?: ((event: MouseEvent) => void) | undefined;
 }
 
 export const WildCard = (params: WildCardOptions) => {
@@ -17,7 +17,7 @@ export const WildCard = (params: WildCardOptions) => {
       image={getImageCardUrl(params.card)}
       colorClass={params.colorClass}
       isSelected={params.isSelected}
-      onDoubleClick={params.onDoubleClick}
+      onClick={params.onClick}
     ></ImageCard>
   );
 };

--- a/packages/frontend/web-ui/src/game/components/WildDraw4Card.spec.tsx
+++ b/packages/frontend/web-ui/src/game/components/WildDraw4Card.spec.tsx
@@ -24,7 +24,7 @@ describe(WildDraw4Card.name, () => {
   let selectedClassName: string;
   let isSelectedFixture: boolean;
   let imageUrlFixture: string;
-  let onDoubleClickMock: jest.Mock<(event: MouseEvent) => void>;
+  let onClickMock: jest.Mock<(event: MouseEvent) => void>;
 
   beforeAll(() => {
     selectedClassName = 'selected';
@@ -37,7 +37,7 @@ describe(WildDraw4Card.name, () => {
     };
 
     imageUrlFixture = 'image-url-fixture';
-    onDoubleClickMock = jest.fn();
+    onClickMock = jest.fn();
   });
 
   describe('when called', () => {
@@ -55,7 +55,7 @@ describe(WildDraw4Card.name, () => {
           card={wildDraw4CardOptionsFixture.card}
           colorClass={wildDraw4CardOptionsFixture.colorClass}
           isSelected={isSelectedFixture}
-          onDoubleClick={onDoubleClickMock}
+          onClick={onClickMock}
         ></WildDraw4Card>,
       );
 
@@ -79,11 +79,11 @@ describe(WildDraw4Card.name, () => {
         '.cornie-card-inner-content',
       ) as Element;
 
-      fireEvent.dblClick(selectedCard);
+      fireEvent.click(selectedCard);
 
       void waitFor(() => {
         // eslint-disable-next-line jest/no-standalone-expect
-        expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
+        expect(onClickMock).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -107,9 +107,9 @@ describe(WildDraw4Card.name, () => {
       expect(imageSourceUrl).toStrictEqual(imageUrlFixture);
     });
 
-    it('should call a onDoubleClick()', () => {
-      expect(onDoubleClickMock).toHaveBeenCalledTimes(1);
-      expect(onDoubleClickMock).toHaveBeenCalledWith(expect.any(Object));
+    it('should call a onClick()', () => {
+      expect(onClickMock).toHaveBeenCalledTimes(1);
+      expect(onClickMock).toHaveBeenCalledWith(expect.any(Object));
     });
   });
 });

--- a/packages/frontend/web-ui/src/game/components/WildDraw4Card.tsx
+++ b/packages/frontend/web-ui/src/game/components/WildDraw4Card.tsx
@@ -8,7 +8,7 @@ export interface WildDraw4CardOptions {
   card: apiModels.WildDraw4CardV1;
   colorClass: 'white-color';
   isSelected?: boolean | undefined;
-  onDoubleClick?: ((event: MouseEvent) => void) | undefined;
+  onClick?: ((event: MouseEvent) => void) | undefined;
 }
 
 export const WildDraw4Card = (params: WildDraw4CardOptions) => {
@@ -17,7 +17,7 @@ export const WildDraw4Card = (params: WildDraw4CardOptions) => {
       image={getImageCardUrl(params.card)}
       colorClass={params.colorClass}
       isSelected={params.isSelected}
-      onDoubleClick={params.onDoubleClick}
+      onClick={params.onClick}
     ></ImageCard>
   );
 };


### PR DESCRIPTION
### Changed:

- Modify `BaseCard.tsx` and his test to change to `onClick` function.
- Modify `DrawCard.tsx` and his test to change to `onClick` function.
- Modify `ImageCard.tsx` and his test to change to `onClick` function.
- Modify `ReverseCard.tsx` and his test to change to `onClick` function.
- Modify `SkipCard.tsx` and his test to change to `onClick` function.
- Modify `TextCard.tsx` and his test to change to `onClick` function.
- Modify `WildCard.tsx` and his test to change to `onClick` function.
- Modify `Card.tsx` and his test to change to `onClick` function.
- Modify `NormalCard.tsx` and his test to change to `onClick` function.
- Modify `WildDraw4Card.tsx` and his test to change to `onClick` function.